### PR TITLE
feat(docker): add health checks for Stellar Wave #53

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -50,6 +50,12 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
     command: cargo run --bin stellar-api
 
   indexer:
@@ -64,9 +70,16 @@ services:
       STELLAR_NETWORK: "testnet"
       STELLAR_RPC_URL: "https://soroban-testnet.stellar.org"
       RUST_LOG: "info,stellar_indexer=debug"
+      INDEXER_PORT: "3002"
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3002/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
     command: cargo run --bin stellar-indexer
 
   pgadmin:

--- a/backend/services/indexer/Cargo.toml
+++ b/backend/services/indexer/Cargo.toml
@@ -19,3 +19,5 @@ tracing-subscriber.workspace = true
 anyhow.workspace = true
 dotenvy.workspace = true
 sqlx.workspace = true
+actix-web = { workspace = true, features = ["rt-multi-thread"] }
+actix-rt = { workspace = true }

--- a/backend/services/indexer/src/main.rs
+++ b/backend/services/indexer/src/main.rs
@@ -1,3 +1,63 @@
-fn main() {
-    println!("stellar-indexer service placeholder");
+use actix_web::{middleware, web, App, HttpResponse, HttpServer};
+use serde::Serialize;
+use std::env;
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: String,
+    service: String,
+    version: String,
+    network: String,
+}
+
+async fn health(
+    network: web::Data<String>,
+) -> HttpResponse {
+    HttpResponse::Ok().json(HealthResponse {
+        status: "healthy".to_string(),
+        service: "stellar-indexer".to_string(),
+        version: "0.1.0".to_string(),
+        network: network.get_ref().clone(),
+    })
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    dotenvy::dotenv().ok();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            std::env::var("RUST_LOG").unwrap_or_else(|_| "info,stellar_indexer=debug".to_string()),
+        )
+        .init();
+
+    let port: u16 = env::var("INDEXER_PORT")
+        .unwrap_or_else(|_| "3002".to_string())
+        .parse()
+        .unwrap_or(3002);
+
+    let network = env::var("STELLAR_NETWORK").unwrap_or_else(|_| "testnet".to_string());
+    let rpc_url = env::var("STELLAR_RPC_URL")
+        .unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string());
+    let db_url = env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://stellar:stellar_dev_password@localhost:5432/stellar_db".to_string());
+
+    tracing::info!("stellar-indexer service starting...");
+    tracing::info!("Configuration:");
+    tracing::info!("  Port: {}", port);
+    tracing::info!("  Network: {}", network);
+    tracing::info!("  RPC URL: {}", rpc_url);
+    tracing::info!("  Database: [hidden]");
+
+    tracing::info!("Starting Stellar Indexer on 0.0.0.0:{}", port);
+
+    HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(network.clone()))
+            .wrap(middleware::Logger::default())
+            .route("/health", web::get().to(health))
+    })
+    .bind(("0.0.0.0", port))?
+    .run()
+    .await
 }

--- a/pr-body-88.txt
+++ b/pr-body-88.txt
@@ -1,0 +1,50 @@
+## Stellar Wave Bounty - Issue #88: API Service - No Request Logging
+
+**Severity:** Medium
+**Component:** `services/api/src/main.rs`
+
+### Problem
+
+While Logger middleware was added, there was no structured logging of request details, user actions, or business events. This made it difficult to debug issues or audit user actions.
+
+### Solution
+
+Added comprehensive structured logging using `tracing`:
+
+- Added `request_id` counter using `AtomicU64` for unique request identification
+- Added structured `tracing::info!` calls with contextual fields for all endpoints:
+  - `request_id` for tracing individual requests across services
+  - `user_action` describing the business operation (create_bounty, apply_for_bounty, etc.)
+  - `entity_type` and `entity_id` for business entity identification
+  - Related data fields (creator, budget, freelancer, discipline, etc.)
+
+### Changes
+
+Endpoints now log structured events:
+- `create_bounty`: logs creator, budget, title
+- `list_bounties`: logs user_action
+- `get_bounty`: logs entity_type=bounty, entity_id
+- `apply_for_bounty`: logs bounty_id, freelancer, proposed_budget
+- `register_freelancer`: logs name, discipline
+- `list_freelancers`: logs discipline filter
+- `get_freelancer`: logs entity_type=freelancer, entity_id
+- `get_escrow`: logs entity_type=escrow, entity_id
+- `release_escrow`: logs entity_type=escrow, entity_id
+
+Startup also logs service metadata (service name, version, host, port).
+
+### Example Log Output
+
+```
+2026-03-25T17:10:00Z INFO stellar_api: API request
+  request_id=42
+  method=POST
+  path=/api/bounties
+  user_action=create_bounty
+  creator=creator123
+  budget=500
+```
+
+---
+**Bounty:** 200 Points via Drips Wave
+**Bounty URL:** https://drips.network/stellar/issue/88


### PR DESCRIPTION
## Stellar Wave Bounty - Issue #53: All Services - No Docker Health Checks

**Severity:** Medium
**Component:** `backend/docker-compose.yml`

### Problem

The API and indexer services in docker-compose did not have health check configurations, preventing Docker from determining if services are actually healthy.

### Solution

Added comprehensive health checks to both services:

#### API Service
```yaml
healthcheck:
  test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
  interval: 30s
  timeout: 10s
  retries: 3
  start_period: 10s
```

#### Indexer Service
- Added `INDEXER_PORT` environment variable (default: 3002)
- Implemented Actix-web HTTP server with `/health` endpoint
- Health check configuration in docker-compose:
```yaml
healthcheck:
  test: ["CMD", "curl", "-f", "http://localhost:3002/health"]
  interval: 30s
  timeout: 10s
  retries: 3
  start_period: 10s
```

### Health Endpoint Response

```json
{
  "status": "healthy",
  "service": "stellar-indexer",
  "version": "0.1.0",
  "network": "testnet"
}
```

### Impact

- Docker can now properly monitor service health
- Services dependent on API/Indexer can use `condition: service_healthy`
- Enables proper container orchestration and restarts
- Clear visibility into service status

---
**Bounty:** 200 Points via Drips Wave
**Bounty URL:** https://drips.network/stellar/issue/53
