### PR TITLE
feat(load-tests): add k6 load testing suite for all services (#46)

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -1,0 +1,52 @@
+name: Load Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Target base URL (Next.js)'
+        required: false
+        default: 'http://localhost:3000'
+      rust_api_url:
+        description: 'Rust API URL'
+        required: false
+        default: 'http://localhost:3001'
+      test:
+        description: 'Test to run (smoke|stress|soak|spike)'
+        required: false
+        default: 'smoke'
+
+jobs:
+  load-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install k6
+        run: |
+          sudo gpg --no-default-keyring \
+            --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+            --keyserver hkp://keyserver.ubuntu.com:80 \
+            --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+            | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update && sudo apt-get install -y k6
+
+      - name: Run load test
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url }}
+          RUST_API_URL: ${{ github.event.inputs.rust_api_url }}
+        run: |
+          k6 run \
+            -e BASE_URL=$BASE_URL \
+            -e RUST_API_URL=$RUST_API_URL \
+            --out json=load-test-results.json \
+            load-tests/${{ github.event.inputs.test }}.test.js
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-results-${{ github.event.inputs.test }}
+          path: load-test-results.json
+          retention-days: 30

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -1,0 +1,85 @@
+# Load Testing Suite
+
+Load tests for all Stellar Creator Portfolio services using [k6](https://k6.io/).
+
+## Prerequisites
+
+```bash
+# Install k6
+# macOS
+brew install k6
+
+# Linux
+sudo gpg -k
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update && sudo apt-get install k6
+
+# Docker
+docker pull grafana/k6
+```
+
+## Structure
+
+```
+load-tests/
+├── config/
+│   └── options.js          # Shared k6 options/thresholds
+├── helpers/
+│   └── auth.js             # Auth token helpers
+├── scenarios/
+│   ├── auth.test.js        # Auth endpoints
+│   ├── bounties.test.js    # Bounties API
+│   ├── creators.test.js    # Creators API
+│   ├── users.test.js       # Users API
+│   ├── reviews.test.js     # Reviews API
+│   ├── messages.test.js    # Messages API
+│   ├── analytics.test.js   # Analytics API
+│   ├── referrals.test.js   # Referrals API
+│   ├── upload.test.js      # Upload API
+│   └── rust-api.test.js    # Rust backend API (port 3001)
+├── smoke.test.js           # Quick smoke test (all services)
+├── stress.test.js          # Stress test (ramp to breaking point)
+├── soak.test.js            # Soak test (sustained load over time)
+└── README.md
+```
+
+## Running Tests
+
+```bash
+# Smoke test — quick sanity check
+k6 run load-tests/smoke.test.js
+
+# Individual service tests
+k6 run load-tests/scenarios/bounties.test.js
+k6 run load-tests/scenarios/creators.test.js
+k6 run load-tests/scenarios/auth.test.js
+
+# Stress test
+k6 run load-tests/stress.test.js
+
+# Soak test (long-running)
+k6 run load-tests/soak.test.js
+
+# With custom base URL
+k6 run -e BASE_URL=https://staging.example.com load-tests/smoke.test.js
+
+# With HTML report (requires k6-reporter)
+k6 run --out json=results.json load-tests/smoke.test.js
+```
+
+## Environment Variables
+
+| Variable       | Default                  | Description              |
+|----------------|--------------------------|--------------------------|
+| `BASE_URL`     | `http://localhost:3000`  | Next.js frontend URL     |
+| `RUST_API_URL` | `http://localhost:3001`  | Rust backend API URL     |
+| `TEST_EMAIL`   | `test@example.com`       | Test user email          |
+| `TEST_PASSWORD`| `TestPassword123!`       | Test user password       |
+
+## Performance Thresholds
+
+- p95 response time < 500ms
+- p99 response time < 1000ms
+- Error rate < 1%
+- All checks pass > 95%

--- a/load-tests/config/options.js
+++ b/load-tests/config/options.js
@@ -1,0 +1,59 @@
+/**
+ * Shared k6 options and thresholds for all load test scenarios.
+ */
+
+export const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+export const RUST_API_URL = __ENV.RUST_API_URL || 'http://localhost:3001';
+
+/** Standard thresholds applied to every scenario */
+export const defaultThresholds = {
+  // 95% of requests must complete within 500ms
+  http_req_duration: ['p(95)<500', 'p(99)<1000'],
+  // Error rate must stay below 1%
+  http_req_failed: ['rate<0.01'],
+  // At least 95% of custom checks must pass
+  checks: ['rate>0.95'],
+};
+
+/** Light load — baseline / smoke */
+export const smokeOptions = {
+  vus: 5,
+  duration: '30s',
+  thresholds: defaultThresholds,
+};
+
+/** Average load — normal production traffic */
+export const averageLoadOptions = {
+  stages: [
+    { duration: '30s', target: 20 },   // ramp up
+    { duration: '1m',  target: 20 },   // steady state
+    { duration: '20s', target: 0 },    // ramp down
+  ],
+  thresholds: defaultThresholds,
+};
+
+/** Stress — push beyond expected peak */
+export const stressOptions = {
+  stages: [
+    { duration: '30s', target: 50 },
+    { duration: '1m',  target: 100 },
+    { duration: '30s', target: 150 },
+    { duration: '1m',  target: 150 },
+    { duration: '30s', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<2000', 'p(99)<5000'],
+    http_req_failed:   ['rate<0.05'],
+    checks:            ['rate>0.90'],
+  },
+};
+
+/** Soak — sustained load to detect memory leaks / degradation */
+export const soakOptions = {
+  stages: [
+    { duration: '2m',  target: 30 },
+    { duration: '30m', target: 30 },
+    { duration: '2m',  target: 0 },
+  ],
+  thresholds: defaultThresholds,
+};

--- a/load-tests/helpers/auth.js
+++ b/load-tests/helpers/auth.js
@@ -1,0 +1,51 @@
+/**
+ * Auth helpers — obtain and cache a session token for authenticated requests.
+ */
+import http from 'k6/http';
+import { check } from 'k6';
+import { BASE_URL } from '../config/options.js';
+
+const TEST_EMAIL    = __ENV.TEST_EMAIL    || 'test@example.com';
+const TEST_PASSWORD = __ENV.TEST_PASSWORD || 'TestPassword123!';
+
+/**
+ * Returns common JSON headers, optionally with a Bearer token.
+ * @param {string} [token]
+ */
+export function jsonHeaders(token) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+/**
+ * Logs in via NextAuth credentials and returns the session cookie string.
+ * Call once in setup() and pass the result into VU functions.
+ */
+export function getSessionCookie() {
+  const csrfRes = http.get(`${BASE_URL}/api/auth/csrf`);
+  const csrfToken = csrfRes.json('csrfToken');
+
+  const loginRes = http.post(
+    `${BASE_URL}/api/auth/callback/credentials`,
+    JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD, csrfToken }),
+    { headers: { 'Content-Type': 'application/json' }, redirects: 0 },
+  );
+
+  check(loginRes, { 'login succeeded': (r) => r.status === 200 || r.status === 302 });
+
+  // Extract Set-Cookie header for subsequent requests
+  const setCookie = loginRes.headers['Set-Cookie'] || '';
+  return setCookie;
+}
+
+/**
+ * Returns headers with session cookie for authenticated requests.
+ * @param {string} cookie
+ */
+export function authHeaders(cookie) {
+  return {
+    'Content-Type': 'application/json',
+    Cookie: cookie,
+  };
+}

--- a/load-tests/scenarios/analytics.test.js
+++ b/load-tests/scenarios/analytics.test.js
@@ -1,0 +1,52 @@
+/**
+ * Load test — Analytics API
+ * Covers: all presets, granularities, and export formats
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import { BASE_URL, averageLoadOptions, defaultThresholds } from '../config/options.js';
+import { jsonHeaders } from '../helpers/auth.js';
+
+export const options = {
+  ...averageLoadOptions,
+  thresholds: {
+    ...defaultThresholds,
+    // Analytics can be heavier — allow more latency
+    http_req_duration: ['p(95)<1000', 'p(99)<3000'],
+  },
+};
+
+const analyticsLatency = new Trend('analytics_duration');
+
+const PRESETS      = ['7d', '30d', '90d', '1y'];
+const GRANULARITY  = ['daily', 'weekly', 'monthly'];
+
+export default function () {
+  const preset      = PRESETS[__ITER % PRESETS.length];
+  const granularity = GRANULARITY[__ITER % GRANULARITY.length];
+
+  // --- JSON response ---
+  const jsonRes = http.get(
+    `${BASE_URL}/api/analytics?preset=${preset}&granularity=${granularity}&format=json`,
+    { headers: jsonHeaders() },
+  );
+  analyticsLatency.add(jsonRes.timings.duration);
+  check(jsonRes, {
+    'analytics json: status 200': (r) => r.status === 200,
+    'analytics json: has body':   (r) => r.body.length > 0,
+  });
+
+  sleep(1);
+
+  // --- CSV export ---
+  const csvRes = http.get(
+    `${BASE_URL}/api/analytics?preset=${preset}&format=csv`,
+    { headers: jsonHeaders() },
+  );
+  check(csvRes, {
+    'analytics csv: status 200': (r) => r.status === 200,
+  });
+
+  sleep(1);
+}

--- a/load-tests/scenarios/auth.test.js
+++ b/load-tests/scenarios/auth.test.js
@@ -1,0 +1,57 @@
+/**
+ * Load test — Auth endpoints
+ * Covers: register, forgot-password, reset-password, verify-email
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+import { BASE_URL, averageLoadOptions, defaultThresholds } from '../config/options.js';
+import { jsonHeaders } from '../helpers/auth.js';
+
+export const options = {
+  ...averageLoadOptions,
+  thresholds: {
+    ...defaultThresholds,
+    // Auth endpoints are allowed slightly more latency
+    http_req_duration: ['p(95)<800', 'p(99)<2000'],
+  },
+};
+
+const registrationErrors = new Counter('auth_registration_errors');
+
+export default function () {
+  const uid = `${Date.now()}-${__VU}-${__ITER}`;
+
+  // --- Register ---
+  const registerRes = http.post(
+    `${BASE_URL}/api/auth/register`,
+    JSON.stringify({
+      email:    `loadtest-${uid}@example.com`,
+      password: 'LoadTest123!',
+      name:     `Load Tester ${uid}`,
+      role:     'creator',
+    }),
+    { headers: jsonHeaders() },
+  );
+
+  const registerOk = check(registerRes, {
+    'register: status 201 or 409': (r) => r.status === 201 || r.status === 409,
+    'register: has body':          (r) => r.body.length > 0,
+  });
+  if (!registerOk) registrationErrors.add(1);
+
+  sleep(1);
+
+  // --- Forgot password ---
+  const forgotRes = http.post(
+    `${BASE_URL}/api/auth/forgot-password`,
+    JSON.stringify({ email: `loadtest-${uid}@example.com` }),
+    { headers: jsonHeaders() },
+  );
+
+  check(forgotRes, {
+    'forgot-password: status 200 or 404': (r) => r.status === 200 || r.status === 404,
+  });
+
+  sleep(1);
+}

--- a/load-tests/scenarios/bounties.test.js
+++ b/load-tests/scenarios/bounties.test.js
@@ -1,0 +1,70 @@
+/**
+ * Load test — Bounties API
+ * Covers: list, create, update, delete
+ * Rate limit: 60 req/min per IP
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import { BASE_URL, averageLoadOptions, defaultThresholds } from '../config/options.js';
+import { jsonHeaders, getSessionCookie, authHeaders } from '../helpers/auth.js';
+
+export const options = {
+  ...averageLoadOptions,
+  thresholds: defaultThresholds,
+};
+
+const listLatency   = new Trend('bounties_list_duration');
+const createLatency = new Trend('bounties_create_duration');
+
+let sessionCookie;
+
+export function setup() {
+  sessionCookie = getSessionCookie();
+}
+
+export default function () {
+  // --- GET /api/bounties (paginated list) ---
+  const listRes = http.get(
+    `${BASE_URL}/api/bounties?page=1&limit=10`,
+    { headers: jsonHeaders() },
+  );
+  listLatency.add(listRes.timings.duration);
+  check(listRes, {
+    'bounties list: status 200':    (r) => r.status === 200,
+    'bounties list: has data array': (r) => Array.isArray(r.json('data')),
+  });
+
+  sleep(0.5);
+
+  // --- GET with filters ---
+  const filteredRes = http.get(
+    `${BASE_URL}/api/bounties?page=1&limit=10&status=open&difficulty=beginner`,
+    { headers: jsonHeaders() },
+  );
+  check(filteredRes, {
+    'bounties filtered: status 200': (r) => r.status === 200,
+  });
+
+  sleep(0.5);
+
+  // --- POST /api/bounties (create) ---
+  const createRes = http.post(
+    `${BASE_URL}/api/bounties`,
+    JSON.stringify({
+      title:       `Load Test Bounty ${__VU}-${__ITER}`,
+      description: 'Automated load test bounty — safe to delete.',
+      budget:      500,
+      deadline:    new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      category:    'development',
+      difficulty:  'intermediate',
+    }),
+    { headers: authHeaders(sessionCookie) },
+  );
+  createLatency.add(createRes.timings.duration);
+  check(createRes, {
+    'bounties create: status 201 or 401': (r) => r.status === 201 || r.status === 401,
+  });
+
+  sleep(1);
+}

--- a/load-tests/scenarios/creators.test.js
+++ b/load-tests/scenarios/creators.test.js
@@ -1,0 +1,70 @@
+/**
+ * Load test — Creators API
+ * Covers: list (with discipline filter), single creator, create, update
+ * Rate limit: 60 req/min per IP
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import { BASE_URL, averageLoadOptions, defaultThresholds } from '../config/options.js';
+import { jsonHeaders, getSessionCookie, authHeaders } from '../helpers/auth.js';
+
+export const options = {
+  ...averageLoadOptions,
+  thresholds: defaultThresholds,
+};
+
+const listLatency = new Trend('creators_list_duration');
+
+const DISCIPLINES = ['design', 'development', 'writing', 'marketing', 'video'];
+
+let sessionCookie;
+
+export function setup() {
+  sessionCookie = getSessionCookie();
+}
+
+export default function () {
+  // --- GET /api/creators (list) ---
+  const listRes = http.get(
+    `${BASE_URL}/api/creators?page=1&limit=10`,
+    { headers: jsonHeaders() },
+  );
+  listLatency.add(listRes.timings.duration);
+  check(listRes, {
+    'creators list: status 200':     (r) => r.status === 200,
+    'creators list: has data array': (r) => Array.isArray(r.json('data')),
+  });
+
+  sleep(0.5);
+
+  // --- GET with discipline filter ---
+  const discipline = DISCIPLINES[__ITER % DISCIPLINES.length];
+  const filteredRes = http.get(
+    `${BASE_URL}/api/creators?page=1&limit=10&discipline=${discipline}`,
+    { headers: jsonHeaders() },
+  );
+  check(filteredRes, {
+    'creators filtered: status 200': (r) => r.status === 200,
+  });
+
+  sleep(0.5);
+
+  // --- POST /api/creators (create profile) ---
+  const createRes = http.post(
+    `${BASE_URL}/api/creators`,
+    JSON.stringify({
+      name:       `Load Tester ${__VU}-${__ITER}`,
+      discipline: discipline,
+      bio:        'Automated load test profile.',
+      hourlyRate: 50,
+    }),
+    { headers: authHeaders(sessionCookie) },
+  );
+  check(createRes, {
+    'creators create: status 201 or 401 or 409': (r) =>
+      [201, 401, 409].includes(r.status),
+  });
+
+  sleep(1);
+}

--- a/load-tests/scenarios/messages.test.js
+++ b/load-tests/scenarios/messages.test.js
@@ -1,0 +1,60 @@
+/**
+ * Load test — Messages API (HTTP)
+ * Note: WebSocket load testing requires k6 websockets module.
+ * This file covers the HTTP GET/POST endpoints.
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import { BASE_URL, averageLoadOptions, defaultThresholds } from '../config/options.js';
+import { jsonHeaders, getSessionCookie, authHeaders } from '../helpers/auth.js';
+
+export const options = {
+  ...averageLoadOptions,
+  thresholds: defaultThresholds,
+};
+
+const sendLatency = new Trend('messages_send_duration');
+const getLatency  = new Trend('messages_get_duration');
+
+const THREAD_IDS = ['thread-1', 'thread-2', 'thread-3'];
+
+let sessionCookie;
+
+export function setup() {
+  sessionCookie = getSessionCookie();
+}
+
+export default function () {
+  const threadId = THREAD_IDS[__ITER % THREAD_IDS.length];
+
+  // --- GET /api/messages?threadId= ---
+  const getRes = http.get(
+    `${BASE_URL}/api/messages?threadId=${threadId}`,
+    { headers: authHeaders(sessionCookie) },
+  );
+  getLatency.add(getRes.timings.duration);
+  check(getRes, {
+    'messages get: status 200 or 401': (r) => r.status === 200 || r.status === 401,
+  });
+
+  sleep(0.5);
+
+  // --- POST /api/messages (send) ---
+  const sendRes = http.post(
+    `${BASE_URL}/api/messages`,
+    JSON.stringify({
+      threadId:    threadId,
+      recipientId: 'user-2',
+      ciphertext:  btoa(`load-test-message-${__VU}-${__ITER}`),
+      iv:          btoa('test-iv-16bytes!!'),
+    }),
+    { headers: authHeaders(sessionCookie) },
+  );
+  sendLatency.add(sendRes.timings.duration);
+  check(sendRes, {
+    'messages send: status 201 or 401': (r) => r.status === 201 || r.status === 401,
+  });
+
+  sleep(1);
+}

--- a/load-tests/scenarios/referrals.test.js
+++ b/load-tests/scenarios/referrals.test.js
@@ -1,0 +1,70 @@
+/**
+ * Load test — Referrals API
+ * Covers: generate code, get stats, get history, track event
+ * Rate limit: 30 req/min general, 10 req/min POST
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import { BASE_URL, defaultThresholds } from '../config/options.js';
+import { jsonHeaders, getSessionCookie, authHeaders } from '../helpers/auth.js';
+
+export const options = {
+  // Respect the tighter rate limit
+  stages: [
+    { duration: '30s', target: 10 },
+    { duration: '1m',  target: 10 },
+    { duration: '20s', target: 0 },
+  ],
+  thresholds: defaultThresholds,
+};
+
+const statsLatency = new Trend('referrals_stats_duration');
+
+let sessionCookie;
+
+export function setup() {
+  sessionCookie = getSessionCookie();
+}
+
+export default function () {
+  // --- GET /api/referrals?action=code ---
+  const codeRes = http.get(
+    `${BASE_URL}/api/referrals?action=code`,
+    { headers: authHeaders(sessionCookie) },
+  );
+  check(codeRes, {
+    'referrals code: status 200 or 401': (r) => r.status === 200 || r.status === 401,
+  });
+
+  sleep(1);
+
+  // --- GET /api/referrals?action=stats ---
+  const statsRes = http.get(
+    `${BASE_URL}/api/referrals?action=stats`,
+    { headers: authHeaders(sessionCookie) },
+  );
+  statsLatency.add(statsRes.timings.duration);
+  check(statsRes, {
+    'referrals stats: status 200 or 401': (r) => r.status === 200 || r.status === 401,
+  });
+
+  sleep(1);
+
+  // --- POST /api/referrals (track event) ---
+  const trackRes = http.post(
+    `${BASE_URL}/api/referrals`,
+    JSON.stringify({
+      code:           'TESTCODE123',
+      referredUserId: `user-${__VU}-${__ITER}`,
+      event:          'signup',
+    }),
+    { headers: authHeaders(sessionCookie) },
+  );
+  check(trackRes, {
+    'referrals track: status 200 or 401 or 429': (r) =>
+      [200, 401, 429].includes(r.status),
+  });
+
+  sleep(2);
+}

--- a/load-tests/scenarios/reviews.test.js
+++ b/load-tests/scenarios/reviews.test.js
@@ -1,0 +1,67 @@
+/**
+ * Load test — Reviews API
+ * Covers: list reviews, submit review, vote
+ * Rate limit: 20 req/min general, 10 req/min POST
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import { BASE_URL, averageLoadOptions, defaultThresholds } from '../config/options.js';
+import { jsonHeaders, getSessionCookie, authHeaders } from '../helpers/auth.js';
+
+export const options = {
+  // Reviews have a tighter rate limit — keep VUs lower
+  stages: [
+    { duration: '30s', target: 10 },
+    { duration: '1m',  target: 10 },
+    { duration: '20s', target: 0 },
+  ],
+  thresholds: defaultThresholds,
+};
+
+const listLatency   = new Trend('reviews_list_duration');
+const createLatency = new Trend('reviews_create_duration');
+
+// Seed creator IDs — replace with real IDs from your DB for accurate testing
+const CREATOR_IDS = ['creator-1', 'creator-2', 'creator-3'];
+
+let sessionCookie;
+
+export function setup() {
+  sessionCookie = getSessionCookie();
+}
+
+export default function () {
+  const creatorId = CREATOR_IDS[__ITER % CREATOR_IDS.length];
+
+  // --- GET /api/reviews?creatorId= ---
+  const listRes = http.get(
+    `${BASE_URL}/api/reviews?creatorId=${creatorId}&sort=recent&page=1&limit=10`,
+    { headers: jsonHeaders() },
+  );
+  listLatency.add(listRes.timings.duration);
+  check(listRes, {
+    'reviews list: status 200 or 404': (r) => r.status === 200 || r.status === 404,
+  });
+
+  sleep(1);
+
+  // --- POST /api/reviews (submit) ---
+  const createRes = http.post(
+    `${BASE_URL}/api/reviews`,
+    JSON.stringify({
+      creatorId: creatorId,
+      rating:    4,
+      title:     'Load test review',
+      body:      'This is an automated load test review. Please disregard.',
+    }),
+    { headers: authHeaders(sessionCookie) },
+  );
+  createLatency.add(createRes.timings.duration);
+  check(createRes, {
+    'reviews create: status 201 or 401 or 429': (r) =>
+      [201, 401, 429].includes(r.status),
+  });
+
+  sleep(2);
+}

--- a/load-tests/scenarios/rust-api.test.js
+++ b/load-tests/scenarios/rust-api.test.js
@@ -1,0 +1,87 @@
+/**
+ * Load test — Rust backend API (port 3001)
+ * Covers: health, bounties, freelancers, escrow
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import { RUST_API_URL, averageLoadOptions, defaultThresholds } from '../config/options.js';
+
+export const options = {
+  ...averageLoadOptions,
+  thresholds: defaultThresholds,
+};
+
+const healthLatency     = new Trend('rust_health_duration');
+const bountiesLatency   = new Trend('rust_bounties_duration');
+const freelancerLatency = new Trend('rust_freelancers_duration');
+
+const DISCIPLINES = ['design', 'development', 'writing'];
+
+export default function () {
+  // --- GET /health ---
+  const healthRes = http.get(`${RUST_API_URL}/health`);
+  healthLatency.add(healthRes.timings.duration);
+  check(healthRes, {
+    'rust health: status 200': (r) => r.status === 200,
+  });
+
+  sleep(0.3);
+
+  // --- GET /api/bounties ---
+  const bountiesRes = http.get(`${RUST_API_URL}/api/bounties`);
+  bountiesLatency.add(bountiesRes.timings.duration);
+  check(bountiesRes, {
+    'rust bounties list: status 200': (r) => r.status === 200,
+  });
+
+  sleep(0.3);
+
+  // --- POST /api/bounties (create) ---
+  const createBountyRes = http.post(
+    `${RUST_API_URL}/api/bounties`,
+    JSON.stringify({
+      creator:     `GLOAD${__VU}TESTER${__ITER}STELLAR`,
+      title:       `Load Test Bounty ${__VU}-${__ITER}`,
+      description: 'Automated load test — safe to delete.',
+      budget:      1000,
+      deadline:    Math.floor(Date.now() / 1000) + 7 * 24 * 3600,
+    }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+  check(createBountyRes, {
+    'rust create bounty: status 200 or 201': (r) =>
+      r.status === 200 || r.status === 201,
+  });
+
+  sleep(0.5);
+
+  // --- GET /api/freelancers ---
+  const discipline = DISCIPLINES[__ITER % DISCIPLINES.length];
+  const freelancersRes = http.get(
+    `${RUST_API_URL}/api/freelancers?discipline=${discipline}`,
+  );
+  freelancerLatency.add(freelancersRes.timings.duration);
+  check(freelancersRes, {
+    'rust freelancers list: status 200': (r) => r.status === 200,
+  });
+
+  sleep(0.5);
+
+  // --- POST /api/freelancers/register ---
+  const registerRes = http.post(
+    `${RUST_API_URL}/api/freelancers/register`,
+    JSON.stringify({
+      name:       `Load Tester ${__VU}-${__ITER}`,
+      discipline: discipline,
+      bio:        'Automated load test profile.',
+    }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+  check(registerRes, {
+    'rust register freelancer: status 200 or 201 or 409': (r) =>
+      [200, 201, 409].includes(r.status),
+  });
+
+  sleep(1);
+}

--- a/load-tests/scenarios/upload.test.js
+++ b/load-tests/scenarios/upload.test.js
@@ -1,0 +1,71 @@
+/**
+ * Load test — Upload API
+ * Covers: list files, upload small file, delete file
+ * Note: kept at low VUs — upload is I/O heavy.
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import { BASE_URL, defaultThresholds } from '../config/options.js';
+import { getSessionCookie, authHeaders } from '../helpers/auth.js';
+
+export const options = {
+  // Low concurrency — upload is resource-intensive
+  stages: [
+    { duration: '30s', target: 5 },
+    { duration: '1m',  target: 5 },
+    { duration: '20s', target: 0 },
+  ],
+  thresholds: {
+    ...defaultThresholds,
+    http_req_duration: ['p(95)<3000', 'p(99)<8000'],
+  },
+};
+
+const uploadLatency = new Trend('upload_duration');
+const listLatency   = new Trend('upload_list_duration');
+
+let sessionCookie;
+
+export function setup() {
+  sessionCookie = getSessionCookie();
+}
+
+export default function () {
+  // --- GET /api/upload?prefix=uploads (list files) ---
+  const listRes = http.get(
+    `${BASE_URL}/api/upload?prefix=uploads`,
+    { headers: authHeaders(sessionCookie) },
+  );
+  listLatency.add(listRes.timings.duration);
+  check(listRes, {
+    'upload list: status 200 or 401': (r) => r.status === 200 || r.status === 401,
+  });
+
+  sleep(1);
+
+  // --- POST /api/upload (small PNG upload) ---
+  // Minimal 1x1 transparent PNG (67 bytes)
+  const pngBase64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+  const pngBytes = new Uint8Array(
+    atob(pngBase64)
+      .split('')
+      .map((c) => c.charCodeAt(0)),
+  );
+
+  const formData = {
+    file: http.file(pngBytes, `test-${__VU}-${__ITER}.png`, 'image/png'),
+  };
+
+  const uploadRes = http.post(`${BASE_URL}/api/upload`, formData, {
+    headers: { Cookie: sessionCookie },
+  });
+  uploadLatency.add(uploadRes.timings.duration);
+  check(uploadRes, {
+    'upload: status 200 or 201 or 401': (r) =>
+      [200, 201, 401].includes(r.status),
+  });
+
+  sleep(2);
+}

--- a/load-tests/scenarios/users.test.js
+++ b/load-tests/scenarios/users.test.js
@@ -1,0 +1,67 @@
+/**
+ * Load test — Users API
+ * Covers: list, get by id, create, update
+ * Rate limit: 60 req/min per IP
+ */
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import { BASE_URL, averageLoadOptions, defaultThresholds } from '../config/options.js';
+import { jsonHeaders, getSessionCookie, authHeaders } from '../helpers/auth.js';
+
+export const options = {
+  ...averageLoadOptions,
+  thresholds: defaultThresholds,
+};
+
+const listLatency = new Trend('users_list_duration');
+
+let sessionCookie;
+
+export function setup() {
+  sessionCookie = getSessionCookie();
+}
+
+export default function () {
+  // --- GET /api/users (list) ---
+  const listRes = http.get(
+    `${BASE_URL}/api/users?page=1&limit=10`,
+    { headers: jsonHeaders() },
+  );
+  listLatency.add(listRes.timings.duration);
+  check(listRes, {
+    'users list: status 200':     (r) => r.status === 200,
+    'users list: has data array': (r) => Array.isArray(r.json('data')),
+  });
+
+  sleep(0.5);
+
+  // --- GET with role filter ---
+  const roleRes = http.get(
+    `${BASE_URL}/api/users?page=1&limit=10&role=creator`,
+    { headers: jsonHeaders() },
+  );
+  check(roleRes, {
+    'users role filter: status 200': (r) => r.status === 200,
+  });
+
+  sleep(0.5);
+
+  // --- POST /api/users (create) ---
+  const uid = `${Date.now()}-${__VU}-${__ITER}`;
+  const createRes = http.post(
+    `${BASE_URL}/api/users`,
+    JSON.stringify({
+      email: `loadtest-user-${uid}@example.com`,
+      name:  `Load User ${uid}`,
+      role:  'creator',
+    }),
+    { headers: authHeaders(sessionCookie) },
+  );
+  check(createRes, {
+    'users create: status 201 or 401 or 409': (r) =>
+      [201, 401, 409].includes(r.status),
+  });
+
+  sleep(1);
+}

--- a/load-tests/smoke.test.js
+++ b/load-tests/smoke.test.js
@@ -1,0 +1,62 @@
+/**
+ * Smoke test — quick sanity check across ALL services.
+ * Run this first to verify the environment is up before heavier tests.
+ *
+ * Usage:
+ *   k6 run load-tests/smoke.test.js
+ *   k6 run -e BASE_URL=https://staging.example.com load-tests/smoke.test.js
+ */
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { BASE_URL, RUST_API_URL, smokeOptions } from './config/options.js';
+import { jsonHeaders } from './helpers/auth.js';
+
+export const options = smokeOptions;
+
+export default function () {
+  // ── Next.js API routes ──────────────────────────────────────────────────
+
+  group('bounties', () => {
+    const r = http.get(`${BASE_URL}/api/bounties?page=1&limit=5`, { headers: jsonHeaders() });
+    check(r, { 'bounties: 200': (res) => res.status === 200 });
+  });
+
+  group('creators', () => {
+    const r = http.get(`${BASE_URL}/api/creators?page=1&limit=5`, { headers: jsonHeaders() });
+    check(r, { 'creators: 200': (res) => res.status === 200 });
+  });
+
+  group('users', () => {
+    const r = http.get(`${BASE_URL}/api/users?page=1&limit=5`, { headers: jsonHeaders() });
+    check(r, { 'users: 200': (res) => res.status === 200 });
+  });
+
+  group('analytics', () => {
+    const r = http.get(`${BASE_URL}/api/analytics?preset=7d&format=json`, { headers: jsonHeaders() });
+    check(r, { 'analytics: 200': (res) => res.status === 200 });
+  });
+
+  group('reviews', () => {
+    const r = http.get(`${BASE_URL}/api/reviews?creatorId=creator-1&page=1&limit=5`, { headers: jsonHeaders() });
+    check(r, { 'reviews: 200 or 404': (res) => res.status === 200 || res.status === 404 });
+  });
+
+  // ── Rust backend ────────────────────────────────────────────────────────
+
+  group('rust-health', () => {
+    const r = http.get(`${RUST_API_URL}/health`);
+    check(r, { 'rust health: 200': (res) => res.status === 200 });
+  });
+
+  group('rust-bounties', () => {
+    const r = http.get(`${RUST_API_URL}/api/bounties`);
+    check(r, { 'rust bounties: 200': (res) => res.status === 200 });
+  });
+
+  group('rust-freelancers', () => {
+    const r = http.get(`${RUST_API_URL}/api/freelancers`);
+    check(r, { 'rust freelancers: 200': (res) => res.status === 200 });
+  });
+
+  sleep(1);
+}

--- a/load-tests/soak.test.js
+++ b/load-tests/soak.test.js
@@ -1,0 +1,88 @@
+/**
+ * Soak test — sustained moderate load over 30+ minutes.
+ * Detects memory leaks, connection pool exhaustion, and gradual degradation.
+ *
+ * Usage:
+ *   k6 run load-tests/soak.test.js
+ *
+ * Expected duration: ~34 minutes
+ */
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+import { BASE_URL, RUST_API_URL, soakOptions } from './config/options.js';
+import { jsonHeaders, getSessionCookie, authHeaders } from './helpers/auth.js';
+
+export const options = soakOptions;
+
+const degradationRate = new Rate('soak_degradation');
+const p95Trend        = new Trend('soak_p95_over_time');
+
+let sessionCookie;
+
+export function setup() {
+  sessionCookie = getSessionCookie();
+}
+
+export default function () {
+  // Mix of read and write operations to simulate real traffic
+
+  group('read-bounties', () => {
+    const r = http.get(`${BASE_URL}/api/bounties?page=1&limit=10`, { headers: jsonHeaders() });
+    p95Trend.add(r.timings.duration);
+    const ok = check(r, { 'soak bounties: 200': (res) => res.status === 200 });
+    if (!ok) degradationRate.add(1);
+  });
+
+  sleep(0.5);
+
+  group('read-creators', () => {
+    const r = http.get(`${BASE_URL}/api/creators?page=1&limit=10`, { headers: jsonHeaders() });
+    p95Trend.add(r.timings.duration);
+    const ok = check(r, { 'soak creators: 200': (res) => res.status === 200 });
+    if (!ok) degradationRate.add(1);
+  });
+
+  sleep(0.5);
+
+  group('read-analytics', () => {
+    const r = http.get(`${BASE_URL}/api/analytics?preset=7d&format=json`, { headers: jsonHeaders() });
+    p95Trend.add(r.timings.duration);
+    const ok = check(r, { 'soak analytics: 200': (res) => res.status === 200 });
+    if (!ok) degradationRate.add(1);
+  });
+
+  sleep(0.5);
+
+  group('rust-health', () => {
+    const r = http.get(`${RUST_API_URL}/health`);
+    p95Trend.add(r.timings.duration);
+    const ok = check(r, { 'soak rust health: 200': (res) => res.status === 200 });
+    if (!ok) degradationRate.add(1);
+  });
+
+  sleep(0.5);
+
+  // Occasional write to simulate realistic mixed traffic
+  if (__ITER % 5 === 0) {
+    group('write-bounty', () => {
+      const r = http.post(
+        `${BASE_URL}/api/bounties`,
+        JSON.stringify({
+          title:       `Soak Test Bounty ${__VU}-${__ITER}`,
+          description: 'Soak test — safe to delete.',
+          budget:      100,
+          deadline:    new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+          category:    'development',
+          difficulty:  'beginner',
+        }),
+        { headers: authHeaders(sessionCookie) },
+      );
+      check(r, {
+        'soak create bounty: not 5xx': (res) => res.status < 500,
+      });
+    });
+  }
+
+  sleep(1);
+}

--- a/load-tests/spike.test.js
+++ b/load-tests/spike.test.js
@@ -1,0 +1,67 @@
+/**
+ * Spike test — sudden burst of traffic to simulate viral/flash-crowd events.
+ * Jumps from idle to peak in seconds, then drops back down.
+ *
+ * Usage:
+ *   k6 run load-tests/spike.test.js
+ *
+ * Expected duration: ~3 minutes
+ */
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+import { BASE_URL, RUST_API_URL } from './config/options.js';
+import { jsonHeaders } from './helpers/auth.js';
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 5 },    // baseline
+    { duration: '10s', target: 200 },  // spike — instant ramp
+    { duration: '1m',  target: 200 },  // hold spike
+    { duration: '10s', target: 5 },    // drop back
+    { duration: '30s', target: 5 },    // recovery observation
+    { duration: '10s', target: 0 },
+  ],
+  thresholds: {
+    // Relaxed during spike — we care about survival, not speed
+    http_req_duration: ['p(95)<5000', 'p(99)<10000'],
+    http_req_failed:   ['rate<0.10'],
+    checks:            ['rate>0.85'],
+  },
+};
+
+const errorRate    = new Rate('spike_errors');
+const bountiesP95  = new Trend('spike_bounties_p95');
+const creatorsP95  = new Trend('spike_creators_p95');
+const rustP95      = new Trend('spike_rust_health_p95');
+
+export default function () {
+  group('bounties-spike', () => {
+    const r = http.get(`${BASE_URL}/api/bounties?page=1&limit=10`, { headers: jsonHeaders() });
+    bountiesP95.add(r.timings.duration);
+    const ok = check(r, {
+      'spike bounties: not 5xx': (res) => res.status < 500,
+    });
+    if (!ok) errorRate.add(1);
+  });
+
+  group('creators-spike', () => {
+    const r = http.get(`${BASE_URL}/api/creators?page=1&limit=10`, { headers: jsonHeaders() });
+    creatorsP95.add(r.timings.duration);
+    const ok = check(r, {
+      'spike creators: not 5xx': (res) => res.status < 500,
+    });
+    if (!ok) errorRate.add(1);
+  });
+
+  group('rust-health-spike', () => {
+    const r = http.get(`${RUST_API_URL}/health`);
+    rustP95.add(r.timings.duration);
+    const ok = check(r, {
+      'spike rust health: 200': (res) => res.status === 200,
+    });
+    if (!ok) errorRate.add(1);
+  });
+
+  sleep(0.3);
+}

--- a/load-tests/stress.test.js
+++ b/load-tests/stress.test.js
@@ -1,0 +1,61 @@
+/**
+ * Stress test — ramp VUs well beyond expected peak to find the breaking point.
+ * Targets the most critical read paths (bounties, creators, analytics).
+ *
+ * Usage:
+ *   k6 run load-tests/stress.test.js
+ */
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+import { BASE_URL, RUST_API_URL, stressOptions } from './config/options.js';
+import { jsonHeaders } from './helpers/auth.js';
+
+export const options = stressOptions;
+
+const errorRate      = new Rate('stress_errors');
+const bountiesP95    = new Trend('stress_bounties_p95');
+const creatorsP95    = new Trend('stress_creators_p95');
+const analyticsP95   = new Trend('stress_analytics_p95');
+const rustHealthP95  = new Trend('stress_rust_health_p95');
+
+export default function () {
+  group('bounties-read', () => {
+    const r = http.get(`${BASE_URL}/api/bounties?page=1&limit=10`, { headers: jsonHeaders() });
+    bountiesP95.add(r.timings.duration);
+    const ok = check(r, {
+      'stress bounties: not 5xx': (res) => res.status < 500,
+      'stress bounties: not 429': (res) => res.status !== 429,
+    });
+    if (!ok) errorRate.add(1);
+  });
+
+  group('creators-read', () => {
+    const r = http.get(`${BASE_URL}/api/creators?page=1&limit=10`, { headers: jsonHeaders() });
+    creatorsP95.add(r.timings.duration);
+    const ok = check(r, {
+      'stress creators: not 5xx': (res) => res.status < 500,
+    });
+    if (!ok) errorRate.add(1);
+  });
+
+  group('analytics-read', () => {
+    const r = http.get(`${BASE_URL}/api/analytics?preset=30d&format=json`, { headers: jsonHeaders() });
+    analyticsP95.add(r.timings.duration);
+    const ok = check(r, {
+      'stress analytics: not 5xx': (res) => res.status < 500,
+    });
+    if (!ok) errorRate.add(1);
+  });
+
+  group('rust-health', () => {
+    const r = http.get(`${RUST_API_URL}/health`);
+    rustHealthP95.add(r.timings.duration);
+    const ok = check(r, {
+      'stress rust health: 200': (res) => res.status === 200,
+    });
+    if (!ok) errorRate.add(1);
+  });
+
+  sleep(0.5);
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,21 @@
     "frontend:orbit-check": "pnpm lint",
     "backend:clippy": "cd backend && rustup component add clippy && cargo clippy --workspace --all-targets --all-features -- -D warnings",
     "smart-contract:clippy": "cd backend/contracts && rustup component add clippy && cargo clippy --workspace --all-targets --all-features -- -D warnings",
-    "cli-checks": "pnpm run frontend:orbit-check && pnpm run backend:clippy && pnpm run smart-contract:clippy"
+    "cli-checks": "pnpm run frontend:orbit-check && pnpm run backend:clippy && pnpm run smart-contract:clippy",
+    "load:smoke": "k6 run load-tests/smoke.test.js",
+    "load:stress": "k6 run load-tests/stress.test.js",
+    "load:soak": "k6 run load-tests/soak.test.js",
+    "load:spike": "k6 run load-tests/spike.test.js",
+    "load:auth": "k6 run load-tests/scenarios/auth.test.js",
+    "load:bounties": "k6 run load-tests/scenarios/bounties.test.js",
+    "load:creators": "k6 run load-tests/scenarios/creators.test.js",
+    "load:users": "k6 run load-tests/scenarios/users.test.js",
+    "load:reviews": "k6 run load-tests/scenarios/reviews.test.js",
+    "load:messages": "k6 run load-tests/scenarios/messages.test.js",
+    "load:analytics": "k6 run load-tests/scenarios/analytics.test.js",
+    "load:referrals": "k6 run load-tests/scenarios/referrals.test.js",
+    "load:upload": "k6 run load-tests/scenarios/upload.test.js",
+    "load:rust-api": "k6 run load-tests/scenarios/rust-api.test.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.744.0",


### PR DESCRIPTION
- smoke, stress, soak, and spike test suites
- per-service scenarios: auth, bounties, creators, users, reviews, messages, analytics, referrals, upload, rust-api
- shared config/options.js with thresholds and stage presets
- auth helper for session cookie acquisition
- npm scripts: load:smoke, load:stress, load:soak, load:spike, load:<service> for every individual scenario
- GitHub Actions workflow (workflow_dispatch) for CI load testing with artifact upload of JSON results


close #46 