### PR TITLE
feat(disputes): filing, evidence hashing, mediation, community vote, …

### DIFF
--- a/__tests__/dispute-integration.test.ts
+++ b/__tests__/dispute-integration.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  replaceDisputeSnapshotForTests,
+  fileDispute,
+  addEvidence,
+  startMediation,
+  openCommunityVote,
+  resolveDisputeWithTemplate,
+  submitAppeal,
+  getDisputeSnapshot,
+  DISPUTE_RESOLUTION_TEMPLATES,
+} from '@/lib/dispute-service';
+
+describe('dispute workflow + escrow integration', () => {
+  beforeEach(() => {
+    replaceDisputeSnapshotForTests({ disputes: [] });
+  });
+
+  it('files a dispute, holds escrow, and records evidence', async () => {
+    const d = fileDispute(
+      {
+        title: 'Title long enough for schema validation rules',
+        description: 'y'.repeat(40),
+        category: 'quality',
+        relatedOrderId: 'ord-x',
+        counterpartyId: 'cp-1',
+        counterpartyName: 'Creator',
+        escrowAmountCents: 50000,
+      },
+      { userId: 'client-1', name: 'Client' }
+    );
+    expect(d.escrow.held).toBe(true);
+    expect(d.escrow.amountCents).toBe(50000);
+
+    addEvidence(
+      d.id,
+      {
+        fileName: 'screenshot.png',
+        mimeType: 'image/png',
+        byteSize: 2048,
+        sha256: 'b'.repeat(64),
+      },
+      { userId: 'client-1', label: 'Client' }
+    );
+    const snap = getDisputeSnapshot();
+    const updated = snap.disputes.find((x) => x.id === d.id);
+    expect(updated?.evidence).toHaveLength(1);
+    expect(updated?.evidence[0]?.sha256).toMatch(/^[b]{64}$/);
+  });
+
+  it('runs mediation, community vote, resolution, and appeal', () => {
+    const d = fileDispute(
+      {
+        title: 'Another title that satisfies minimum length',
+        description: 'z'.repeat(40),
+        category: 'communication',
+        relatedOrderId: 'ord-y',
+        counterpartyId: 'cp-2',
+        escrowAmountCents: 100,
+      },
+      { userId: 'a1', name: 'Alice' }
+    );
+    startMediation(d.id, 'admin-1', 'Please share timelines');
+    openCommunityVote(d.id);
+    const tpl = DISPUTE_RESOLUTION_TEMPLATES[0];
+    if (!tpl) throw new Error('no template');
+    resolveDisputeWithTemplate(d.id, tpl.id, 'Admin');
+    const mid = getDisputeSnapshot().disputes.find((x) => x.id === d.id);
+    expect(mid?.status).toBe('resolved');
+    expect(mid?.escrow.releasedAt).toBeDefined();
+
+    submitAppeal(d.id, { reason: 'New evidence surfaced after resolution.' }, 'cp-2');
+    const after = getDisputeSnapshot().disputes.find((x) => x.id === d.id);
+    expect(after?.status).toBe('appealed');
+    expect(after?.appeal?.status).toBe('pending');
+  });
+});

--- a/__tests__/dispute-perf.test.ts
+++ b/__tests__/dispute-perf.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  replaceDisputeSnapshotForTests,
+  fileDispute,
+  getDisputeSnapshot,
+} from '@/lib/dispute-service';
+
+describe('dispute performance', () => {
+  beforeEach(() => {
+    replaceDisputeSnapshotForTests({ disputes: [] });
+  });
+
+  it('handles many concurrent dispute filings', async () => {
+    const n = 40;
+    const base = 'Title long enough for all dispute validation rules here ';
+    await Promise.all(
+      Array.from({ length: n }, (_, i) =>
+        Promise.resolve(
+          fileDispute(
+            {
+              title: `${base}${i}`,
+              description: 'd'.repeat(40),
+              category: 'other',
+              relatedOrderId: `ord-${i}`,
+              counterpartyId: `cp-${i}`,
+              escrowAmountCents: i % 5 === 0 ? 100 : 0,
+            },
+            { userId: `u-${i}`, name: `User ${i}` }
+          )
+        )
+      )
+    );
+    expect(getDisputeSnapshot().disputes.length).toBeGreaterThanOrEqual(n);
+  });
+});

--- a/__tests__/dispute-security.test.ts
+++ b/__tests__/dispute-security.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  replaceDisputeSnapshotForTests,
+  fileDispute,
+  openCommunityVote,
+  castCommunityVote,
+  verifyEvidenceDigest,
+  canViewDispute,
+  hashEvidenceBytes,
+} from '@/lib/dispute-service';
+
+describe('dispute security', () => {
+  beforeEach(() => {
+    replaceDisputeSnapshotForTests({ disputes: [] });
+  });
+
+  it('verifies evidence integrity against SHA-256', async () => {
+    const encoded = new TextEncoder().encode('hello-dispute');
+    const buf = encoded.buffer.slice(
+      encoded.byteOffset,
+      encoded.byteOffset + encoded.byteLength
+    );
+    const sha256 = await hashEvidenceBytes(buf);
+    const meta = {
+      fileName: 'x.txt',
+      mimeType: 'text/plain',
+      byteLength: buf.byteLength,
+      sha256,
+    };
+    const ok = await verifyEvidenceDigest(
+      {
+        fileName: meta.fileName,
+        mimeType: meta.mimeType,
+        byteSize: meta.byteLength,
+        sha256: meta.sha256,
+      },
+      buf
+    );
+    expect(ok).toBe(true);
+  });
+
+  it('blocks parties from casting community votes', () => {
+    const d = fileDispute(
+      {
+        title: 'Title long enough for all dispute validation here',
+        description: 'p'.repeat(40),
+        category: 'other',
+        relatedOrderId: 'ord-z',
+        counterpartyId: 'party-b',
+        escrowAmountCents: 0,
+      },
+      { userId: 'party-a', name: 'A' }
+    );
+    openCommunityVote(d.id);
+    expect(() =>
+      castCommunityVote(
+        d.id,
+        { userId: 'party-a', side: 'client' },
+        'USER'
+      )
+    ).toThrow();
+  });
+
+  it('restricts dispute visibility to parties and admins', () => {
+    const d = fileDispute(
+      {
+        title: 'Title long enough for all dispute validation here',
+        description: 'q'.repeat(40),
+        category: 'other',
+        relatedOrderId: 'ord-w',
+        counterpartyId: 'c2',
+        escrowAmountCents: 0,
+      },
+      { userId: 'c1', name: 'One' }
+    );
+    expect(canViewDispute('c1', 'CLIENT', d)).toBe(true);
+    expect(canViewDispute('c2', 'CREATOR', d)).toBe(true);
+    expect(canViewDispute('outsider', 'USER', d)).toBe(false);
+    expect(canViewDispute('outsider', 'ADMIN', d)).toBe(true);
+  });
+});

--- a/__tests__/dispute-validation.test.ts
+++ b/__tests__/dispute-validation.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fileDisputeInputSchema,
+  evidenceMetadataSchema,
+  parseFileDisputeInput,
+  disputeFormInputSchema,
+  toFileDisputeInput,
+} from '@/lib/dispute-service';
+
+describe('dispute validation', () => {
+  it('accepts a valid filing payload', () => {
+    const r = fileDisputeInputSchema.parse({
+      title: 'Enough title length here',
+      description: 'x'.repeat(40),
+      category: 'payment',
+      relatedOrderId: 'ord-1',
+      counterpartyId: 'u2',
+      escrowAmountCents: 1000,
+    });
+    expect(r.escrowAmountCents).toBe(1000);
+  });
+
+  it('rejects short description', () => {
+    expect(() =>
+      fileDisputeInputSchema.parse({
+        title: 'Enough title length here',
+        description: 'short',
+        category: 'other',
+        relatedOrderId: 'ord-1',
+        counterpartyId: 'u2',
+      })
+    ).toThrow();
+  });
+
+  it('maps form dollars to cents', () => {
+    const form = disputeFormInputSchema.parse({
+      title: 'Enough title length here',
+      description: 'x'.repeat(40),
+      category: 'delivery',
+      relatedOrderId: 'ord-1',
+      counterpartyId: 'u2',
+      escrowDollars: '12.34',
+    });
+    const input = toFileDisputeInput(form);
+    expect(input.escrowAmountCents).toBe(1234);
+  });
+
+  it('parses evidence metadata with valid digest', () => {
+    const meta = evidenceMetadataSchema.parse({
+      fileName: 'proof.pdf',
+      mimeType: 'application/pdf',
+      byteSize: 1024,
+      sha256: 'a'.repeat(64),
+    });
+    expect(meta.fileName).toBe('proof.pdf');
+  });
+
+  it('parseFileDisputeInput throws on bad input', () => {
+    expect(() => parseFileDisputeInput({})).toThrow();
+  });
+});

--- a/__tests__/dispute-workflow-e2e.test.ts
+++ b/__tests__/dispute-workflow-e2e.test.ts
@@ -1,0 +1,65 @@
+/**
+ * End-to-end style flow (Vitest). Included in `pnpm test`.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  replaceDisputeSnapshotForTests,
+  fileDispute,
+  addEvidence,
+  startMediation,
+  openCommunityVote,
+  castCommunityVote,
+  resolveDisputeWithTemplate,
+  closeDispute,
+  getDisputeSnapshot,
+  DISPUTE_RESOLUTION_TEMPLATES,
+} from '@/lib/dispute-service';
+
+describe('E2E dispute resolution (simulated)', () => {
+  beforeEach(() => {
+    replaceDisputeSnapshotForTests({ disputes: [] });
+  });
+
+  it('runs filing → evidence → mediation → community vote → resolution → close', () => {
+    const d = fileDispute(
+      {
+        title: 'End-to-end title with enough characters present',
+        description: 'e'.repeat(40),
+        category: 'delivery',
+        relatedOrderId: 'ord-e2e',
+        counterpartyId: 'cp-e2e',
+        escrowAmountCents: 25000,
+      },
+      { userId: 'client-e2e', name: 'Client' }
+    );
+
+    addEvidence(
+      d.id,
+      {
+        fileName: 'deliverables.zip',
+        mimeType: 'application/zip',
+        byteSize: 4096,
+        sha256: 'c'.repeat(64),
+      },
+      { userId: 'client-e2e', label: 'Client' }
+    );
+
+    startMediation(d.id, 'admin-e2e', 'Schedule joint session');
+    openCommunityVote(d.id);
+    castCommunityVote(
+      d.id,
+      { userId: 'community-member-1', side: 'creator' },
+      'USER'
+    );
+
+    const tpl = DISPUTE_RESOLUTION_TEMPLATES.find((t) => t.id === 'tpl_split');
+    if (!tpl) throw new Error('missing template');
+    resolveDisputeWithTemplate(d.id, tpl.id, 'Admin', 'Split 60/40 per review.');
+    closeDispute(d.id);
+
+    const row = getDisputeSnapshot().disputes.find((x) => x.id === d.id);
+    expect(row?.status).toBe('closed');
+    expect(row?.communityVotes).toHaveLength(1);
+    expect(row?.evidence).toHaveLength(1);
+  });
+});

--- a/app/admin/disputes/page.tsx
+++ b/app/admin/disputes/page.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+import { useReducer, useState } from 'react';
+import Link from 'next/link';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  getDisputeSnapshot,
+  startMediation,
+  openCommunityVote,
+  resolveDisputeWithTemplate,
+  closeDispute,
+  computeDisputeAnalytics,
+  DISPUTE_RESOLUTION_TEMPLATES,
+  type DisputeRecord,
+} from '@/lib/dispute-service';
+import { Gavel, Users, BarChart3, ArrowLeft } from 'lucide-react';
+
+const STATUS_LABEL: Record<DisputeRecord['status'], string> = {
+  filed: 'Filed',
+  evidence: 'Evidence',
+  mediation: 'Mediation',
+  community_vote: 'Community vote',
+  resolved: 'Resolved',
+  appealed: 'Appeal',
+  closed: 'Closed',
+};
+
+export default function AdminDisputesPage() {
+  const [, bump] = useReducer((x: number) => x + 1, 0);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [mediationNote, setMediationNote] = useState('');
+  const [resolutionExtra, setResolutionExtra] = useState('');
+  const [templateId, setTemplateId] = useState(DISPUTE_RESOLUTION_TEMPLATES[0]?.id ?? '');
+
+  const snapshot =
+    typeof window !== 'undefined'
+      ? getDisputeSnapshot()
+      : { disputes: [] as DisputeRecord[] };
+
+  const disputes = snapshot.disputes;
+  const selected = disputes.find((d) => d.id === selectedId) ?? disputes[0] ?? null;
+
+  const analytics = computeDisputeAnalytics(disputes);
+
+  const voteTally = selected
+    ? selected.communityVotes.reduce(
+        (acc, v) => {
+          acc[v.side] += 1;
+          return acc;
+        },
+        { client: 0, creator: 0 }
+      )
+    : { client: 0, creator: 0 };
+
+  function refresh() {
+    bump();
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/admin" className="gap-1">
+            <ArrowLeft className="h-4 w-4" /> Admin
+          </Link>
+        </Button>
+      </div>
+
+      <div>
+        <h1 className="text-2xl font-bold mb-1 flex items-center gap-2">
+          <Gavel className="h-7 w-7" /> Dispute mediation
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          Review cases, run mediation, optionally open advisory community votes, and resolve using
+          templates. Escrow actions are simulated.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <BarChart3 className="h-4 w-4" /> Open
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{analytics.totalOpen}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Mediation</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{analytics.inMediation}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <Users className="h-4 w-4" /> Community vote
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{analytics.awaitingCommunity}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Resolved (30d)</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{analytics.resolvedLast30d}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Card className="lg:col-span-1">
+          <CardHeader>
+            <CardTitle className="text-base">Cases</CardTitle>
+            <CardDescription>Select a dispute</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2 max-h-[480px] overflow-y-auto">
+            {disputes.map((d) => (
+              <button
+                key={d.id}
+                type="button"
+                onClick={() => setSelectedId(d.id)}
+                className={`w-full text-left rounded-lg border p-3 text-sm transition-colors ${
+                  selected?.id === d.id
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border hover:bg-secondary/50'
+                }`}
+              >
+                <div className="font-medium line-clamp-1">{d.title}</div>
+                <div className="text-xs text-muted-foreground mt-1 flex items-center gap-2">
+                  <Badge variant="outline" className="text-[10px]">
+                    {STATUS_LABEL[d.status]}
+                  </Badge>
+                  <span className="truncate">{d.id}</span>
+                </div>
+              </button>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="text-base">Case detail</CardTitle>
+            <CardDescription>
+              {selected
+                ? `${selected.filedByName} vs ${selected.counterpartyName}`
+                : 'No disputes loaded'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {!selected ? (
+              <p className="text-sm text-muted-foreground">Nothing to show.</p>
+            ) : (
+              <>
+                <div className="space-y-1 text-sm">
+                  <p>
+                    <span className="text-muted-foreground">Order ref:</span>{' '}
+                    {selected.relatedOrderId}
+                  </p>
+                  <p>
+                    <span className="text-muted-foreground">Category:</span> {selected.category}
+                  </p>
+                  <p className="pt-2">{selected.description}</p>
+                  {selected.escrow.held && (
+                    <p className="text-amber-600 text-sm pt-2">
+                      Escrow hold (simulated): ${(selected.escrow.amountCents / 100).toFixed(2)}
+                    </p>
+                  )}
+                </div>
+
+                {selected.mediationNotes.length > 0 && (
+                  <div>
+                    <p className="text-xs font-medium text-muted-foreground mb-1">Mediation notes</p>
+                    <ul className="list-disc pl-5 text-sm space-y-1">
+                      {selected.mediationNotes.map((n, i) => (
+                        <li key={i}>{n}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground mb-1">
+                    Community votes (advisory)
+                  </p>
+                  <p className="text-sm">
+                    Client: {voteTally.client} · Creator: {voteTally.creator}
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="med-note">Mediation note</Label>
+                  <Textarea
+                    id="med-note"
+                    value={mediationNote}
+                    onChange={(e) => setMediationNote(e.target.value)}
+                    rows={2}
+                    placeholder="Optional note appended to the case"
+                  />
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => {
+                      startMediation(selected.id, 'admin', mediationNote.trim() || undefined);
+                      setMediationNote('');
+                      refresh();
+                    }}
+                  >
+                    Start / continue mediation
+                  </Button>
+                </div>
+
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    openCommunityVote(selected.id);
+                    refresh();
+                  }}
+                >
+                  Open community vote window
+                </Button>
+
+                <div className="space-y-2 border-t border-border pt-4">
+                  <Label>Resolution template</Label>
+                  <Select value={templateId} onValueChange={setTemplateId}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Template" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {DISPUTE_RESOLUTION_TEMPLATES.map((t) => (
+                        <SelectItem key={t.id} value={t.id}>
+                          {t.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Textarea
+                    value={resolutionExtra}
+                    onChange={(e) => setResolutionExtra(e.target.value)}
+                    rows={2}
+                    placeholder="Optional extra context for the parties"
+                  />
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      onClick={() => {
+                        resolveDisputeWithTemplate(
+                          selected.id,
+                          templateId,
+                          'Admin',
+                          resolutionExtra.trim() || undefined
+                        );
+                        setResolutionExtra('');
+                        refresh();
+                      }}
+                    >
+                      Apply template & resolve
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => {
+                        closeDispute(selected.id);
+                        refresh();
+                      }}
+                    >
+                      Close case
+                    </Button>
+                  </div>
+                </div>
+
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground mb-1">Timeline</p>
+                  <ul className="text-xs space-y-1 max-h-40 overflow-y-auto border rounded-md p-2 bg-muted/30">
+                    {[...selected.timeline].reverse().map((t, i) => (
+                      <li key={i}>
+                        <span className="text-muted-foreground">
+                          {new Date(t.at).toLocaleString()}
+                        </span>{' '}
+                        — {t.message}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
   Users, Briefcase, DollarSign, Flag, TrendingUp,
-  UserPlus, CheckCircle, ArrowRight, ScrollText,
+  UserPlus, CheckCircle, ArrowRight, ScrollText, Gavel,
 } from 'lucide-react';
 import {
   mockStats, mockAuditLogs, mockReports,
@@ -54,6 +54,7 @@ export default function AdminOverviewPage() {
     { href: '/admin/bounties', label: 'Moderate Bounties', icon: Briefcase },
     { href: '/admin/verifications', label: 'Verifications', icon: CheckCircle },
     { href: '/admin/reports', label: 'Open Reports', icon: Flag },
+    { href: '/admin/disputes', label: 'Disputes', icon: Gavel },
     { href: '/admin/audit', label: 'Audit Log', icon: ScrollText },
   ];
 

--- a/app/disputes/page.tsx
+++ b/app/disputes/page.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import Link from 'next/link';
+import { useEffect, useReducer, useState } from 'react';
+import { Header } from '@/components/header';
+import { DisputeForm } from '@/components/dispute-form';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  getDisputeSnapshot,
+  listDisputesForUser,
+  computeDisputeAnalytics,
+  type DisputeRecord,
+} from '@/lib/dispute-service';
+import { Scale, Shield, History } from 'lucide-react';
+
+const STATUS_LABEL: Record<DisputeRecord['status'], string> = {
+  filed: 'Filed',
+  evidence: 'Evidence',
+  mediation: 'Mediation',
+  community_vote: 'Community vote',
+  resolved: 'Resolved',
+  appealed: 'Appeal',
+  closed: 'Closed',
+};
+
+export default function DisputesPage() {
+  const { data: session, status } = useSession();
+  const [, bump] = useReducer((x: number) => x + 1, 0);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true); // eslint-disable-line react-hooks/set-state-in-effect
+  }, []);
+
+  const snapshot =
+    mounted && typeof window !== 'undefined'
+      ? getDisputeSnapshot()
+      : { disputes: [] as DisputeRecord[] };
+
+  const myDisputes = session?.user?.id
+    ? listDisputesForUser(session.user.id)
+    : [];
+
+  const analytics = computeDisputeAnalytics(snapshot.disputes);
+
+  if (status === 'loading' || !mounted) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Header />
+        <div className="max-w-4xl mx-auto px-4 py-8 space-y-4">
+          <Skeleton className="h-10 w-64" />
+          <Skeleton className="h-48 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-8">
+        <div>
+          <div className="flex items-start gap-3 mb-2">
+            <Scale className="h-8 w-8 text-primary shrink-0" />
+            <div>
+              <h1 className="text-2xl font-bold mb-1">Dispute resolution</h1>
+              <p className="text-muted-foreground text-sm">
+                File a dispute, submit hashed evidence, and track progress. Escrow holds are
+                simulated until treasury integration is live.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium flex items-center gap-2">
+                <Shield className="h-4 w-4" /> Open pipeline
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold">{analytics.totalOpen}</p>
+              <p className="text-xs text-muted-foreground">Across platform (demo data)</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">Your cases</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold">{myDisputes.length}</p>
+              <p className="text-xs text-muted-foreground">Where you are a party</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">Resolved (30d)</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold">{analytics.resolvedLast30d}</p>
+              <p className="text-xs text-muted-foreground">Prevention signals tracked</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>File a new dispute</CardTitle>
+            <CardDescription>
+              Provide a clear description and reference. Optional evidence is fingerprinted
+              (SHA-256) on device.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <DisputeForm
+              userId={session.user.id}
+              userName={session.user.name || session.user.email || 'User'}
+              onFiled={() => bump()}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <History className="h-5 w-5" /> Your dispute history
+            </CardTitle>
+            <CardDescription>
+              Only disputes you filed or are named on are listed.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {myDisputes.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No disputes yet.</p>
+            ) : (
+              myDisputes.map((d) => (
+                <div
+                  key={d.id}
+                  className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 border border-border rounded-lg p-3"
+                >
+                  <div className="min-w-0">
+                    <p className="font-medium truncate">{d.title}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {d.id} · {new Date(d.updatedAt).toLocaleString()}
+                    </p>
+                    {d.escrow.held && (
+                      <p className="text-xs text-amber-600 mt-1">
+                        Escrow hold: ${(d.escrow.amountCents / 100).toFixed(2)} (simulated)
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <Badge variant="outline">{STATUS_LABEL[d.status]}</Badge>
+                    <Button variant="ghost" size="sm" asChild>
+                      <Link href="/dashboard">Dashboard</Link>
+                    </Button>
+                  </div>
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/components/dispute-form.tsx
+++ b/components/dispute-form.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  fileDispute,
+  disputeFormInputSchema,
+  toFileDisputeInput,
+  addEvidence,
+  hashEvidenceBytes,
+  type DisputeRecord,
+  type DisputeFormInput,
+} from '@/lib/dispute-service';
+import { Loader2 } from 'lucide-react';
+
+type FormValues = DisputeFormInput;
+
+export function DisputeForm({
+  userId,
+  userName,
+  onFiled,
+}: {
+  userId: string;
+  userName: string;
+  onFiled?: (d: DisputeRecord) => void;
+}) {
+  const [evidenceFile, setEvidenceFile] = useState<File | null>(null);
+  const [evidenceNote, setEvidenceNote] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<FormValues>({
+    resolver: zodResolver(disputeFormInputSchema),
+    defaultValues: {
+      title: '',
+      description: '',
+      category: 'other',
+      relatedOrderId: '',
+      counterpartyId: '',
+      counterpartyName: '',
+      escrowDollars: '',
+    },
+  });
+
+  const category = useWatch({ control, name: 'category', defaultValue: 'other' });
+
+  async function onSubmit(values: FormValues) {
+    setSubmitError(null);
+    try {
+      const input = toFileDisputeInput(values);
+      const d = fileDispute(input, { userId, name: userName });
+      if (evidenceFile) {
+        const buf = await evidenceFile.arrayBuffer();
+        const sha256 = await hashEvidenceBytes(buf);
+        addEvidence(
+          d.id,
+          {
+            fileName: evidenceFile.name,
+            mimeType: evidenceFile.type || 'application/octet-stream',
+            byteSize: evidenceFile.size,
+            sha256,
+            note: evidenceNote.trim() || undefined,
+          },
+          { userId, label: userName }
+        );
+      }
+      reset();
+      setEvidenceFile(null);
+      setEvidenceNote('');
+      onFiled?.(d);
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e.message : 'Could not file dispute');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      {submitError && (
+        <p className="text-sm text-destructive" role="alert">
+          {submitError}
+        </p>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="title">Title</Label>
+        <Input id="title" {...register('title')} placeholder="Short summary of the issue" />
+        {errors.title && (
+          <p className="text-xs text-destructive">{errors.title.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="description">Description</Label>
+        <Textarea
+          id="description"
+          {...register('description')}
+          rows={6}
+          placeholder="What happened? Include dates, agreed scope, and what you need from mediation."
+        />
+        {errors.description && (
+          <p className="text-xs text-destructive">{errors.description.message}</p>
+        )}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label>Category</Label>
+          <Select
+            value={category}
+            onValueChange={(v) =>
+              setValue('category', v as FormValues['category'], { shouldValidate: true })
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Category" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="payment">Payment</SelectItem>
+              <SelectItem value="delivery">Delivery</SelectItem>
+              <SelectItem value="quality">Quality</SelectItem>
+              <SelectItem value="communication">Communication</SelectItem>
+              <SelectItem value="other">Other</SelectItem>
+            </SelectContent>
+          </Select>
+          {errors.category && (
+            <p className="text-xs text-destructive">{errors.category.message}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="relatedOrderId">Order / project reference</Label>
+          <Input
+            id="relatedOrderId"
+            {...register('relatedOrderId')}
+            placeholder="e.g. bounty id or contract ref"
+          />
+          {errors.relatedOrderId && (
+            <p className="text-xs text-destructive">{errors.relatedOrderId.message}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="counterpartyId">Counterparty user ID</Label>
+          <Input
+            id="counterpartyId"
+            {...register('counterpartyId')}
+            placeholder="Their platform user id"
+          />
+          {errors.counterpartyId && (
+            <p className="text-xs text-destructive">{errors.counterpartyId.message}</p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="counterpartyName">Counterparty name (optional)</Label>
+          <Input
+            id="counterpartyName"
+            {...register('counterpartyName')}
+            placeholder="Display name"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="escrow">Escrow amount (USD, optional)</Label>
+        <Input
+          id="escrow"
+          type="number"
+          min={0}
+          step="0.01"
+          {...register('escrowDollars')}
+          placeholder="0.00 — simulates hold when &gt; 0"
+        />
+        <p className="text-xs text-muted-foreground">
+          Enter dollars; we store cents internally. Funds stay simulated until live escrow is
+          connected.
+        </p>
+        {errors.escrowDollars && (
+          <p className="text-xs text-destructive">{errors.escrowDollars.message}</p>
+        )}
+      </div>
+
+      <div className="rounded-lg border border-border p-4 space-y-3 bg-muted/30">
+        <div>
+          <Label htmlFor="evidence">Evidence file (optional)</Label>
+          <p className="text-xs text-muted-foreground mt-1">
+            We record a SHA-256 hash and metadata only in this demo; attach the real file to your
+            support ticket in production.
+          </p>
+        </div>
+        <Input
+          id="evidence"
+          type="file"
+          accept="image/*,.pdf,.zip,.txt"
+          onChange={(e) => setEvidenceFile(e.target.files?.[0] ?? null)}
+        />
+        <div className="space-y-2">
+          <Label htmlFor="evidenceNote">Evidence note (optional)</Label>
+          <Input
+            id="evidenceNote"
+            value={evidenceNote}
+            onChange={(e) => setEvidenceNote(e.target.value)}
+            placeholder="What this file shows"
+          />
+        </div>
+      </div>
+
+      <Button type="submit" disabled={isSubmitting} className="w-full sm:w-auto">
+        {isSubmitting ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Submitting…
+          </>
+        ) : (
+          'File dispute'
+        )}
+      </Button>
+    </form>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -81,6 +81,11 @@ export function Header() {
             <Link href="/about" className="px-4 py-2 text-sm font-medium text-foreground hover:text-primary transition-colors rounded-lg hover:bg-secondary/50">
               About
             </Link>
+            {session && (
+              <Link href="/disputes" className="px-4 py-2 text-sm font-medium text-foreground hover:text-primary transition-colors rounded-lg hover:bg-secondary/50">
+                Disputes
+              </Link>
+            )}
           </nav>
 
           {/* Right Actions */}
@@ -200,6 +205,11 @@ export function Header() {
             <Link href="/about" className="block px-4 py-2 text-sm font-medium text-foreground hover:text-primary transition-colors">
               About
             </Link>
+            {session && (
+              <Link href="/disputes" className="block px-4 py-2 text-sm font-medium text-foreground hover:text-primary transition-colors">
+                Disputes
+              </Link>
+            )}
             
             {session ? (
               <>

--- a/lib/dispute-service.ts
+++ b/lib/dispute-service.ts
@@ -1,0 +1,612 @@
+/**
+ * Dispute resolution domain layer — client-side persistence (localStorage).
+ * Replace with API + DB when backend endpoints are ready.
+ */
+
+import { z } from 'zod';
+
+// ── Zod schemas (validation) ─────────────────────────────────────────────────
+
+export const disputeCategorySchema = z.enum([
+  'payment',
+  'delivery',
+  'quality',
+  'communication',
+  'other',
+]);
+export type DisputeCategory = z.infer<typeof disputeCategorySchema>;
+
+export const disputeStatusSchema = z.enum([
+  'filed',
+  'evidence',
+  'mediation',
+  'community_vote',
+  'resolved',
+  'appealed',
+  'closed',
+]);
+export type DisputeStatus = z.infer<typeof disputeStatusSchema>;
+
+export const fileDisputeInputSchema = z.object({
+  title: z.string().min(8, 'Title must be at least 8 characters').max(200),
+  description: z
+    .string()
+    .min(40, 'Please describe the issue in at least 40 characters')
+    .max(8000),
+  category: disputeCategorySchema,
+  relatedOrderId: z.string().min(1, 'Order or project reference is required').max(120),
+  counterpartyId: z.string().min(1, 'Counterparty user id is required').max(120),
+  counterpartyName: z.string().min(1).max(200).optional(),
+  escrowAmountCents: z.number().int().min(0).max(1_000_000_000).default(0),
+});
+export type FileDisputeInput = z.infer<typeof fileDisputeInputSchema>;
+
+/** Form: dollars as string; map to cents before calling `fileDispute`. */
+export const disputeFormInputSchema = fileDisputeInputSchema
+  .omit({ escrowAmountCents: true })
+  .extend({
+    escrowDollars: z.string().optional().default(''),
+  });
+export type DisputeFormInput = z.infer<typeof disputeFormInputSchema>;
+
+export function toFileDisputeInput(form: DisputeFormInput): FileDisputeInput {
+  const raw = parseFloat(form.escrowDollars?.trim() || '0');
+  const escrowAmountCents = Number.isFinite(raw)
+    ? Math.min(1_000_000_000, Math.max(0, Math.round(raw * 100)))
+    : 0;
+  return fileDisputeInputSchema.parse({
+    title: form.title,
+    description: form.description,
+    category: form.category,
+    relatedOrderId: form.relatedOrderId,
+    counterpartyId: form.counterpartyId,
+    counterpartyName: form.counterpartyName,
+    escrowAmountCents,
+  });
+}
+
+export const evidenceMetadataSchema = z.object({
+  fileName: z.string().min(1).max(500),
+  mimeType: z.string().min(1).max(200),
+  byteSize: z.number().int().min(1).max(25 * 1024 * 1024),
+  sha256: z.string().regex(/^[a-f0-9]{64}$/i, 'Invalid SHA-256 digest'),
+  note: z.string().max(2000).optional(),
+});
+export type EvidenceMetadata = z.infer<typeof evidenceMetadataSchema>;
+
+export const communityVoteSchema = z.object({
+  userId: z.string().min(1),
+  side: z.enum(['client', 'creator']),
+});
+export type CommunityVoteInput = z.infer<typeof communityVoteSchema>;
+
+export const appealInputSchema = z.object({
+  reason: z.string().min(20).max(4000),
+});
+export type AppealInput = z.infer<typeof appealInputSchema>;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type UserRole = 'USER' | 'CLIENT' | 'CREATOR' | 'ADMIN';
+
+export interface EvidenceItem extends EvidenceMetadata {
+  id: string;
+  submittedByUserId: string;
+  submittedByLabel: string;
+  submittedAt: string;
+  /** Redacted preview only — binary stays local until upload API exists */
+  caption?: string;
+}
+
+export type ResolutionOutcome =
+  | 'favor_client'
+  | 'favor_creator'
+  | 'split'
+  | 'dismissed';
+
+export interface DisputeResolution {
+  outcome: ResolutionOutcome;
+  summary: string;
+  templateId?: string;
+  resolvedBy?: string;
+  resolvedAt: string;
+}
+
+export interface DisputeAppeal {
+  status: 'pending' | 'reviewed';
+  reason: string;
+  submittedAt: string;
+  reviewedAt?: string;
+  outcome?: 'upheld' | 'denied';
+}
+
+export interface DisputeRecord {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  filedByUserId: string;
+  filedByName: string;
+  counterpartyId: string;
+  counterpartyName: string;
+  relatedOrderId: string;
+  title: string;
+  description: string;
+  category: DisputeCategory;
+  status: DisputeStatus;
+  evidence: EvidenceItem[];
+  mediationNotes: string[];
+  assignedAdminId?: string;
+  communityVotes: Array<{
+    userId: string;
+    side: 'client' | 'creator';
+    castAt: string;
+  }>;
+  resolution?: DisputeResolution;
+  appeal?: DisputeAppeal;
+  escrow: {
+    held: boolean;
+    amountCents: number;
+    holdStartedAt?: string;
+    releasedAt?: string;
+  };
+  timeline: Array<{ at: string; message: string }>;
+  preventionTags: string[];
+}
+
+export interface DisputeResolutionTemplate {
+  id: string;
+  label: string;
+  outcome: ResolutionOutcome;
+  body: string;
+}
+
+export const DISPUTE_RESOLUTION_TEMPLATES: DisputeResolutionTemplate[] = [
+  {
+    id: 'tpl_release_client',
+    label: 'Release escrow to client (non-delivery)',
+    outcome: 'favor_client',
+    body: 'After review, deliverables were incomplete or not provided per agreement. Escrow is released to the client; the creator may appeal with additional evidence.',
+  },
+  {
+    id: 'tpl_release_creator',
+    label: 'Release escrow to creator (work accepted)',
+    outcome: 'favor_creator',
+    body: 'Deliverables met the agreed scope. Escrow is released to the creator. The client may appeal only with new material evidence.',
+  },
+  {
+    id: 'tpl_split',
+    label: 'Partial refund / split',
+    outcome: 'split',
+    body: 'Both parties contributed to the issue. A partial split of escrow is applied per platform policy. Details were communicated to both sides.',
+  },
+  {
+    id: 'tpl_dismiss',
+    label: 'Dismiss — no policy breach',
+    outcome: 'dismissed',
+    body: 'No breach of platform terms was found. Parties are encouraged to continue work or cancel per contract. Escrow handling follows the original milestone rules.',
+  },
+];
+
+const STORAGE_KEY = 'stellar_disputes_v1';
+
+export interface DisputeStoreSnapshot {
+  disputes: DisputeRecord[];
+}
+
+const seedDisputes: DisputeRecord[] = [
+  {
+    id: 'dsp_seed_1',
+    createdAt: '2026-03-20T10:00:00.000Z',
+    updatedAt: '2026-03-21T14:00:00.000Z',
+    filedByUserId: 'u5',
+    filedByName: 'Marcus Webb',
+    counterpartyId: 'u1',
+    counterpartyName: 'Alex Chen',
+    relatedOrderId: 'ord_demo_001',
+    title: 'Milestone delivery incomplete',
+    description:
+      'The second milestone was marked complete but key assets described in the scope were not delivered. I have requested revisions with no response for 5 business days.',
+    category: 'delivery',
+    status: 'mediation',
+    evidence: [],
+    mediationNotes: ['Admin invited both parties to upload dated screenshots.'],
+    assignedAdminId: 'admin',
+    communityVotes: [],
+    escrow: { held: true, amountCents: 150000, holdStartedAt: '2026-03-20T10:05:00.000Z' },
+    timeline: [
+      { at: '2026-03-20T10:00:00.000Z', message: 'Dispute filed; escrow hold requested.' },
+      { at: '2026-03-20T10:05:00.000Z', message: 'Escrow hold active for $1,500.00.' },
+      { at: '2026-03-21T14:00:00.000Z', message: 'Mediation started by admin.' },
+    ],
+    preventionTags: ['late_milestone'],
+  },
+];
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function newId(prefix: string): string {
+  return `${prefix}_${Math.random().toString(36).slice(2, 12)}_${Date.now().toString(36)}`;
+}
+
+/** SHA-256 hex digest for evidence integrity (browser + Node test env). */
+export async function hashEvidenceBytes(buf: ArrayBuffer): Promise<string> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error('Web Crypto is not available');
+  }
+  const digest = await subtle.digest('SHA-256', buf);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function parseFileDisputeInput(raw: unknown): FileDisputeInput {
+  return fileDisputeInputSchema.parse(raw);
+}
+
+export function parseEvidenceMetadata(raw: unknown): EvidenceMetadata {
+  return evidenceMetadataSchema.parse(raw);
+}
+
+function loadSnapshot(): DisputeStoreSnapshot {
+  if (typeof window === 'undefined') {
+    return { disputes: [...seedDisputes] };
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      const initial: DisputeStoreSnapshot = { disputes: [...seedDisputes] };
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(initial));
+      return initial;
+    }
+    const parsed = JSON.parse(raw) as DisputeStoreSnapshot;
+    if (!parsed?.disputes || !Array.isArray(parsed.disputes)) {
+      return { disputes: [...seedDisputes] };
+    }
+    return parsed;
+  } catch {
+    return { disputes: [...seedDisputes] };
+  }
+}
+
+function saveSnapshot(s: DisputeStoreSnapshot): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+}
+
+export function getDisputeSnapshot(): DisputeStoreSnapshot {
+  return loadSnapshot();
+}
+
+export function replaceDisputeSnapshotForTests(snapshot: DisputeStoreSnapshot): void {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+  }
+}
+
+export function clearDisputeStorageForTests(): void {
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+function pushTimeline(d: DisputeRecord, message: string): void {
+  d.timeline.push({ at: nowIso(), message });
+  d.updatedAt = nowIso();
+}
+
+export function listDisputesForUser(userId: string): DisputeRecord[] {
+  const { disputes } = loadSnapshot();
+  return disputes.filter(
+    (d) => d.filedByUserId === userId || d.counterpartyId === userId
+  );
+}
+
+export function canViewDispute(
+  userId: string,
+  role: UserRole,
+  d: DisputeRecord
+): boolean {
+  if (role === 'ADMIN') return true;
+  return d.filedByUserId === userId || d.counterpartyId === userId;
+}
+
+export function canSubmitEvidence(
+  userId: string,
+  d: DisputeRecord
+): boolean {
+  if (d.status === 'resolved' || d.status === 'closed') return false;
+  return d.filedByUserId === userId || d.counterpartyId === userId;
+}
+
+export function fileDispute(
+  input: FileDisputeInput,
+  filedBy: { userId: string; name: string }
+): DisputeRecord {
+  const parsed = fileDisputeInputSchema.parse(input);
+  const snap = loadSnapshot();
+  const d: DisputeRecord = {
+    id: newId('dsp'),
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+    filedByUserId: filedBy.userId,
+    filedByName: filedBy.name,
+    counterpartyId: parsed.counterpartyId,
+    counterpartyName: parsed.counterpartyName ?? 'Counterparty',
+    relatedOrderId: parsed.relatedOrderId,
+    title: parsed.title,
+    description: parsed.description,
+    category: parsed.category,
+    status: 'filed',
+    evidence: [],
+    mediationNotes: [],
+    communityVotes: [],
+    escrow: {
+      held: parsed.escrowAmountCents > 0,
+      amountCents: parsed.escrowAmountCents,
+      holdStartedAt:
+        parsed.escrowAmountCents > 0 ? nowIso() : undefined,
+    },
+    timeline: [],
+    preventionTags: inferPreventionTags(parsed.category, parsed.description),
+  };
+  pushTimeline(d, 'Dispute filed.');
+  if (d.escrow.held) {
+    pushTimeline(
+      d,
+      `Escrow hold active for ${(d.escrow.amountCents / 100).toFixed(2)} (simulated).`
+    );
+    d.status = 'evidence';
+  } else {
+    d.status = 'evidence';
+    pushTimeline(d, 'No escrow amount linked — proceed with evidence only.');
+  }
+  snap.disputes = [d, ...snap.disputes];
+  saveSnapshot(snap);
+  return d;
+}
+
+function inferPreventionTags(
+  category: DisputeCategory,
+  description: string
+): string[] {
+  const tags: string[] = [];
+  const lower = description.toLowerCase();
+  if (category === 'payment' || lower.includes('pay')) tags.push('payment_risk');
+  if (lower.includes('deadline') || lower.includes('late')) tags.push('timeline');
+  if (lower.includes('scope') || lower.includes('revision')) tags.push('scope_creep');
+  return tags;
+}
+
+export function addEvidence(
+  disputeId: string,
+  meta: EvidenceMetadata,
+  submittedBy: { userId: string; label: string }
+): DisputeRecord {
+  evidenceMetadataSchema.parse(meta);
+  const snap = loadSnapshot();
+  const d = snap.disputes.find((x) => x.id === disputeId);
+  if (!d) throw new Error('Dispute not found');
+  if (!canSubmitEvidence(submittedBy.userId, d)) {
+    throw new Error('Not allowed to submit evidence for this dispute');
+  }
+  const item: EvidenceItem = {
+    ...meta,
+    id: newId('ev'),
+    submittedByUserId: submittedBy.userId,
+    submittedByLabel: submittedBy.label,
+    submittedAt: nowIso(),
+  };
+  d.evidence.push(item);
+  pushTimeline(d, `Evidence uploaded: ${meta.fileName} (SHA-256 recorded).`);
+  if (d.status === 'filed') d.status = 'evidence';
+  saveSnapshot(snap);
+  return d;
+}
+
+export function startMediation(
+  disputeId: string,
+  adminId: string,
+  note?: string
+): DisputeRecord {
+  const snap = loadSnapshot();
+  const d = snap.disputes.find((x) => x.id === disputeId);
+  if (!d) throw new Error('Dispute not found');
+  d.assignedAdminId = adminId;
+  d.status = 'mediation';
+  if (note) d.mediationNotes.push(note);
+  pushTimeline(d, 'Mediation started by admin.');
+  saveSnapshot(snap);
+  return d;
+}
+
+export function openCommunityVote(disputeId: string): DisputeRecord {
+  const snap = loadSnapshot();
+  const d = snap.disputes.find((x) => x.id === disputeId);
+  if (!d) throw new Error('Dispute not found');
+  d.status = 'community_vote';
+  pushTimeline(d, 'Community review window opened (advisory votes).');
+  saveSnapshot(snap);
+  return d;
+}
+
+export function castCommunityVote(
+  disputeId: string,
+  vote: CommunityVoteInput,
+  voterRole: UserRole
+): DisputeRecord {
+  communityVoteSchema.parse(vote);
+  if (voterRole !== 'USER' && voterRole !== 'CLIENT' && voterRole !== 'CREATOR') {
+    throw new Error('Only community members may vote');
+  }
+  const snap = loadSnapshot();
+  const d = snap.disputes.find((x) => x.id === disputeId);
+  if (!d) throw new Error('Dispute not found');
+  if (d.status !== 'community_vote') {
+    throw new Error('Community vote is not open for this dispute');
+  }
+  if (vote.userId === d.filedByUserId || vote.userId === d.counterpartyId) {
+    throw new Error('Parties to the dispute cannot vote');
+  }
+  const existing = d.communityVotes.some((v) => v.userId === vote.userId);
+  if (existing) throw new Error('Already voted');
+  d.communityVotes.push({
+    userId: vote.userId,
+    side: vote.side,
+    castAt: nowIso(),
+  });
+  pushTimeline(d, `Community vote recorded (${vote.side}).`);
+  saveSnapshot(snap);
+  return d;
+}
+
+export function resolveDisputeWithTemplate(
+  disputeId: string,
+  templateId: string,
+  adminName: string,
+  extraSummary?: string
+): DisputeRecord {
+  const tpl = DISPUTE_RESOLUTION_TEMPLATES.find((t) => t.id === templateId);
+  if (!tpl) throw new Error('Unknown template');
+  const snap = loadSnapshot();
+  const d = snap.disputes.find((x) => x.id === disputeId);
+  if (!d) throw new Error('Dispute not found');
+  if (d.status === 'closed') throw new Error('Dispute already closed');
+
+  const summary = extraSummary ? `${tpl.body}\n\n${extraSummary}` : tpl.body;
+  d.resolution = {
+    outcome: tpl.outcome,
+    summary,
+    templateId: tpl.id,
+    resolvedBy: adminName,
+    resolvedAt: nowIso(),
+  };
+  d.status = 'resolved';
+  if (d.escrow.held) {
+    d.escrow.releasedAt = nowIso();
+    pushTimeline(
+      d,
+      'Escrow hold released per resolution (simulated settlement).'
+    );
+  }
+  pushTimeline(d, `Resolved using template: ${tpl.label}.`);
+  saveSnapshot(snap);
+  return d;
+}
+
+export function submitAppeal(
+  disputeId: string,
+  input: AppealInput,
+  submittedByUserId: string
+): DisputeRecord {
+  appealInputSchema.parse(input);
+  const snap = loadSnapshot();
+  const d = snap.disputes.find((x) => x.id === disputeId);
+  if (!d) throw new Error('Dispute not found');
+  if (d.status !== 'resolved') {
+    throw new Error('Appeals are only accepted after a resolution');
+  }
+  if (d.appeal?.status === 'pending') {
+    throw new Error('An appeal is already pending');
+  }
+  if (
+    submittedByUserId !== d.filedByUserId &&
+    submittedByUserId !== d.counterpartyId
+  ) {
+    throw new Error('Only dispute parties may appeal');
+  }
+  d.appeal = {
+    status: 'pending',
+    reason: input.reason,
+    submittedAt: nowIso(),
+  };
+  d.status = 'appealed';
+  if (d.escrow.held || d.escrow.amountCents > 0) {
+    d.escrow.held = true;
+    d.escrow.holdStartedAt = d.escrow.holdStartedAt ?? nowIso();
+    pushTimeline(d, 'Escrow hold reinstated pending appeal review.');
+  }
+  pushTimeline(d, 'Appeal submitted.');
+  saveSnapshot(snap);
+  return d;
+}
+
+export function closeDispute(disputeId: string): DisputeRecord {
+  const snap = loadSnapshot();
+  const d = snap.disputes.find((x) => x.id === disputeId);
+  if (!d) throw new Error('Dispute not found');
+  d.status = 'closed';
+  pushTimeline(d, 'Dispute closed.');
+  saveSnapshot(snap);
+  return d;
+}
+
+// ── Analytics & prevention ───────────────────────────────────────────────────
+
+export interface DisputeAnalytics {
+  totalOpen: number;
+  inMediation: number;
+  awaitingCommunity: number;
+  resolvedLast30d: number;
+  averageEvidenceCount: number;
+  topCategories: Array<{ category: DisputeCategory; count: number }>;
+  preventionFlags: Record<string, number>;
+}
+
+export function computeDisputeAnalytics(
+  disputes: DisputeRecord[]
+): DisputeAnalytics {
+  const openStatuses: DisputeStatus[] = [
+    'filed',
+    'evidence',
+    'mediation',
+    'community_vote',
+    'appealed',
+  ];
+  const totalOpen = disputes.filter((d) => openStatuses.includes(d.status)).length;
+  const inMediation = disputes.filter((d) => d.status === 'mediation').length;
+  const awaitingCommunity = disputes.filter(
+    (d) => d.status === 'community_vote'
+  ).length;
+  const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+  const resolvedLast30d = disputes.filter((d) => {
+    if (d.status !== 'resolved' && d.status !== 'closed') return false;
+    const t = d.resolution?.resolvedAt ?? d.updatedAt;
+    return new Date(t).getTime() >= thirtyDaysAgo;
+  }).length;
+  const evCount =
+    disputes.reduce((acc, d) => acc + d.evidence.length, 0) /
+    Math.max(1, disputes.length);
+  const catMap = new Map<DisputeCategory, number>();
+  for (const d of disputes) {
+    catMap.set(d.category, (catMap.get(d.category) ?? 0) + 1);
+  }
+  const topCategories = [...catMap.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([category, count]) => ({ category, count }));
+  const preventionFlags: Record<string, number> = {};
+  for (const d of disputes) {
+    for (const t of d.preventionTags) {
+      preventionFlags[t] = (preventionFlags[t] ?? 0) + 1;
+    }
+  }
+  return {
+    totalOpen,
+    inMediation,
+    awaitingCommunity,
+    resolvedLast30d,
+    averageEvidenceCount: Math.round(evCount * 10) / 10,
+    topCategories,
+    preventionFlags,
+  };
+}
+
+export function verifyEvidenceDigest(
+  meta: EvidenceMetadata,
+  fileBytes: ArrayBuffer
+): Promise<boolean> {
+  return hashEvidenceBytes(fileBytes).then((h) => h.toLowerCase() === meta.sha256.toLowerCase());
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,12 +8,17 @@ export default withAuth(
     const isAuthPage = req.nextUrl.pathname.startsWith('/auth');
     const isDashboard = req.nextUrl.pathname.startsWith('/dashboard');
     const isAdmin = req.nextUrl.pathname.startsWith('/admin');
+    const isDisputes = req.nextUrl.pathname.startsWith('/disputes');
 
     if (isAuthPage && isAuth) {
       return NextResponse.redirect(new URL('/dashboard', req.url));
     }
 
     if (isDashboard && !isAuth) {
+      return NextResponse.redirect(new URL('/auth/login', req.url));
+    }
+
+    if (isDisputes && !isAuth) {
       return NextResponse.redirect(new URL('/auth/login', req.url));
     }
 
@@ -34,7 +39,11 @@ export default withAuth(
       authorized: ({ token, req }) => {
         // Allow public access to non-protected routes
         const pathname = req.nextUrl.pathname;
-        if (pathname.startsWith('/admin') || pathname.startsWith('/dashboard')) {
+        if (
+          pathname.startsWith('/admin') ||
+          pathname.startsWith('/dashboard') ||
+          pathname.startsWith('/disputes')
+        ) {
           return !!token;
         }
         return true;
@@ -47,6 +56,7 @@ export const config = {
   matcher: [
     '/dashboard/:path*',
     '/admin/:path*',
+    '/disputes/:path*',
     '/auth/:path*',
     '/api/auth/:path*',
   ],


### PR DESCRIPTION
## Summary

Adds an end-to-end **dispute resolution** flow for clients and creators: filing, optional **SHA-256 evidence** metadata, **simulated escrow hold**, **admin mediation**, **advisory community voting**, **resolution templates**, **appeals**, and **analytics** (client-side persistence via `localStorage` until a real API exists).

## Changes

| Area | Description |
|------|-------------|
| `lib/dispute-service.ts` | Domain logic: Zod validation, lifecycle, evidence integrity helpers, templates, analytics |
| `app/disputes/page.tsx` | User disputes UI (auth required) |
| `components/dispute-form.tsx` | File dispute + optional evidence (hash on device) |
| `app/admin/disputes/page.tsx` | Mediation, templates, community vote, resolution, close |
| `middleware.ts` | Require sign-in for `/disputes` |
| `components/header.tsx`, `app/admin/page.tsx` | Navigation to disputes / admin disputes |
closes #27 
## Tests

- `__tests__/dispute-validation.test.ts` — validation  
- `__tests__/dispute-integration.test.ts` — workflow + escrow  
- `__tests__/dispute-security.test.ts` — evidence integrity, access control, vote abuse  
- `__tests__/dispute-perf.test.ts` — concurrent filings  
- `__tests__/dispute-workflow-e2e.test.ts` — full simulated E2E path  

## Notes

- Escrow and persistence are **simulated** (`localStorage`); swap for API + DB when the backend is ready.  
- Full-repo `eslint .` may still surface pre-existing issues outside this change.

## How to verify

1. Sign in → **Disputes** → file a dispute (optional USD amount for hold, optional file for hash).  
2. As **ADMIN** → **Admin → Disputes** → run mediation, open community vote, resolve with a template.