### PR TITLE
feat(bounties): application workflow, dashboards, API, and notifications

### DIFF
--- a/__tests__/bounty-application-validation.test.ts
+++ b/__tests__/bounty-application-validation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { applicationSubmitSchema } from '@/lib/validators'
+
+describe('applicationSubmitSchema', () => {
+  it('accepts valid proposal', () => {
+    const r = applicationSubmitSchema.safeParse({
+      bounty_id: 'bounty-1',
+      proposed_budget: 2500,
+      timeline: 14,
+      proposal: 'a'.repeat(50),
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects short proposal', () => {
+    const r = applicationSubmitSchema.safeParse({
+      bounty_id: 'bounty-1',
+      proposed_budget: 100,
+      timeline: 7,
+      proposal: 'short',
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects negative budget', () => {
+    const r = applicationSubmitSchema.safeParse({
+      bounty_id: 'bounty-1',
+      proposed_budget: -1,
+      timeline: 7,
+      proposal: 'a'.repeat(50),
+    })
+    expect(r.success).toBe(false)
+  })
+})

--- a/__tests__/bounty-applications-perf.test.ts
+++ b/__tests__/bounty-applications-perf.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  __resetBountyStoreForTests,
+  submitApplication,
+  getApplicantCountsForBounties,
+} from '@/lib/bounty-service'
+
+describe('bounty applications performance', () => {
+  beforeEach(() => {
+    __resetBountyStoreForTests()
+  })
+
+  it('counts scale for many applications', () => {
+    const n = 500
+    for (let i = 0; i < n; i++) {
+      submitApplication({
+        bountyId: 'bounty-1',
+        applicantId: `applicant-${i}`,
+        applicantName: `User ${i}`,
+        applicantEmail: `u${i}@example.com`,
+        proposedBudget: 1000 + i,
+        timelineDays: 7,
+        proposal: 'proposal text '.repeat(5),
+      })
+    }
+    const t0 = performance.now()
+    const counts = getApplicantCountsForBounties(['bounty-1', 'bounty-2', 'bounty-3'])
+    const ms = performance.now() - t0
+    expect(counts['bounty-1']).toBe(n)
+    expect(ms).toBeLessThan(200)
+  })
+})

--- a/__tests__/bounty-applications-security.test.ts
+++ b/__tests__/bounty-applications-security.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  __resetBountyStoreForTests,
+  submitApplication,
+  canViewApplication,
+  getApplicationById,
+} from '@/lib/bounty-service'
+import { getBountyById } from '@/lib/creators-data'
+
+describe('bounty application access control', () => {
+  beforeEach(() => {
+    __resetBountyStoreForTests()
+  })
+
+  it('does not leak application data to unrelated users', () => {
+    const result = submitApplication({
+      bountyId: 'bounty-1',
+      applicantId: 'applicant-secret',
+      applicantName: 'Secret',
+      applicantEmail: 'sec@example.com',
+      proposedBudget: 3000,
+      timelineDays: 14,
+      proposal: 'Confidential '.repeat(10),
+    })
+    expect('application' in result).toBe(true)
+    if (!('application' in result)) return
+
+    const bounty = getBountyById('bounty-1')
+    const app = getApplicationById(result.application.id)
+    expect(bounty).toBeDefined()
+    expect(app).toBeDefined()
+    if (!bounty || !app) return
+
+    expect(canViewApplication('other-user', 'CREATOR', app, bounty)).toBe(false)
+    expect(canViewApplication('other-user', 'USER', app, bounty)).toBe(false)
+  })
+})

--- a/__tests__/bounty-service.test.ts
+++ b/__tests__/bounty-service.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  __resetBountyStoreForTests,
+  submitApplication,
+  getApplicationById,
+  updateApplicationStatus,
+  clientCanManageBounty,
+  canViewApplication,
+  getApplicantCountsForBounties,
+  listApplicationsForBounty,
+} from '@/lib/bounty-service'
+import { getBountyById } from '@/lib/creators-data'
+
+describe('bounty-service', () => {
+  beforeEach(() => {
+    __resetBountyStoreForTests()
+  })
+
+  it('submits application and prevents duplicate', () => {
+    const first = submitApplication({
+      bountyId: 'bounty-1',
+      applicantId: 'user-a',
+      applicantName: 'Alice',
+      applicantEmail: 'a@example.com',
+      proposedBudget: 2000,
+      timelineDays: 10,
+      proposal: 'x'.repeat(60),
+    })
+    expect('application' in first).toBe(true)
+    if ('application' in first) {
+      expect(first.application.status).toBe('pending')
+    }
+
+    const dup = submitApplication({
+      bountyId: 'bounty-1',
+      applicantId: 'user-a',
+      applicantName: 'Alice',
+      applicantEmail: 'a@example.com',
+      proposedBudget: 2000,
+      timelineDays: 10,
+      proposal: 'y'.repeat(60),
+    })
+    expect('error' in dup).toBe(true)
+  })
+
+  it('updates status from pending only', () => {
+    const { application } = submitApplication({
+      bountyId: 'bounty-2',
+      applicantId: 'user-b',
+      applicantName: 'Bob',
+      applicantEmail: 'b@example.com',
+      proposedBudget: 1500,
+      timelineDays: 5,
+      proposal: 'z'.repeat(55),
+    }) as { application: { id: string } }
+
+    const ok = updateApplicationStatus({
+      applicationId: application.id,
+      status: 'accepted',
+      actorId: 'client-1',
+      actorName: 'Client',
+    })
+    expect('application' in ok).toBe(true)
+
+    const bad = updateApplicationStatus({
+      applicationId: application.id,
+      status: 'rejected',
+      actorId: 'client-1',
+      actorName: 'Client',
+    })
+    expect('error' in bad).toBe(true)
+  })
+
+  it('clientCanManageBounty respects ownerUserId', () => {
+    const bounty = getBountyById('bounty-1')
+    expect(bounty).toBeDefined()
+    if (!bounty) return
+    expect(clientCanManageBounty('any', 'CLIENT', bounty)).toBe(true)
+  })
+
+  it('canViewApplication denies stranger', () => {
+    const { application } = submitApplication({
+      bountyId: 'bounty-3',
+      applicantId: 'user-c',
+      applicantName: 'C',
+      applicantEmail: 'c@example.com',
+      proposedBudget: 1000,
+      timelineDays: 3,
+      proposal: 'p'.repeat(50),
+    }) as { application: { id: string; applicantId: string } }
+
+    const bounty = getBountyById('bounty-3')
+    const app = getApplicationById(application.id)
+    expect(bounty && app).toBeTruthy()
+    if (!bounty || !app) return
+
+    expect(canViewApplication('stranger', 'CREATOR', app, bounty)).toBe(false)
+    expect(canViewApplication(application.applicantId, 'CREATOR', app, bounty)).toBe(true)
+  })
+
+  it('counts applications per bounty', () => {
+    submitApplication({
+      bountyId: 'bounty-4',
+      applicantId: 'u1',
+      applicantName: 'U1',
+      applicantEmail: 'u1@example.com',
+      proposedBudget: 500,
+      timelineDays: 2,
+      proposal: 'q'.repeat(50),
+    })
+    submitApplication({
+      bountyId: 'bounty-4',
+      applicantId: 'u2',
+      applicantName: 'U2',
+      applicantEmail: 'u2@example.com',
+      proposedBudget: 600,
+      timelineDays: 2,
+      proposal: 'r'.repeat(50),
+    })
+    const counts = getApplicantCountsForBounties(['bounty-4', 'bounty-1'])
+    expect(counts['bounty-4']).toBe(2)
+    expect(listApplicationsForBounty('bounty-4')).toHaveLength(2)
+  })
+})

--- a/app/api/bounty-applications/[id]/messages/route.ts
+++ b/app/api/bounty-applications/[id]/messages/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { validateRequest, formatZodErrors, bountyMessageBodySchema } from '@/lib/validators'
+import {
+  getApplicationById,
+  addThreadMessage,
+  listThreadMessages,
+  canViewApplication,
+} from '@/lib/bounty-service'
+import { getBountyById } from '@/lib/creators-data'
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+export async function GET(_request: NextRequest, context: RouteParams) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id: applicationId } = await context.params
+  const application = getApplicationById(applicationId)
+  const bounty = application ? getBountyById(application.bountyId) : undefined
+  if (!application || !bounty) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  if (
+    !canViewApplication(session.user.id, session.user.role, application, bounty)
+  ) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const messages = listThreadMessages(applicationId)
+  return NextResponse.json({ messages })
+}
+
+export async function POST(request: NextRequest, context: RouteParams) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id: applicationId } = await context.params
+  const application = getApplicationById(applicationId)
+  const bounty = application ? getBountyById(application.bountyId) : undefined
+  if (!application || !bounty) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  if (
+    !canViewApplication(session.user.id, session.user.role, application, bounty)
+  ) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const validation = validateRequest(bountyMessageBodySchema, body)
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: formatZodErrors(validation.errors) },
+      { status: 400 },
+    )
+  }
+
+  const result = addThreadMessage({
+    applicationId,
+    bountyId: bounty.id,
+    senderId: session.user.id,
+    senderName: session.user.name || session.user.email || 'User',
+    senderEmail: session.user.email || '',
+    body: validation.data.body,
+  })
+
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: 400 })
+  }
+
+  return NextResponse.json({ message: result.message }, { status: 201 })
+}

--- a/app/api/bounty-applications/[id]/route.ts
+++ b/app/api/bounty-applications/[id]/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import {
+  validateRequest,
+  formatZodErrors,
+  applicationStatusBodySchema,
+} from '@/lib/validators'
+import {
+  getApplicationById,
+  updateApplicationStatus,
+  clientCanManageBounty,
+  pushNotification,
+} from '@/lib/bounty-service'
+import { getBountyById } from '@/lib/creators-data'
+import { sendApplicantStatusEmail } from '@/lib/bounty-notify-email'
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+export async function PATCH(request: NextRequest, context: RouteParams) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await context.params
+  const application = getApplicationById(id)
+  if (!application) {
+    return NextResponse.json({ error: 'Application not found' }, { status: 404 })
+  }
+
+  const bounty = getBountyById(application.bountyId)
+  if (!bounty) {
+    return NextResponse.json({ error: 'Bounty not found' }, { status: 404 })
+  }
+
+  const canManage = clientCanManageBounty(session.user.id, session.user.role, bounty)
+  if (!canManage && session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const validation = validateRequest(applicationStatusBodySchema, body)
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: formatZodErrors(validation.errors) },
+      { status: 400 },
+    )
+  }
+
+  const { status } = validation.data
+  const result = updateApplicationStatus({
+    applicationId: id,
+    status,
+    actorId: session.user.id,
+    actorName: session.user.name || session.user.email || 'Client',
+  })
+
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: 400 })
+  }
+
+  pushNotification({
+    userId: application.applicantId,
+    title: status === 'accepted' ? 'Application accepted' : 'Application update',
+    body:
+      status === 'accepted'
+        ? `Your proposal for "${bounty.title}" was accepted.`
+        : `Your application for "${bounty.title}" was not selected.`,
+    applicationId: application.id,
+    bountyId: bounty.id,
+  })
+
+  void (async () => {
+    try {
+      if (application.applicantEmail) {
+        await sendApplicantStatusEmail({
+          to: application.applicantEmail,
+          name: application.applicantName,
+          bountyTitle: bounty.title,
+          status,
+        })
+      }
+    } catch (e) {
+      console.error('[bounty-applications] status email', e)
+    }
+  })()
+
+  return NextResponse.json({ application: result.application })
+}

--- a/app/api/bounty-applications/[id]/timeline/route.ts
+++ b/app/api/bounty-applications/[id]/timeline/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import {
+  getApplicationById,
+  getTimelineForApplication,
+  canViewApplication,
+} from '@/lib/bounty-service'
+import { getBountyById } from '@/lib/creators-data'
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+export async function GET(_request: NextRequest, context: RouteParams) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id: applicationId } = await context.params
+  const application = getApplicationById(applicationId)
+  const bounty = application ? getBountyById(application.bountyId) : undefined
+  if (!application || !bounty) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  if (
+    !canViewApplication(session.user.id, session.user.role, application, bounty)
+  ) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const timeline = getTimelineForApplication(applicationId)
+  return NextResponse.json({ timeline })
+}

--- a/app/api/bounty-applications/route.ts
+++ b/app/api/bounty-applications/route.ts
@@ -1,0 +1,187 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import {
+  validateRequest,
+  formatZodErrors,
+  applicationSubmitSchema,
+} from '@/lib/validators'
+import {
+  submitApplication,
+  listApplicationsForBounty,
+  listApplicationsForApplicant,
+  getApplicantCountsForBounties,
+  clientCanManageBounty,
+  pushNotification,
+} from '@/lib/bounty-service'
+import { getBountyById, bounties } from '@/lib/creators-data'
+import {
+  sendApplicantReceivedEmail,
+  sendClientNewApplicationEmail,
+  getEmailForUserId,
+} from '@/lib/bounty-notify-email'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const countsOnly = searchParams.get('counts') === '1'
+  if (countsOnly) {
+    const ids = bounties.map((b) => b.id)
+    const counts = getApplicantCountsForBounties(ids)
+    return NextResponse.json({ counts })
+  }
+
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const bountyId = searchParams.get('bounty_id')
+  const applicantMe = searchParams.get('applicant') === 'me'
+
+  if (applicantMe) {
+    if (session.user.role !== 'CREATOR' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    const applications = listApplicationsForApplicant(session.user.id)
+    return NextResponse.json({ applications })
+  }
+
+  if (bountyId) {
+    const bounty = getBountyById(bountyId)
+    if (!bounty) {
+      return NextResponse.json({ error: 'Bounty not found' }, { status: 404 })
+    }
+    const canManage = clientCanManageBounty(session.user.id, session.user.role, bounty)
+    if (!canManage && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    const applications = listApplicationsForBounty(bountyId)
+    return NextResponse.json({ applications })
+  }
+
+  return NextResponse.json(
+    { error: 'Specify applicant=me or bounty_id' },
+    { status: 400 },
+  )
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (session.user.role !== 'CREATOR' && session.user.role !== 'ADMIN') {
+    return NextResponse.json(
+      { error: 'Only creator accounts can submit applications' },
+      { status: 403 },
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const validation = validateRequest(applicationSubmitSchema, body)
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: formatZodErrors(validation.errors) },
+      { status: 400 },
+    )
+  }
+
+  const { bounty_id, proposed_budget, timeline, proposal } = validation.data
+  const bounty = getBountyById(bounty_id)
+  if (!bounty) {
+    return NextResponse.json({ error: 'Bounty not found' }, { status: 404 })
+  }
+
+  const result = submitApplication({
+    bountyId: bounty_id,
+    applicantId: session.user.id,
+    applicantName: session.user.name || session.user.email || 'Creator',
+    applicantEmail: session.user.email || '',
+    proposedBudget: proposed_budget,
+    timelineDays: timeline,
+    proposal,
+  })
+
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: 400 })
+  }
+
+  const { application } = result
+
+  pushNotification({
+    userId: session.user.id,
+    title: 'Application submitted',
+    body: `Your proposal for "${bounty.title}" was sent to the client.`,
+    applicationId: application.id,
+    bountyId: bounty.id,
+  })
+
+  if (bounty.ownerUserId) {
+    pushNotification({
+      userId: bounty.ownerUserId,
+      title: 'New bounty application',
+      body: `${application.applicantName} applied to "${bounty.title}".`,
+      applicationId: application.id,
+      bountyId: bounty.id,
+    })
+  }
+
+  const appUrl = process.env.NEXTAUTH_URL ?? 'http://localhost:3000'
+
+  void (async () => {
+    try {
+      if (session.user.email) {
+        await sendApplicantReceivedEmail({
+          to: session.user.email,
+          name: session.user.name || 'there',
+          bountyTitle: bounty.title,
+        })
+      }
+    } catch (e) {
+      console.error('[bounty-applications] applicant email', e)
+    }
+
+    try {
+      let clientEmail: string | null = null
+      let clientName = 'there'
+      if (bounty.ownerUserId) {
+        clientEmail = await getEmailForUserId(bounty.ownerUserId)
+        clientName = clientEmail?.split('@')[0] ?? clientName
+      }
+      if (!clientEmail && process.env.BOUNTY_NOTIFY_EMAIL) {
+        clientEmail = process.env.BOUNTY_NOTIFY_EMAIL
+      }
+      if (clientEmail) {
+        await sendClientNewApplicationEmail({
+          to: clientEmail,
+          name: clientName,
+          bountyTitle: bounty.title,
+          applicantName: application.applicantName,
+          bountyId: bounty.id,
+        })
+      }
+    } catch (e) {
+      console.error('[bounty-applications] client email', e)
+    }
+  })()
+
+  return NextResponse.json(
+    {
+      application,
+      bounty: {
+        id: bounty.id,
+        title: bounty.title,
+        status: bounty.status,
+      },
+      message: `Application submitted successfully. View progress in your dashboard: ${appUrl}/dashboard/applications`,
+    },
+    { status: 201 },
+  )
+}

--- a/app/api/bounty-notifications/route.ts
+++ b/app/api/bounty-notifications/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import {
+  listNotificationsForUser,
+  markNotificationRead,
+  markAllNotificationsRead,
+} from '@/lib/bounty-service'
+
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const notifications = listNotificationsForUser(session.user.id)
+  return NextResponse.json({ notifications })
+}
+
+export async function PATCH(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: { id?: string; readAll?: boolean }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (body.readAll) {
+    const n = markAllNotificationsRead(session.user.id)
+    return NextResponse.json({ updated: n })
+  }
+
+  if (body.id) {
+    const ok = markNotificationRead(body.id, session.user.id)
+    if (!ok) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+    return NextResponse.json({ success: true })
+  }
+
+  return NextResponse.json({ error: 'Provide id or readAll: true' }, { status: 400 })
+}

--- a/app/bounties/[id]/bounty-detail-client.tsx
+++ b/app/bounties/[id]/bounty-detail-client.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { BountyApplicationForm } from '@/components/bounty-application-form'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import type { BountyApplicationRecord } from '@/lib/bounty-service'
+
+export function BountyDetailClient({
+  bountyId,
+  bountyTitle,
+  suggestedBudget,
+  status,
+}: {
+  bountyId: string
+  bountyTitle: string
+  suggestedBudget: number
+  status: string
+}) {
+  const { data: session, status: authStatus } = useSession()
+  const router = useRouter()
+  const [existing, setExisting] = useState<BountyApplicationRecord | null | undefined>(undefined)
+  const [submitted, setSubmitted] = useState(false)
+
+  useEffect(() => {
+    /* Fetch existing application when session is ready (async boundary). */
+    if (authStatus !== 'authenticated' || !session?.user?.id) {
+      queueMicrotask(() => setExisting(null))
+      return
+    }
+    if (session.user.role === 'CLIENT') {
+      queueMicrotask(() => setExisting(null))
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      const res = await fetch('/api/bounty-applications?applicant=me')
+      if (!res.ok || cancelled) return
+      const data = await res.json()
+      const mine = (data.applications as BountyApplicationRecord[]).find(
+        (a) => a.bountyId === bountyId,
+      )
+      if (!cancelled) setExisting(mine ?? null)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [authStatus, session?.user?.id, session?.user?.role, bountyId])
+
+  if (authStatus === 'loading') {
+    return <p className="text-muted-foreground text-sm">Loading…</p>
+  }
+
+  if (!session) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Apply</CardTitle>
+          <CardDescription>Sign in as a creator to submit a proposal for this bounty.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild>
+            <Link href={`/auth/login?callbackUrl=/bounties/${bountyId}`}>Sign in</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (session.user.role === 'CLIENT') {
+    return (
+      <Alert>
+        <AlertTitle>Client account</AlertTitle>
+        <AlertDescription>
+          Switch to a creator account to apply, or review applications from your{' '}
+          <Link href="/dashboard/bounties" className="underline font-medium">
+            bounty dashboard
+          </Link>
+          .
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (status !== 'open') {
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Not accepting applications</AlertTitle>
+        <AlertDescription>This bounty is {status}.</AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (submitted) {
+    return (
+      <Card className="border-primary/30">
+        <CardHeader>
+          <CardTitle>Application sent</CardTitle>
+          <CardDescription>
+            Your proposal for &ldquo;{bountyTitle}&rdquo; was submitted. Track status and messages from
+            your dashboard.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex gap-3">
+          <Button asChild>
+            <Link href="/dashboard/applications">View applications</Link>
+          </Button>
+          <Button variant="outline" onClick={() => router.refresh()}>
+            Back to bounty
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (existing === undefined) {
+    return <p className="text-muted-foreground text-sm">Checking existing applications…</p>
+  }
+
+  if (existing) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>You already applied</CardTitle>
+          <CardDescription>
+            Submitted {new Date(existing.createdAt).toLocaleString()} — status:{' '}
+            <span className="capitalize font-medium text-foreground">{existing.status}</span>
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild variant="outline">
+            <Link href="/dashboard/applications">Open application dashboard</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Submit your proposal</CardTitle>
+        <CardDescription>
+          Include timeline, budget, and how you will deliver the work. Minimum 50 characters.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <BountyApplicationForm
+          bountyId={bountyId}
+          bountyTitle={bountyTitle}
+          suggestedBudget={suggestedBudget}
+          onSuccess={() => {
+            setSubmitted(true)
+          }}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/bounties/[id]/bounty-meta-client.tsx
+++ b/app/bounties/[id]/bounty-meta-client.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Calendar, DollarSign, Zap } from 'lucide-react'
+
+export function BountyMetaRow({
+  currency,
+  budget,
+  deadlineMs,
+  status,
+}: {
+  currency: string
+  budget: number
+  deadlineMs: number
+  status: string
+}) {
+  const [daysLeft, setDaysLeft] = useState<number | null>(null)
+
+  useEffect(() => {
+    const update = () => {
+      setDaysLeft(
+        Math.max(0, Math.ceil((deadlineMs - Date.now()) / (1000 * 60 * 60 * 24))),
+      )
+    }
+    update()
+    const t = setInterval(update, 60_000)
+    return () => clearInterval(t)
+  }, [deadlineMs])
+
+  return (
+    <div className="grid sm:grid-cols-3 gap-4 mb-8">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardDescription className="flex items-center gap-1">
+            <DollarSign className="h-4 w-4" /> Budget
+          </CardDescription>
+          <CardTitle className="text-2xl">
+            {currency} {budget.toLocaleString()}
+          </CardTitle>
+        </CardHeader>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardDescription className="flex items-center gap-1">
+            <Calendar className="h-4 w-4" /> Deadline
+          </CardDescription>
+          <CardTitle className="text-2xl">{daysLeft === null ? '—' : `${daysLeft} days`}</CardTitle>
+        </CardHeader>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardDescription className="flex items-center gap-1">
+            <Zap className="h-4 w-4" /> Status
+          </CardDescription>
+          <CardTitle className="text-2xl capitalize">{status}</CardTitle>
+        </CardHeader>
+      </Card>
+    </div>
+  )
+}

--- a/app/bounties/[id]/page.tsx
+++ b/app/bounties/[id]/page.tsx
@@ -1,0 +1,128 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { getBountyById } from '@/lib/creators-data'
+import { Header } from '@/components/header'
+import { Footer } from '@/components/footer'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+import { ArrowLeft } from 'lucide-react'
+import { BountyDetailClient } from './bounty-detail-client'
+import { BountyMetaRow } from './bounty-meta-client'
+
+export function generateStaticParams() {
+  return [
+    { id: 'bounty-1' },
+    { id: 'bounty-2' },
+    { id: 'bounty-3' },
+    { id: 'bounty-4' },
+  ]
+}
+
+export default async function BountyDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const bounty = getBountyById(id)
+  if (!bounty) {
+    notFound()
+  }
+
+  const difficultyClass: Record<string, string> = {
+    beginner: 'badge-beginner',
+    intermediate: 'badge-intermediate',
+    advanced: 'badge-advanced',
+    expert: 'badge-expert',
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background">
+      <Header />
+
+      <main className="flex-grow">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <Button variant="ghost" asChild className="mb-6 -ml-2">
+            <Link href="/bounties">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              All bounties
+            </Link>
+          </Button>
+
+          <div className="flex flex-wrap items-start justify-between gap-4 mb-6">
+            <div>
+              <p className="text-sm text-muted-foreground mb-1">{bounty.category}</p>
+              <h1 className="text-3xl font-bold text-balance">{bounty.title}</h1>
+            </div>
+            <Badge className={`capitalize ${difficultyClass[bounty.difficulty] ?? ''}`}>
+              {bounty.difficulty}
+            </Badge>
+          </div>
+
+          <BountyMetaRow
+            currency={bounty.currency}
+            budget={bounty.budget}
+            deadlineMs={bounty.deadline.getTime()}
+            status={bounty.status}
+          />
+
+          <Card className="mb-8">
+            <CardHeader>
+              <CardTitle>Description</CardTitle>
+            </CardHeader>
+            <CardContent className="text-muted-foreground leading-relaxed whitespace-pre-wrap">
+              {bounty.description}
+            </CardContent>
+          </Card>
+
+          <div className="grid md:grid-cols-2 gap-8 mb-8">
+            <Card>
+              <CardHeader>
+                <CardTitle>Required skills</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc pl-5 space-y-1 text-sm text-muted-foreground">
+                  {bounty.requiredSkills.map((s) => (
+                    <li key={s}>{s}</li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Deliverables</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground whitespace-pre-wrap">
+                {bounty.deliverables}
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="mb-8">
+            <h3 className="text-sm font-medium text-foreground mb-2">Tags</h3>
+            <div className="flex flex-wrap gap-2">
+              {bounty.tags.map((tag) => (
+                <Badge key={tag} variant="secondary">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          </div>
+
+          <Separator className="my-8" />
+
+          <BountyDetailClient
+            bountyId={bounty.id}
+            bountyTitle={bounty.title}
+            suggestedBudget={bounty.budget}
+            status={bounty.status}
+          />
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  )
+}

--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
@@ -12,6 +12,21 @@ import { Empty, EmptyHeader, EmptyTitle, EmptyDescription, EmptyContent, EmptyMe
 export default function BountiesPage() {
   const [selectedDifficulty, setSelectedDifficulty] = useState('All');
   const [selectedCategory, setSelectedCategory] = useState('All');
+  const [counts, setCounts] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch('/api/bounty-applications?counts=1');
+        if (res.ok) {
+          const data = await res.json();
+          setCounts(data.counts ?? {});
+        }
+      } catch {
+        /* ignore */
+      }
+    })();
+  }, []);
 
   const difficulties = ['All', 'beginner', 'intermediate', 'advanced', 'expert'];
   const categories = ['All', 'Brand Strategy', 'Technical Writing', 'Content Creation', 'UX Research'];
@@ -38,7 +53,9 @@ export default function BountiesPage() {
       <div className="flex items-start justify-between mb-4">
         <div className="flex-1">
           <h3 className="text-xl font-bold text-foreground mb-1 line-clamp-2">
-            {bounty.title}
+            <Link href={`/bounties/${bounty.id}`} className="hover:text-primary transition-colors">
+              {bounty.title}
+            </Link>
           </h3>
           <p className="text-sm text-muted-foreground">{bounty.category}</p>
         </div>
@@ -88,11 +105,13 @@ export default function BountiesPage() {
       <div className="flex items-center justify-between">
         <div className="text-sm text-muted-foreground">
           <Zap size={14} className="inline mr-1" />
-          {bounty.applicants} applications
+          {counts[bounty.id] ?? bounty.applicants} applications
         </div>
-        <Button size="sm" variant="default" className="group">
-          Apply Now
-          <ArrowRight size={14} className="ml-2 group-hover:translate-x-0.5 transition-transform" />
+        <Button size="sm" variant="default" className="group" asChild>
+          <Link href={`/bounties/${bounty.id}`}>
+            Apply Now
+            <ArrowRight size={14} className="ml-2 group-hover:translate-x-0.5 transition-transform" />
+          </Link>
         </Button>
       </div>
     </div>

--- a/app/dashboard/applications/page.tsx
+++ b/app/dashboard/applications/page.tsx
@@ -1,0 +1,317 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Header } from '@/components/header'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Textarea } from '@/components/ui/textarea'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Separator } from '@/components/ui/separator'
+import { getBountyById } from '@/lib/creators-data'
+import type {
+  BountyApplicationRecord,
+  ApplicationThreadMessage,
+  TimelineEntry,
+  BountyNotificationRecord,
+} from '@/lib/bounty-service'
+import { Loader2, Bell } from 'lucide-react'
+
+export default function DashboardApplicationsPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [applications, setApplications] = useState<BountyApplicationRecord[]>([])
+  const [notifications, setNotifications] = useState<BountyNotificationRecord[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [messages, setMessages] = useState<ApplicationThreadMessage[]>([])
+  const [timeline, setTimeline] = useState<TimelineEntry[]>([])
+  const [reply, setReply] = useState('')
+  const [sending, setSending] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  const selected = applications.find((a) => a.id === selectedId) ?? null
+  const selectedBounty = selected ? getBountyById(selected.bountyId) : undefined
+
+  const loadAll = useCallback(async () => {
+    const [aRes, nRes] = await Promise.all([
+      fetch('/api/bounty-applications?applicant=me'),
+      fetch('/api/bounty-notifications'),
+    ])
+    if (aRes.ok) {
+      const data = await aRes.json()
+      const apps = data.applications ?? []
+      setApplications(apps)
+      setSelectedId((prev) => prev ?? apps[0]?.id ?? null)
+    }
+    if (nRes.ok) {
+      const data = await nRes.json()
+      setNotifications(data.notifications ?? [])
+    }
+  }, [])
+
+  const loadThread = useCallback(async (applicationId: string) => {
+    const [mRes, tRes] = await Promise.all([
+      fetch(`/api/bounty-applications/${applicationId}/messages`),
+      fetch(`/api/bounty-applications/${applicationId}/timeline`),
+    ])
+    if (mRes.ok) {
+      const m = await mRes.json()
+      setMessages(m.messages ?? [])
+    }
+    if (tRes.ok) {
+      const t = await tRes.json()
+      setTimeline(t.timeline ?? [])
+    }
+  }, [])
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/auth/login')
+  }, [status, router])
+
+  useEffect(() => {
+    if (status !== 'authenticated' || !session) return
+    if (session.user.role !== 'CREATOR' && session.user.role !== 'ADMIN') {
+      router.replace('/dashboard')
+      return
+    }
+    void (async () => {
+      setLoading(true)
+      await loadAll()
+      setLoading(false)
+    })()
+  }, [status, session, router, loadAll])
+
+  useEffect(() => {
+    if (selectedId) void loadThread(selectedId)
+  }, [selectedId, loadThread])
+
+  async function sendMessage() {
+    if (!selectedId || !reply.trim()) return
+    setSending(true)
+    try {
+      const res = await fetch(`/api/bounty-applications/${selectedId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body: reply }),
+      })
+      if (res.ok) {
+        setReply('')
+        await loadThread(selectedId)
+        await loadAll()
+      }
+    } finally {
+      setSending(false)
+    }
+  }
+
+  async function markRead(nid: string) {
+    await fetch('/api/bounty-notifications', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: nid }),
+    })
+    setNotifications((prev) => prev.map((n) => (n.id === nid ? { ...n, read: true } : n)))
+  }
+
+  if (status === 'loading' || !session) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (session.user.role !== 'CREATOR' && session.user.role !== 'ADMIN') {
+    return null
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold mb-2">My applications</h1>
+            <p className="text-muted-foreground">
+              Track proposal status, timeline, and messages with clients.
+            </p>
+          </div>
+          <Button variant="outline" asChild>
+            <Link href="/bounties">Browse bounties</Link>
+          </Button>
+        </div>
+
+        {notifications.filter((n) => !n.read).length > 0 && (
+          <Card className="mb-6 border-primary/20">
+            <CardHeader className="flex flex-row items-center gap-2 pb-2">
+              <Bell className="h-4 w-4" />
+              <CardTitle className="text-base">Unread</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {notifications
+                .filter((n) => !n.read)
+                .map((n) => (
+                  <div
+                    key={n.id}
+                    className="flex flex-wrap items-center justify-between gap-2 rounded-lg border p-3 text-sm"
+                  >
+                    <div>
+                      <p className="font-medium">{n.title}</p>
+                      <p className="text-muted-foreground">{n.body}</p>
+                    </div>
+                    <Button size="sm" variant="secondary" onClick={() => void markRead(n.id)}>
+                      Dismiss
+                    </Button>
+                  </div>
+                ))}
+            </CardContent>
+          </Card>
+        )}
+
+        {loading ? (
+          <p className="text-muted-foreground">Loading…</p>
+        ) : applications.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>No applications yet</CardTitle>
+              <CardDescription>
+                Submit a proposal from any open bounty to see it here.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild>
+                <Link href="/bounties">Find bounties</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid lg:grid-cols-3 gap-6">
+            <Card className="lg:col-span-1">
+              <CardHeader>
+                <CardTitle className="text-base">Applications</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {applications.map((a) => {
+                  const b = getBountyById(a.bountyId)
+                  return (
+                    <button
+                      key={a.id}
+                      type="button"
+                      onClick={() => setSelectedId(a.id)}
+                      className={`w-full text-left rounded-lg border p-3 transition-colors ${
+                        selectedId === a.id ? 'border-primary bg-primary/5' : 'border-border hover:bg-muted/50'
+                      }`}
+                    >
+                      <p className="font-medium text-sm line-clamp-2">{b?.title ?? a.bountyId}</p>
+                      <Badge variant="outline" className="mt-1 capitalize">
+                        {a.status}
+                      </Badge>
+                    </button>
+                  )
+                })}
+              </CardContent>
+            </Card>
+
+            {selected && selectedBounty && (
+              <div className="lg:col-span-2 space-y-6">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>{selectedBounty.title}</CardTitle>
+                    <CardDescription>
+                      Applied {new Date(selected.createdAt).toLocaleString()}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="flex flex-wrap gap-2">
+                      <Badge className="capitalize">{selected.status}</Badge>
+                      <span className="text-sm text-muted-foreground">
+                        Offer: {selectedBounty.currency} {selected.proposedBudget.toLocaleString()} ·{' '}
+                        {selected.timelineDays} days
+                      </span>
+                    </div>
+                    <Separator />
+                    <div>
+                      <p className="text-sm font-medium mb-1">Your proposal</p>
+                      <p className="text-sm whitespace-pre-wrap border rounded-lg p-3 bg-muted/30">
+                        {selected.proposal}
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Timeline</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="space-y-3 text-sm">
+                      {timeline.map((t) => (
+                        <li key={t.id} className="flex gap-3">
+                          <span className="text-muted-foreground shrink-0 w-36">
+                            {new Date(t.createdAt).toLocaleString()}
+                          </span>
+                          <span>
+                            <span className="font-medium">{t.label}</span>
+                            {t.detail ? (
+                              <span className="text-muted-foreground"> — {t.detail}</span>
+                            ) : null}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Messages</CardTitle>
+                    <CardDescription>Chat with the client about this application.</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <ScrollArea className="h-[220px] rounded-md border p-3">
+                      <div className="space-y-3">
+                        {messages.map((m) => (
+                          <div key={m.id} className="text-sm">
+                            <p className="font-medium">
+                              {m.senderName}{' '}
+                              <span className="text-muted-foreground font-normal">
+                                {new Date(m.createdAt).toLocaleString()}
+                              </span>
+                            </p>
+                            <p className="whitespace-pre-wrap mt-1">{m.body}</p>
+                          </div>
+                        ))}
+                        {messages.length === 0 && (
+                          <p className="text-muted-foreground text-sm">No messages yet.</p>
+                        )}
+                      </div>
+                    </ScrollArea>
+                    <div className="flex gap-2">
+                      <Textarea
+                        placeholder="Message the client…"
+                        value={reply}
+                        onChange={(e) => setReply(e.target.value)}
+                        rows={3}
+                      />
+                      <Button
+                        type="button"
+                        className="self-end"
+                        disabled={sending || !reply.trim()}
+                        onClick={() => void sendMessage()}
+                      >
+                        {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Send'}
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/app/dashboard/bounties/[id]/page.tsx
+++ b/app/dashboard/bounties/[id]/page.tsx
@@ -1,0 +1,354 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { useRouter, useParams } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Header } from '@/components/header'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Textarea } from '@/components/ui/textarea'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { getBountyById } from '@/lib/creators-data'
+import type {
+  BountyApplicationRecord,
+  ApplicationThreadMessage,
+  TimelineEntry,
+} from '@/lib/bounty-service'
+import { ArrowLeft, Loader2 } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+
+export default function DashboardBountyDetailPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const params = useParams()
+  const id = typeof params?.id === 'string' ? params.id : ''
+  const bounty = id ? getBountyById(id) : undefined
+
+  const [applications, setApplications] = useState<BountyApplicationRecord[]>([])
+  const [loading, setLoading] = useState(true)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [messages, setMessages] = useState<ApplicationThreadMessage[]>([])
+  const [timeline, setTimeline] = useState<TimelineEntry[]>([])
+  const [reply, setReply] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const selected = applications.find((a) => a.id === selectedId) ?? null
+
+  const loadApplications = useCallback(async () => {
+    if (!id) return
+    const res = await fetch(`/api/bounty-applications?bounty_id=${encodeURIComponent(id)}`)
+    if (!res.ok) return
+    const data = await res.json()
+    const apps: BountyApplicationRecord[] = data.applications ?? []
+    setApplications(apps)
+    setSelectedId((prev) => prev ?? apps[0]?.id ?? null)
+  }, [id])
+
+  const loadThread = useCallback(async (applicationId: string) => {
+    const [mRes, tRes] = await Promise.all([
+      fetch(`/api/bounty-applications/${applicationId}/messages`),
+      fetch(`/api/bounty-applications/${applicationId}/timeline`),
+    ])
+    if (mRes.ok) {
+      const m = await mRes.json()
+      setMessages(m.messages ?? [])
+    }
+    if (tRes.ok) {
+      const t = await tRes.json()
+      setTimeline(t.timeline ?? [])
+    }
+  }, [])
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/auth/login')
+  }, [status, router])
+
+  useEffect(() => {
+    setSelectedId(null)
+    setApplications([])
+  }, [id])
+
+  useEffect(() => {
+    if (status !== 'authenticated' || !session || !id) return
+    if (session.user.role !== 'CLIENT' && session.user.role !== 'ADMIN') {
+      router.replace('/dashboard')
+      return
+    }
+    void (async () => {
+      setLoading(true)
+      await loadApplications()
+      setLoading(false)
+    })()
+  }, [status, session, id, router, loadApplications])
+
+  useEffect(() => {
+    if (selectedId) void loadThread(selectedId)
+  }, [selectedId, loadThread])
+
+  if (status === 'loading' || !session) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!bounty) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Header />
+        <div className="max-w-2xl mx-auto px-4 py-16 text-center">
+          <p className="text-muted-foreground mb-4">Bounty not found.</p>
+          <Button asChild variant="outline">
+            <Link href="/dashboard/bounties">Back</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  async function setStatus(applicationId: string, next: 'accepted' | 'rejected') {
+    const res = await fetch(`/api/bounty-applications/${applicationId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: next }),
+    })
+    if (res.ok) await loadApplications()
+  }
+
+  async function sendMessage() {
+    if (!selectedId || !reply.trim()) return
+    setSending(true)
+    try {
+      const res = await fetch(`/api/bounty-applications/${selectedId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body: reply }),
+      })
+      if (res.ok) {
+        setReply('')
+        await loadThread(selectedId)
+      }
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Button variant="ghost" asChild className="mb-6 -ml-2">
+          <Link href="/dashboard/bounties">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            All bounties
+          </Link>
+        </Button>
+
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold mb-1">{bounty.title}</h1>
+          <p className="text-muted-foreground text-sm">
+            {bounty.currency} {bounty.budget.toLocaleString()} ·{' '}
+            <span className="capitalize">{bounty.status}</span>
+          </p>
+        </div>
+
+        {loading ? (
+          <p className="text-muted-foreground">Loading applications…</p>
+        ) : applications.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>No applications yet</CardTitle>
+              <CardDescription>Creators will appear here when they submit proposals.</CardDescription>
+            </CardHeader>
+          </Card>
+        ) : (
+          <div className="grid lg:grid-cols-3 gap-6">
+            <Card className="lg:col-span-1">
+              <CardHeader>
+                <CardTitle className="text-base">Applicants</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {applications.map((a) => (
+                  <button
+                    key={a.id}
+                    type="button"
+                    onClick={() => setSelectedId(a.id)}
+                    className={`w-full text-left rounded-lg border p-3 transition-colors ${
+                      selectedId === a.id ? 'border-primary bg-primary/5' : 'border-border hover:bg-muted/50'
+                    }`}
+                  >
+                    <p className="font-medium text-sm truncate">{a.applicantName}</p>
+                    <Badge variant="outline" className="mt-1 capitalize">
+                      {a.status}
+                    </Badge>
+                  </button>
+                ))}
+              </CardContent>
+            </Card>
+
+            {selected && (
+              <div className="lg:col-span-2 space-y-6">
+                <Card>
+                  <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-4">
+                    <div>
+                      <CardTitle>{selected.applicantName}</CardTitle>
+                      <CardDescription>{selected.applicantEmail}</CardDescription>
+                    </div>
+                    <div className="flex gap-2">
+                      {selected.status === 'pending' && (
+                        <>
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button size="sm" variant="default">
+                                Accept
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Accept this proposal?</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  The applicant will be notified by email. You can still message them
+                                  in this thread.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction onClick={() => void setStatus(selected.id, 'accepted')}>
+                                  Accept
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button size="sm" variant="outline">
+                                Reject
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Reject this application?</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  The freelancer will be notified. This cannot be undone.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction onClick={() => void setStatus(selected.id, 'rejected')}>
+                                  Reject
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        </>
+                      )}
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="grid sm:grid-cols-2 gap-4 text-sm">
+                      <div>
+                        <p className="text-muted-foreground">Proposed budget</p>
+                        <p className="font-semibold">
+                          {bounty.currency} {selected.proposedBudget.toLocaleString()}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-muted-foreground">Timeline</p>
+                        <p className="font-semibold">{selected.timelineDays} days</p>
+                      </div>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-sm mb-1">Proposal</p>
+                      <p className="text-sm whitespace-pre-wrap border rounded-lg p-3 bg-muted/30">
+                        {selected.proposal}
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Timeline</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="space-y-3 text-sm">
+                      {timeline.map((t) => (
+                        <li key={t.id} className="flex gap-3">
+                          <span className="text-muted-foreground shrink-0 w-36">
+                            {new Date(t.createdAt).toLocaleString()}
+                          </span>
+                          <span>
+                            <span className="font-medium">{t.label}</span>
+                            {t.detail ? (
+                              <span className="text-muted-foreground"> — {t.detail}</span>
+                            ) : null}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Messages</CardTitle>
+                    <CardDescription>Discuss scope and next steps with the applicant.</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <ScrollArea className="h-[220px] rounded-md border p-3">
+                      <div className="space-y-3">
+                        {messages.map((m) => (
+                          <div key={m.id} className="text-sm">
+                            <p className="font-medium">
+                              {m.senderName}{' '}
+                              <span className="text-muted-foreground font-normal">
+                                {new Date(m.createdAt).toLocaleString()}
+                              </span>
+                            </p>
+                            <p className="whitespace-pre-wrap mt-1">{m.body}</p>
+                          </div>
+                        ))}
+                        {messages.length === 0 && (
+                          <p className="text-muted-foreground text-sm">No messages yet.</p>
+                        )}
+                      </div>
+                    </ScrollArea>
+                    <div className="flex gap-2">
+                      <Textarea
+                        placeholder="Write a message…"
+                        value={reply}
+                        onChange={(e) => setReply(e.target.value)}
+                        rows={3}
+                      />
+                      <Button
+                        type="button"
+                        className="self-end"
+                        disabled={sending || !reply.trim()}
+                        onClick={() => void sendMessage()}
+                      >
+                        {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Send'}
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/app/dashboard/bounties/page.tsx
+++ b/app/dashboard/bounties/page.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Header } from '@/components/header'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { bounties } from '@/lib/creators-data'
+import { Briefcase, ArrowRight } from 'lucide-react'
+
+export default function DashboardBountiesPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [counts, setCounts] = useState<Record<string, number>>({})
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/auth/login')
+  }, [status, router])
+
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    if (session?.user.role !== 'CLIENT' && session?.user.role !== 'ADMIN') {
+      router.replace('/dashboard')
+      return
+    }
+    void (async () => {
+      const res = await fetch('/api/bounty-applications?counts=1')
+      if (res.ok) {
+        const data = await res.json()
+        setCounts(data.counts ?? {})
+      }
+      setLoaded(true)
+    })()
+  }, [status, session?.user.role, router])
+
+  if (status === 'loading' || !session) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Header />
+        <div className="max-w-4xl mx-auto px-4 py-8">
+          <Skeleton className="h-10 w-64 mb-8" />
+          <Skeleton className="h-32" />
+        </div>
+      </div>
+    )
+  }
+
+  if (session.user.role !== 'CLIENT' && session.user.role !== 'ADMIN') {
+    return null
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-2">Your bounties</h1>
+          <p className="text-muted-foreground">
+            Review proposals, timelines, and messages for each open role.
+          </p>
+        </div>
+
+        {!loaded ? (
+          <Skeleton className="h-48 w-full" />
+        ) : (
+          <div className="space-y-4">
+            {bounties.map((b) => (
+              <Card key={b.id}>
+                <CardHeader className="flex flex-row items-start justify-between gap-4">
+                  <div>
+                    <CardTitle className="text-lg">{b.title}</CardTitle>
+                    <CardDescription>{b.category}</CardDescription>
+                  </div>
+                  <Badge variant="secondary">
+                    {counts[b.id] ?? 0} application{(counts[b.id] ?? 0) === 1 ? '' : 's'}
+                  </Badge>
+                </CardHeader>
+                <CardContent className="flex flex-wrap gap-3 justify-between items-center">
+                  <p className="text-sm text-muted-foreground">
+                    Budget {b.currency} {b.budget.toLocaleString()} ·{' '}
+                    <span className="capitalize">{b.status}</span>
+                  </p>
+                  <Button asChild size="sm">
+                    <Link href={`/dashboard/bounties/${b.id}`}>
+                      Manage applications
+                      <ArrowRight className="ml-2 h-4 w-4" />
+                    </Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        <Card className="mt-8 border-dashed">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Briefcase className="h-4 w-4" />
+              Public listing
+            </CardTitle>
+            <CardDescription>Browse all open bounties on the marketplace.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button variant="outline" asChild>
+              <Link href="/bounties">View bounties</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -192,6 +192,48 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
 
+          {(userRole === 'CREATOR' || userRole === 'ADMIN') && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <FileText className="h-5 w-5" />
+                  My applications
+                </CardTitle>
+                <CardDescription>
+                  Track proposals, timelines, and client messages
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Link href="/dashboard/applications">
+                  <Button variant="outline" className="w-full">
+                    Open applications
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+          )}
+
+          {(userRole === 'CLIENT' || userRole === 'ADMIN') && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Users className="h-5 w-5" />
+                  Bounty applications
+                </CardTitle>
+                <CardDescription>
+                  Review and accept proposals for your roles
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Link href="/dashboard/bounties">
+                  <Button variant="outline" className="w-full">
+                    Manage applications
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+          )}
+
           {/* Find Talent Card (for Clients) */}
           {(userRole === 'CLIENT' || userRole === 'ADMIN') && (
             <Card>

--- a/components/bounty-application-form.tsx
+++ b/components/bounty-application-form.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { applicationSubmitSchema } from '@/lib/validators'
+import type { z } from 'zod'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Loader2 } from 'lucide-react'
+
+const schema = applicationSubmitSchema
+type FormValues = z.infer<typeof schema>
+
+export function BountyApplicationForm({
+  bountyId,
+  bountyTitle,
+  suggestedBudget,
+  onSuccess,
+}: {
+  bountyId: string
+  bountyTitle: string
+  suggestedBudget: number
+  onSuccess?: () => void
+}) {
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      bounty_id: bountyId,
+      proposed_budget: suggestedBudget,
+      timeline: 14,
+      proposal: '',
+    },
+  })
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    setSubmitError(null)
+    const res = await fetch('/api/bounty-applications', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      setSubmitError(data.error || 'Failed to submit application')
+      return
+    }
+    onSuccess?.()
+  })
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      <input type="hidden" {...form.register('bounty_id')} />
+
+      <div className="space-y-2">
+        <Label htmlFor="proposed_budget">Proposed budget ({bountyTitle})</Label>
+        <Input
+          id="proposed_budget"
+          type="number"
+          min={1}
+          step={1}
+          {...form.register('proposed_budget', { valueAsNumber: true })}
+        />
+        {form.formState.errors.proposed_budget && (
+          <p className="text-sm text-destructive">
+            {form.formState.errors.proposed_budget.message}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="timeline">Timeline (days)</Label>
+        <Input
+          id="timeline"
+          type="number"
+          min={1}
+          max={3650}
+          {...form.register('timeline', { valueAsNumber: true })}
+        />
+        {form.formState.errors.timeline && (
+          <p className="text-sm text-destructive">{form.formState.errors.timeline.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="proposal">Proposal (min. 50 characters)</Label>
+        <Textarea
+          id="proposal"
+          rows={10}
+          placeholder="Describe your approach, relevant experience, and deliverables."
+          className="min-h-[200px] resize-y font-mono text-sm"
+          {...form.register('proposal')}
+        />
+        {form.formState.errors.proposal && (
+          <p className="text-sm text-destructive">{form.formState.errors.proposal.message}</p>
+        )}
+      </div>
+
+      {submitError && (
+        <Alert variant="destructive">
+          <AlertDescription>{submitError}</AlertDescription>
+        </Alert>
+      )}
+
+      <Button type="submit" disabled={form.formState.isSubmitting} className="w-full sm:w-auto">
+        {form.formState.isSubmitting ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Submitting…
+          </>
+        ) : (
+          'Submit application'
+        )}
+      </Button>
+    </form>
+  )
+}

--- a/lib/bounty-notify-email.ts
+++ b/lib/bounty-notify-email.ts
@@ -1,0 +1,83 @@
+import { sendEmail } from '@/lib/email/mailer'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function getEmailForUserId(userId: string): Promise<string | null> {
+  const u = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { email: true },
+  })
+  return u?.email ?? null
+}
+
+export async function sendApplicantReceivedEmail(params: {
+  to: string
+  name: string
+  bountyTitle: string
+}): Promise<void> {
+  const appUrl = process.env.NEXTAUTH_URL ?? 'http://localhost:3000'
+  await sendEmail({
+    to: params.to,
+    subject: `Application received — ${params.bountyTitle}`,
+    template: 'bounty-notification',
+    variables: {
+      name: params.name,
+      headline: 'Your proposal was submitted',
+      bodyText: `We received your application for "${params.bountyTitle}". The client will review it and you will be notified when the status changes.`,
+      actionUrl: `${appUrl}/dashboard/applications`,
+      actionLabel: 'View my applications',
+      footerNote: 'You can message the client from the application thread once they respond.',
+    },
+  })
+}
+
+export async function sendClientNewApplicationEmail(params: {
+  to: string
+  name: string
+  bountyTitle: string
+  applicantName: string
+  bountyId: string
+}): Promise<void> {
+  const appUrl = process.env.NEXTAUTH_URL ?? 'http://localhost:3000'
+  await sendEmail({
+    to: params.to,
+    subject: `New application for "${params.bountyTitle}"`,
+    template: 'bounty-notification',
+    variables: {
+      name: params.name,
+      headline: 'Someone applied to your bounty',
+      bodyText: `${params.applicantName} submitted a proposal for "${params.bountyTitle}". Review applications in your dashboard.`,
+      actionUrl: `${appUrl}/dashboard/bounties/${params.bountyId}`,
+      actionLabel: 'Review applications',
+      footerNote: 'Sign in to Stellar Creators to accept or reject proposals.',
+    },
+  })
+}
+
+export async function sendApplicantStatusEmail(params: {
+  to: string
+  name: string
+  bountyTitle: string
+  status: 'accepted' | 'rejected'
+}): Promise<void> {
+  const appUrl = process.env.NEXTAUTH_URL ?? 'http://localhost:3000'
+  const accepted = params.status === 'accepted'
+  await sendEmail({
+    to: params.to,
+    subject: accepted
+      ? `Accepted — ${params.bountyTitle}`
+      : `Update on your application — ${params.bountyTitle}`,
+    template: 'bounty-notification',
+    variables: {
+      name: params.name,
+      headline: accepted ? 'Your application was accepted' : 'Your application was not selected',
+      bodyText: accepted
+        ? `Great news — the client accepted your proposal for "${params.bountyTitle}".`
+        : `The client reviewed applications for "${params.bountyTitle}" and chose another freelancer this time.`,
+      actionUrl: `${appUrl}/dashboard/applications`,
+      actionLabel: 'View applications',
+      footerNote: 'You can continue the conversation in your dashboard if messaging is enabled.',
+    },
+  })
+}

--- a/lib/bounty-service.ts
+++ b/lib/bounty-service.ts
@@ -1,0 +1,330 @@
+import { getBountyById, type Bounty } from '@/lib/creators-data'
+
+export type ApplicationStatus = 'pending' | 'accepted' | 'rejected'
+
+export interface BountyApplicationRecord {
+  id: string
+  bountyId: string
+  applicantId: string
+  applicantName: string
+  applicantEmail: string
+  proposedBudget: number
+  timelineDays: number
+  proposal: string
+  status: ApplicationStatus
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TimelineEntry {
+  id: string
+  applicationId: string
+  bountyId: string
+  type: 'submitted' | 'status_changed' | 'message'
+  label: string
+  detail?: string
+  actorId?: string
+  actorName?: string
+  meta?: Record<string, string>
+  createdAt: string
+}
+
+export interface ApplicationThreadMessage {
+  id: string
+  applicationId: string
+  bountyId: string
+  senderId: string
+  senderName: string
+  senderEmail: string
+  body: string
+  createdAt: string
+}
+
+export interface BountyNotificationRecord {
+  id: string
+  userId: string
+  title: string
+  body: string
+  read: boolean
+  applicationId?: string
+  bountyId?: string
+  createdAt: string
+}
+
+type Store = {
+  applications: BountyApplicationRecord[]
+  timeline: TimelineEntry[]
+  messages: ApplicationThreadMessage[]
+  notifications: BountyNotificationRecord[]
+}
+
+function getGlobalStore(): Store {
+  const g = globalThis as unknown as { __bountyApplicationStore?: Store }
+  if (!g.__bountyApplicationStore) {
+    g.__bountyApplicationStore = {
+      applications: [],
+      timeline: [],
+      messages: [],
+      notifications: [],
+    }
+  }
+  return g.__bountyApplicationStore
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+export function clientCanManageBounty(
+  userId: string,
+  role: string,
+  bounty: Bounty,
+): boolean {
+  if (role === 'ADMIN') return true
+  if (role !== 'CLIENT') return false
+  if (bounty.ownerUserId == null || bounty.ownerUserId === '') return true
+  return bounty.ownerUserId === userId
+}
+
+export function creatorOwnsApplication(
+  applicantId: string,
+  role: string,
+  application: BountyApplicationRecord,
+): boolean {
+  if (role === 'ADMIN') return true
+  if (role !== 'CREATOR') return false
+  return application.applicantId === applicantId
+}
+
+export function canViewApplication(
+  userId: string,
+  role: string,
+  application: BountyApplicationRecord,
+  bounty: Bounty | undefined,
+): boolean {
+  if (!bounty) return false
+  if (role === 'ADMIN') return true
+  if (application.applicantId === userId) return true
+  if (role === 'CLIENT' && clientCanManageBounty(userId, role, bounty)) return true
+  return false
+}
+
+export function submitApplication(params: {
+  bountyId: string
+  applicantId: string
+  applicantName: string
+  applicantEmail: string
+  proposedBudget: number
+  timelineDays: number
+  proposal: string
+}): { application: BountyApplicationRecord } | { error: string } {
+  const bounty = getBountyById(params.bountyId)
+  if (!bounty) return { error: 'Bounty not found' }
+  if (bounty.status !== 'open') return { error: 'This bounty is not accepting applications' }
+
+  const store = getGlobalStore()
+  const dup = store.applications.some(
+    (a) => a.bountyId === params.bountyId && a.applicantId === params.applicantId,
+  )
+  if (dup) return { error: 'You have already applied to this bounty' }
+
+  const id = crypto.randomUUID()
+  const ts = nowIso()
+  const application: BountyApplicationRecord = {
+    id,
+    bountyId: params.bountyId,
+    applicantId: params.applicantId,
+    applicantName: params.applicantName,
+    applicantEmail: params.applicantEmail,
+    proposedBudget: params.proposedBudget,
+    timelineDays: params.timelineDays,
+    proposal: params.proposal,
+    status: 'pending',
+    createdAt: ts,
+    updatedAt: ts,
+  }
+  store.applications.push(application)
+
+  const tId = crypto.randomUUID()
+  store.timeline.push({
+    id: tId,
+    applicationId: id,
+    bountyId: params.bountyId,
+    type: 'submitted',
+    label: 'Application submitted',
+    detail: `${params.applicantName} submitted a proposal`,
+    actorId: params.applicantId,
+    actorName: params.applicantName,
+    createdAt: ts,
+  })
+
+  return { application }
+}
+
+export function listApplicationsForBounty(bountyId: string): BountyApplicationRecord[] {
+  return getGlobalStore().applications.filter((a) => a.bountyId === bountyId)
+}
+
+export function listApplicationsForApplicant(applicantId: string): BountyApplicationRecord[] {
+  return getGlobalStore().applications.filter((a) => a.applicantId === applicantId)
+}
+
+export function getApplicationById(id: string): BountyApplicationRecord | undefined {
+  return getGlobalStore().applications.find((a) => a.id === id)
+}
+
+export function getApplicantCountsForBounties(bountyIds: string[]): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const id of bountyIds) counts[id] = 0
+  for (const a of getGlobalStore().applications) {
+    if (counts[a.bountyId] !== undefined) counts[a.bountyId]++
+  }
+  return counts
+}
+
+export function updateApplicationStatus(params: {
+  applicationId: string
+  status: ApplicationStatus
+  actorId: string
+  actorName: string
+}): { application: BountyApplicationRecord } | { error: string } {
+  const store = getGlobalStore()
+  const idx = store.applications.findIndex((a) => a.id === params.applicationId)
+  if (idx === -1) return { error: 'Application not found' }
+
+  const bounty = getBountyById(store.applications[idx].bountyId)
+  if (!bounty) return { error: 'Bounty not found' }
+
+  const prev = store.applications[idx].status
+  if (prev !== 'pending') {
+    return { error: 'Only pending applications can be accepted or rejected' }
+  }
+
+  const ts = nowIso()
+  const updated: BountyApplicationRecord = {
+    ...store.applications[idx],
+    status: params.status,
+    updatedAt: ts,
+  }
+  store.applications[idx] = updated
+
+  store.timeline.push({
+    id: crypto.randomUUID(),
+    applicationId: params.applicationId,
+    bountyId: updated.bountyId,
+    type: 'status_changed',
+    label: `Application ${params.status}`,
+    detail: `Status changed from ${prev} to ${params.status}`,
+    actorId: params.actorId,
+    actorName: params.actorName,
+    meta: { from: prev, to: params.status },
+    createdAt: ts,
+  })
+
+  return { application: updated }
+}
+
+export function getTimelineForApplication(applicationId: string): TimelineEntry[] {
+  return getGlobalStore()
+    .timeline.filter((t) => t.applicationId === applicationId)
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+}
+
+export function getTimelineForBounty(bountyId: string): TimelineEntry[] {
+  return getGlobalStore()
+    .timeline.filter((t) => t.bountyId === bountyId)
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+}
+
+export function addThreadMessage(params: {
+  applicationId: string
+  bountyId: string
+  senderId: string
+  senderName: string
+  senderEmail: string
+  body: string
+}): { message: ApplicationThreadMessage } | { error: string } {
+  const application = getApplicationById(params.applicationId)
+  if (!application) return { error: 'Application not found' }
+  if (application.bountyId !== params.bountyId) return { error: 'Invalid bounty for application' }
+
+  const ts = nowIso()
+  const message: ApplicationThreadMessage = {
+    id: crypto.randomUUID(),
+    applicationId: params.applicationId,
+    bountyId: params.bountyId,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderEmail: params.senderEmail,
+    body: params.body.trim(),
+    createdAt: ts,
+  }
+  getGlobalStore().messages.push(message)
+
+  getGlobalStore().timeline.push({
+    id: crypto.randomUUID(),
+    applicationId: params.applicationId,
+    bountyId: params.bountyId,
+    type: 'message',
+    label: 'New message',
+    detail: params.body.slice(0, 120),
+    actorId: params.senderId,
+    actorName: params.senderName,
+    createdAt: ts,
+  })
+
+  return { message }
+}
+
+export function listThreadMessages(applicationId: string): ApplicationThreadMessage[] {
+  return getGlobalStore()
+    .messages.filter((m) => m.applicationId === applicationId)
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+}
+
+export function pushNotification(n: Omit<BountyNotificationRecord, 'id' | 'createdAt' | 'read'>): BountyNotificationRecord {
+  const record: BountyNotificationRecord = {
+    ...n,
+    id: crypto.randomUUID(),
+    read: false,
+    createdAt: nowIso(),
+  }
+  getGlobalStore().notifications.push(record)
+  return record
+}
+
+export function listNotificationsForUser(userId: string): BountyNotificationRecord[] {
+  return getGlobalStore()
+    .notifications.filter((n) => n.userId === userId)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+}
+
+export function markNotificationRead(notificationId: string, userId: string): boolean {
+  const store = getGlobalStore()
+  const n = store.notifications.find((x) => x.id === notificationId && x.userId === userId)
+  if (!n) return false
+  n.read = true
+  return true
+}
+
+export function markAllNotificationsRead(userId: string): number {
+  let n = 0
+  for (const x of getGlobalStore().notifications) {
+    if (x.userId === userId && !x.read) {
+      x.read = true
+      n++
+    }
+  }
+  return n
+}
+
+/** Test helper: reset in-memory store (do not use in production routes except tests). */
+export function __resetBountyStoreForTests(): void {
+  const g = globalThis as unknown as { __bountyApplicationStore?: Store }
+  g.__bountyApplicationStore = {
+    applications: [],
+    timeline: [],
+    messages: [],
+    notifications: [],
+  }
+}

--- a/lib/creators-data.ts
+++ b/lib/creators-data.ts
@@ -317,6 +317,8 @@ export interface Bounty {
   postedDate: Date;
   requiredSkills: string[];
   deliverables: string;
+  /** When set, only this user (client) may manage applications. Omit for open demo bounties. */
+  ownerUserId?: string | null;
 }
 
 export interface BountyApplication {
@@ -472,3 +474,7 @@ export const getBountiesByDifficulty = (difficulty: string): Bounty[] => {
   if (difficulty === 'All') return bounties;
   return bounties.filter(bounty => bounty.difficulty === difficulty);
 };
+
+export function getBountyById(id: string): Bounty | undefined {
+  return bounties.find((b) => b.id === id);
+}

--- a/lib/email/mailer.ts
+++ b/lib/email/mailer.ts
@@ -13,7 +13,7 @@ import path from 'path';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type EmailTemplate = 'verify-email' | 'reset-password' | 'welcome';
+export type EmailTemplate = 'verify-email' | 'reset-password' | 'welcome' | 'bounty-notification';
 
 interface BaseTemplateVars {
   subject: string;
@@ -37,10 +37,20 @@ export interface WelcomeVars {
   isCreator?: boolean;
 }
 
+export interface BountyNotificationVars {
+  name: string;
+  headline: string;
+  bodyText: string;
+  actionUrl?: string;
+  actionLabel?: string;
+  footerNote?: string;
+}
+
 type TemplateVarsMap = {
   'verify-email': VerifyEmailVars;
   'reset-password': ResetPasswordVars;
   welcome: WelcomeVars;
+  'bounty-notification': BountyNotificationVars;
 };
 
 export interface SendEmailOptions<T extends EmailTemplate> {

--- a/lib/email/templates/bounty-notification.hbs
+++ b/lib/email/templates/bounty-notification.hbs
@@ -1,0 +1,8 @@
+<h1>{{headline}}</h1>
+<p>Hi {{name}},</p>
+<p>{{bodyText}}</p>
+{{#if actionUrl}}
+<a href="{{actionUrl}}" class="btn">{{actionLabel}}</a>
+{{/if}}
+<hr class="divider" />
+<p class="small">{{footerNote}}</p>

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -82,11 +82,27 @@ export const userSchema = z.object({
 export const userUpdateSchema = userSchema.partial()
 
 export const applicationSchema = z.object({
-  bounty_id: z.string().uuid(),
-  creator_id: z.string().uuid(),
+  bounty_id: z.string().min(1).max(128),
+  creator_id: z.string().min(1).max(128),
   proposed_budget: z.number().positive(),
   timeline: z.number().int().positive(),
   proposal: z.string().min(1).max(5000),
+})
+
+/** Client-submitted body (applicant comes from session). */
+export const applicationSubmitSchema = z.object({
+  bounty_id: z.string().min(1).max(128),
+  proposed_budget: z.number().positive(),
+  timeline: z.number().int().positive().max(3650),
+  proposal: z.string().min(50).max(5000),
+})
+
+export const applicationStatusBodySchema = z.object({
+  status: z.enum(['accepted', 'rejected']),
+})
+
+export const bountyMessageBodySchema = z.object({
+  body: z.string().min(1).max(8000),
 })
 
 export const applicationUpdateSchema = z.object({
@@ -103,6 +119,9 @@ export type BountyUpdateInput = z.infer<typeof bountyUpdateSchema>
 export type UserInput = z.infer<typeof userSchema>
 export type UserUpdateInput = z.infer<typeof userUpdateSchema>
 export type ApplicationInput = z.infer<typeof applicationSchema>
+export type ApplicationSubmitInput = z.infer<typeof applicationSubmitSchema>
+export type ApplicationStatusBodyInput = z.infer<typeof applicationStatusBodySchema>
+export type BountyMessageBodyInput = z.infer<typeof bountyMessageBodySchema>
 export type ApplicationUpdateInput = z.infer<typeof applicationUpdateSchema>
 export type PaginationInput = z.infer<typeof paginationSchema>
 


### PR DESCRIPTION
## Summary
Implements end-to-end bounty applications: detail page, proposal submission, client review (accept/reject), creator tracking, in-app notifications, threaded messaging, timeline, and email hooks.

## Changes
- **Pages:** `/bounties/[id]` (detail + apply), `/dashboard/bounties`, `/dashboard/bounties/[id]`, `/dashboard/applications`; dashboard home links for clients/creators.
- **UI:** `BountyApplicationForm` (RHF + Zod, min 50 char proposal); live applicant counts on `/bounties`.
- **API:** `bounty-applications` (GET/POST, PATCH by id), messages + timeline sub-routes, public `?counts=1` for listing counts, `bounty-notifications` (GET/PATCH).
- **Backend logic:** `lib/bounty-service.ts` (in-memory store, access checks, timeline/messages/notifications).
- **Email:** `bounty-notification` template + `lib/bounty-notify-email.ts` (applicant + optional client via `BOUNTY_NOTIFY_EMAIL` / `ownerUserId`).
- **Data:** `getBountyById`, optional `ownerUserId` on `Bounty`; relaxed application IDs in validators for demo bounty slugs.
- **Tests:** Vitest — validation, service, security, performance (`__tests__/bounty-*.test.ts`).
closes #7 
## Env / config
- Optional: `BOUNTY_NOTIFY_EMAIL` for client “new application” emails when bounty has no `ownerUserId`.

## Out of scope / notes
- Applications are stored in-process (suitable for demo/single instance); production would wire Prisma/Supabase.
- Full-repo `next build` may still fail on pre-existing issues (e.g. missing `@/components/pagination` on creators page).

## How to test
1. `pnpm install && pnpm prisma generate`
2. `pnpm exec vitest run __tests__/bounty-`
3. As CREATOR: open a bounty → submit proposal → `/dashboard/applications`.
4. As CLIENT: `/dashboard/bounties` → manage → accept/reject, messages, timeline.

Branch: `feature/stellar-creator-portfolio-bounty-applications`