### PR TITLE
feat(creators): project gallery filters, list/grid, modal, richer cards

### DIFF
--- a/__tests__/project-helpers.test.ts
+++ b/__tests__/project-helpers.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import type { Project } from '@/lib/creators-data'
+import {
+  filterProjectsByCategory,
+  getProjectDetail,
+  getProjectStatus,
+  getProjectTechStack,
+  projectCategoryOptions,
+} from '@/lib/project-helpers'
+
+const sample: Project[] = [
+  {
+    id: 'a',
+    title: 'A',
+    description: 'Short',
+    category: 'Alpha',
+    image: '/x.jpg',
+    tags: ['t1'],
+    year: 2024,
+    techStack: ['React'],
+    detail: 'Long story',
+  },
+  {
+    id: 'b',
+    title: 'B',
+    description: 'Beta desc',
+    category: 'Beta',
+    image: '/y.jpg',
+    tags: ['t2', 't3'],
+    year: 2023,
+  },
+]
+
+describe('project-helpers', () => {
+  it('lists categories with All first', () => {
+    expect(projectCategoryOptions(sample)).toEqual(['All', 'Alpha', 'Beta'])
+  })
+
+  it('filters by category', () => {
+    expect(filterProjectsByCategory(sample, 'All')).toHaveLength(2)
+    expect(filterProjectsByCategory(sample, 'Alpha')).toHaveLength(1)
+    expect(filterProjectsByCategory(sample, 'Beta')[0]?.id).toBe('b')
+  })
+
+  it('defaults status to completed', () => {
+    expect(getProjectStatus(sample[1]!)).toBe('completed')
+  })
+
+  it('prefers techStack over tags', () => {
+    expect(getProjectTechStack(sample[0]!)).toEqual(['React'])
+    expect(getProjectTechStack(sample[1]!)).toEqual(['t2', 't3'])
+  })
+
+  it('uses detail when present', () => {
+    expect(getProjectDetail(sample[0]!)).toBe('Long story')
+    expect(getProjectDetail(sample[1]!)).toBe('Beta desc')
+  })
+})

--- a/app/creators/[id]/page.tsx
+++ b/app/creators/[id]/page.tsx
@@ -8,13 +8,19 @@ import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
 import { ProjectCard } from '@/components/project-card';
 import { Button } from '@/components/ui/button';
-import { creators } from '@/lib/creators-data';
-import { ArrowLeft, Linkedin, Twitter, ExternalLink, Star, Settings2 } from 'lucide-react';
+import { creators, type Project } from '@/lib/creators-data';
+import {
+  projectCategoryOptions,
+  filterProjectsByCategory,
+} from '@/lib/project-helpers';
+import { ArrowLeft, Linkedin, Twitter, ExternalLink, Star, Settings2, LayoutGrid, List } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import { AggregateRatingDisplay } from '@/components/rating-display';
 import { SocialShare } from '@/components/social-share';
 import Image from 'next/image';
 import { buildOptimizationProps, buildSizes } from '@/lib/image-utils';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { ProjectModal } from '@/components/project-modal';
 
 interface CreatorProfilePageProps {
   params: {
@@ -27,6 +33,9 @@ export default function CreatorProfilePage({ params }: CreatorProfilePageProps) 
   const { data: session } = useSession();
   const creator = creators.find((c) => c.id === params.id);
   const [aggregate, setAggregate] = useState<AggregateRating | null>(null);
+  const [modalProject, setModalProject] = useState<Project | null>(null);
+  const [projectFilter, setProjectFilter] = useState('All');
+  const [galleryLayout, setGalleryLayout] = useState<'grid' | 'list'>('grid');
   const heroSizes = buildSizes({
     mobile: '100vw',
     tablet: '100vw',
@@ -34,17 +43,21 @@ export default function CreatorProfilePage({ params }: CreatorProfilePageProps) 
     largeDesktop: '100vw',
   });
 
-  if (!creator) {
-    notFound();
-  }
-
   // Fetch aggregate rating
   useEffect(() => {
+    if (!creator) return;
     fetch(`/api/reviews?creatorId=${creator.id}&limit=1000`)
       .then((r) => r.json())
       .then((d) => setAggregate(d.aggregate))
       .catch(() => {});
-  }, [creator.id]);
+  }, [creator]);
+
+  const projectCategories = projectCategoryOptions(creator?.projects ?? []);
+  const filteredProjects = filterProjectsByCategory(creator?.projects ?? [], projectFilter);
+
+  if (!creator) {
+    notFound();
+  }
 
   return (
     <div className="min-h-screen flex flex-col bg-background">
@@ -237,15 +250,85 @@ export default function CreatorProfilePage({ params }: CreatorProfilePageProps) 
         {creator.projects.length > 0 && (
           <section className="py-16 sm:py-24">
             <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-              <h2 className="text-3xl font-bold text-foreground mb-12">Featured Work</h2>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {creator.projects.map((project) => (
-                  <ProjectCard key={project.id} project={project} />
+              <div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between mb-8">
+                <div>
+                  <h2 className="text-3xl font-bold text-foreground">Featured Work</h2>
+                  <p className="text-muted-foreground mt-2 max-w-xl text-sm sm:text-base">
+                    Filter by category, switch between grid and list, and open a project for the full
+                    brief, timeline, and tech stack.
+                  </p>
+                </div>
+                <ToggleGroup
+                  type="single"
+                  value={galleryLayout}
+                  onValueChange={(v) => {
+                    if (v === 'grid' || v === 'list') setGalleryLayout(v);
+                  }}
+                  variant="outline"
+                  size="sm"
+                  className="shrink-0 self-start sm:self-auto"
+                  aria-label="Gallery layout"
+                >
+                  <ToggleGroupItem value="grid" aria-label="Grid gallery">
+                    <LayoutGrid className="h-4 w-4" />
+                  </ToggleGroupItem>
+                  <ToggleGroupItem value="list" aria-label="List gallery">
+                    <List className="h-4 w-4" />
+                  </ToggleGroupItem>
+                </ToggleGroup>
+              </div>
+
+              <div
+                className="flex flex-wrap gap-2 mb-8"
+                role="group"
+                aria-label="Filter projects by category"
+              >
+                {projectCategories.map((cat) => (
+                  <Button
+                    key={cat}
+                    type="button"
+                    variant={projectFilter === cat ? 'default' : 'outline'}
+                    size="sm"
+                    className="rounded-full"
+                    onClick={() => setProjectFilter(cat)}
+                  >
+                    {cat}
+                  </Button>
                 ))}
               </div>
+
+              {filteredProjects.length === 0 ? (
+                <p className="text-muted-foreground">No projects in this category.</p>
+              ) : (
+                <div
+                  className={
+                    galleryLayout === 'grid'
+                      ? 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'
+                      : 'flex flex-col gap-4'
+                  }
+                >
+                  {filteredProjects.map((project, idx) => (
+                    <ProjectCard
+                      key={project.id}
+                      project={project}
+                      layout={galleryLayout}
+                      imageIndex={idx}
+                      onViewDetails={setModalProject}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
           </section>
         )}
+
+        <ProjectModal
+          project={modalProject}
+          open={modalProject !== null}
+          onOpenChange={(open) => {
+            if (!open) setModalProject(null);
+          }}
+        />
 
         {/* Reviews Section */}
         {aggregate && aggregate.total > 0 && (

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -1,79 +1,158 @@
 'use client';
 
-import { Project } from '@/lib/creators-data';
-import { ExternalLink } from 'lucide-react';
+import Image from 'next/image';
+import type { Project } from '@/lib/creators-data';
+import { getProjectStatus, getProjectTechStack } from '@/lib/project-helpers';
+import { ExternalLink, Calendar, Maximize2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { buildOptimizationProps, buildSizes } from '@/lib/image-utils';
+import { cn } from '@/lib/utils';
 
-interface ProjectCardProps {
-  project: Project;
+const statusClass: Record<string, string> = {
+  completed: 'bg-emerald-500/12 text-emerald-800 dark:text-emerald-300',
+  'in-progress': 'bg-amber-500/12 text-amber-900 dark:text-amber-200',
+  archived: 'bg-muted text-muted-foreground',
+};
+
+function formatStatus(status: string): string {
+  return status.replace(/-/g, ' ');
 }
 
-export function ProjectCard({ project }: ProjectCardProps) {
+export interface ProjectCardProps {
+  project: Project;
+  layout?: 'grid' | 'list';
+  /** For LCP / eager loading on first tiles */
+  imageIndex?: number;
+  onViewDetails?: (project: Project) => void;
+}
+
+export function ProjectCard({
+  project,
+  layout = 'grid',
+  imageIndex = 0,
+  onViewDetails,
+}: ProjectCardProps) {
+  const status = getProjectStatus(project);
+  const tech = getProjectTechStack(project);
+  const previewTech = tech.slice(0, 4);
+  const moreTech = tech.length - previewTech.length;
+
+  const cardSizes = buildSizes({
+    mobile: '100vw',
+    tablet: layout === 'list' ? '200px' : '50vw',
+    desktop: layout === 'list' ? '240px' : '33vw',
+    largeDesktop: layout === 'list' ? '280px' : '400px',
+  });
+
+  const imgProps = buildOptimizationProps({
+    index: imageIndex,
+    aboveFoldCount: 3,
+    sizes: cardSizes,
+  });
+
+  const interactive = Boolean(onViewDetails);
+
   return (
-    <div className="group bg-card border border-border rounded-lg overflow-hidden hover:shadow-lg transition-all duration-300">
-      {/* Image */}
-      <div className="aspect-video bg-gradient-to-br from-primary/20 to-accent/20 overflow-hidden relative">
-        {project.image && (
-          <img
-            src={project.image}
-            alt={project.title}
-            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-          />
+    <article
+      className={cn(
+        'group bg-card border border-border rounded-xl overflow-hidden transition-all duration-200',
+        'hover:shadow-md hover:border-primary/20',
+        layout === 'list' && 'flex flex-col sm:flex-row sm:items-stretch gap-0',
+        interactive && 'cursor-pointer',
+      )}
+      onClick={interactive ? () => onViewDetails?.(project) : undefined}
+    >
+      <div
+        className={cn(
+          'relative bg-gradient-to-br from-primary/15 to-accent/15 overflow-hidden shrink-0',
+          layout === 'grid' && 'aspect-video w-full',
+          layout === 'list' && 'aspect-video w-full sm:w-52 md:w-60 sm:min-h-[140px]',
         )}
+      >
+        {project.image ? (
+          <Image
+            src={project.image}
+            alt=""
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+            sizes={cardSizes}
+            {...imgProps}
+            placeholder="empty"
+          />
+        ) : null}
+        <div className="absolute top-2 left-2 flex flex-wrap gap-1.5">
+          <Badge variant="secondary" className="text-xs font-medium shadow-sm">
+            {project.category}
+          </Badge>
+          <Badge
+            variant="secondary"
+            className={cn('text-xs capitalize shadow-sm', statusClass[status] ?? statusClass.completed)}
+          >
+            {formatStatus(status)}
+          </Badge>
+        </div>
       </div>
 
-      {/* Content */}
-      <div className="p-5">
-        {/* Category Badge */}
-        <div className="inline-block mb-2">
-          <span className="text-xs font-semibold px-2.5 py-1 bg-muted text-muted-foreground rounded-full">
-            {project.category}
-          </span>
-        </div>
+      <div className={cn('p-4 sm:p-5 flex flex-col flex-1 min-w-0', layout === 'list' && 'sm:py-4')}>
+        <h3 className="text-lg font-bold text-foreground mb-2 line-clamp-2 leading-snug">{project.title}</h3>
 
-        {/* Title */}
-        <h4 className="text-base font-bold text-foreground mb-2 line-clamp-2">
-          {project.title}
-        </h4>
+        <p className="text-sm text-muted-foreground mb-3 line-clamp-3 leading-relaxed">{project.description}</p>
 
-        {/* Description */}
-        <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
-          {project.description}
-        </p>
+        {project.duration ? (
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-3">
+            <Calendar className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            <span>{project.duration}</span>
+          </div>
+        ) : null}
 
-        {/* Tags */}
-        <div className="flex flex-wrap gap-2 mb-3">
-          {project.tags.slice(0, 2).map((tag) => (
+        <div className="flex flex-wrap gap-1.5 mb-4">
+          {previewTech.map((t) => (
             <span
-              key={tag}
-              className="text-xs px-2 py-1 bg-muted rounded text-muted-foreground"
+              key={t}
+              className="text-xs px-2 py-0.5 rounded-md bg-secondary/80 text-secondary-foreground font-medium"
             >
-              {tag}
+              {t}
             </span>
           ))}
-          {project.tags.length > 2 && (
-            <span className="text-xs px-2 py-1 bg-muted rounded text-muted-foreground">
-              +{project.tags.length - 2}
-            </span>
-          )}
+          {moreTech > 0 ? (
+            <span className="text-xs px-2 py-0.5 rounded-md bg-muted text-muted-foreground">+{moreTech}</span>
+          ) : null}
         </div>
 
-        {/* Footer */}
-        <div className="flex justify-between items-center">
-          <span className="text-xs text-muted-foreground font-medium">
-            {project.year}
-          </span>
-          {project.link && (
-            <a
-              href={project.link}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center text-accent hover:text-primary transition-colors"
-            >
-              <ExternalLink size={16} />
-            </a>
-          )}
+        <div className="mt-auto flex flex-wrap items-center gap-2 justify-between">
+          <span className="text-xs font-semibold text-muted-foreground">{project.year}</span>
+          <div className="flex items-center gap-2">
+            {onViewDetails ? (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="h-8 gap-1"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onViewDetails(project);
+                }}
+              >
+                <Maximize2 className="h-3.5 w-3.5" aria-hidden />
+                Details
+              </Button>
+            ) : null}
+            {project.link ? (
+              <a
+                href={project.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border text-accent hover:bg-secondary transition-colors"
+                aria-label={`Open ${project.title} in new tab`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            ) : null}
+          </div>
         </div>
       </div>
-    </div>
+    </article>
   );
 }

--- a/components/project-modal.tsx
+++ b/components/project-modal.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import Image from 'next/image'
+import type { Project } from '@/lib/creators-data'
+import {
+  getProjectDetail,
+  getProjectStatus,
+  getProjectTechStack,
+} from '@/lib/project-helpers'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { ExternalLink, Calendar, Layers } from 'lucide-react'
+import { buildOptimizationProps, buildSizes } from '@/lib/image-utils'
+import { cn } from '@/lib/utils'
+
+const statusStyles: Record<string, string> = {
+  completed: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30',
+  'in-progress': 'bg-amber-500/15 text-amber-800 dark:text-amber-300 border-amber-500/30',
+  archived: 'bg-muted text-muted-foreground border-border',
+}
+
+export interface ProjectModalProps {
+  project: Project | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ProjectModal({ project, open, onOpenChange }: ProjectModalProps) {
+  if (!project) return null
+
+  const status = getProjectStatus(project)
+  const tech = getProjectTechStack(project)
+  const detail = getProjectDetail(project)
+  const modalSizes = buildSizes({
+    mobile: '100vw',
+    tablet: '90vw',
+    desktop: 'min(720px, 90vw)',
+    largeDesktop: '720px',
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-h-[min(92vh,900px)] overflow-y-auto p-0 gap-0 sm:max-w-2xl"
+      >
+        <div className="relative aspect-video w-full bg-muted">
+          {project.image ? (
+            <Image
+              src={project.image}
+              alt={project.title}
+              fill
+              className="object-cover"
+              sizes={modalSizes}
+              {...buildOptimizationProps({ priority: false, sizes: modalSizes })}
+              placeholder="empty"
+            />
+          ) : null}
+        </div>
+
+        <div className="space-y-4 p-6">
+          <DialogHeader className="space-y-3 text-left">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="font-normal">
+                {project.category}
+              </Badge>
+              <Badge
+                variant="outline"
+                className={cn('capitalize border', statusStyles[status] ?? statusStyles.completed)}
+              >
+                {status.replace(/-/g, ' ')}
+              </Badge>
+              <span className="text-sm text-muted-foreground">{project.year}</span>
+            </div>
+            <DialogTitle className="text-xl sm:text-2xl pr-8">{project.title}</DialogTitle>
+            <DialogDescription asChild>
+              <p className="text-base text-foreground leading-relaxed whitespace-pre-wrap">
+                {detail}
+              </p>
+            </DialogDescription>
+          </DialogHeader>
+
+          {project.duration ? (
+            <div className="flex items-start gap-2 text-sm text-muted-foreground">
+              <Calendar className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+              <div>
+                <span className="font-medium text-foreground">Timeline</span>
+                <p>{project.duration}</p>
+              </div>
+            </div>
+          ) : null}
+
+          <div>
+            <div className="mb-2 flex items-center gap-2 text-sm font-medium text-foreground">
+              <Layers className="h-4 w-4" aria-hidden />
+              Tech stack
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {tech.map((t) => (
+                <Badge key={t} variant="secondary" className="font-normal">
+                  {t}
+                </Badge>
+              ))}
+            </div>
+          </div>
+
+          {project.link ? (
+            <Button className="w-full sm:w-auto" asChild>
+              <a href={project.link} target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="mr-2 h-4 w-4" />
+                Open live project
+              </a>
+            </Button>
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/creators-data.ts
+++ b/lib/creators-data.ts
@@ -1,3 +1,5 @@
+export type ProjectStatus = 'completed' | 'in-progress' | 'archived';
+
 export interface Project {
   id: string;
   title: string;
@@ -7,6 +9,13 @@ export interface Project {
   link?: string;
   tags: string[];
   year: number;
+  status?: ProjectStatus;
+  /** Human-readable engagement length, e.g. "12 weeks". */
+  duration?: string;
+  /** Technologies / tools; card and modal prefer this over raw tags when set. */
+  techStack?: string[];
+  /** Longer story for the detail modal; defaults to `description`. */
+  detail?: string;
 }
 
 export interface Service {
@@ -82,30 +91,46 @@ export const creators: Creator[] = [
       {
         id: 'project-1',
         title: 'SaaSPro Design System',
-        description: 'Comprehensive design system for enterprise SaaS platform',
+        description:
+          'Enterprise design system with tokens, components, and docs adopted by 40+ product squads.',
         category: 'Design System',
         image: '/projects/design-system.jpg',
         link: 'https://saaspro.design',
         tags: ['Design System', 'Figma', 'Enterprise'],
         year: 2024,
+        status: 'completed',
+        duration: '5 months',
+        techStack: ['Figma', 'Storybook', 'React', 'Design Tokens'],
+        detail:
+          'Partnered with engineering to ship a token-first system, 120+ documented components, and accessibility baked into every pattern. Cut design–dev handoff time by roughly 35% and stabilized UI consistency across five product lines.',
       },
       {
         id: 'project-2',
         title: 'FinTech Mobile App',
-        description: 'Redesigned mobile banking app with improved UX',
+        description: 'Mobile banking refresh focused on clarity, trust, and faster money movement.',
         category: 'Product Design',
         image: '/projects/fintech-app.jpg',
         tags: ['Mobile', 'Finance', 'Responsive'],
         year: 2023,
+        status: 'in-progress',
+        duration: '14 weeks (ongoing)',
+        techStack: ['Figma', 'ProtoPie', 'iOS HIG', 'WCAG 2.2'],
+        detail:
+          'Leading UX for onboarding, transfers, and statements. Running weekly usability tests with 12 participants; latest iteration improved task success for “send money” from 71% to 89%. Dark mode and biometric flows are in beta.',
       },
       {
         id: 'project-3',
         title: 'E-commerce Platform Redesign',
-        description: 'Complete redesign resulting in 40% increase in conversions',
+        description: 'End-to-end commerce redesign that lifted conversion and reduced support tickets.',
         category: 'E-commerce',
         image: '/projects/ecommerce.jpg',
         tags: ['E-commerce', 'Conversion', 'UX Research'],
         year: 2023,
+        status: 'archived',
+        duration: '6 months',
+        techStack: ['Sketch', 'Hotjar', 'Google Analytics', 'A/B testing'],
+        detail:
+          'Archived after successful handoff to the internal team. Project covered navigation IA, PDP templates, and checkout friction removal — validated with quantitative experiments and qualitative diary studies.',
       },
     ],
     verification: {
@@ -137,29 +162,44 @@ export const creators: Creator[] = [
       {
         id: 'project-4',
         title: 'TechStartup Brand Guidelines',
-        description: 'Complete brand voice and messaging framework',
+        description: 'Voice, tone, and messaging system for a Series B developer tools company.',
         category: 'Brand Strategy',
         image: '/projects/brand-guidelines.jpg',
         tags: ['Branding', 'Strategy', 'Copywriting'],
         year: 2024,
+        status: 'completed',
+        duration: '10 weeks',
+        techStack: ['Notion', 'Grammarly', 'Figma', 'Style guide CMS'],
+        detail:
+          'Delivered a 60-page guidelines site, elevator pitches for three personas, and reusable content blocks for marketing and product. Writers reported 50% faster first-draft approval cycles.',
       },
       {
         id: 'project-5',
         title: 'API Documentation Suite',
-        description: 'Technical documentation for complex developer platform',
+        description: 'Developer docs with auth flows, error catalogs, and runnable examples.',
         category: 'Technical Writing',
         image: '/projects/api-docs.jpg',
         tags: ['Technical Writing', 'Documentation', 'Developers'],
         year: 2023,
+        status: 'completed',
+        duration: '4 months',
+        techStack: ['OpenAPI', 'MDX', 'Docusaurus', 'Postman'],
+        detail:
+          'Structured reference for 180+ endpoints, migration guides from v1 to v2, and interactive snippets. Partnered with support to cut “how do I auth?” tickets by 42% in two quarters.',
       },
       {
         id: 'project-6',
         title: 'Content Calendar & Strategy',
-        description: 'Year-long social media and blog strategy for SaaS',
+        description: 'Integrated blog, LinkedIn, and newsletter program for B2B SaaS growth.',
         category: 'Content Strategy',
         image: '/projects/content-calendar.jpg',
         tags: ['Content Marketing', 'Social Media', 'Strategy'],
         year: 2023,
+        status: 'in-progress',
+        duration: 'Rolling retainer',
+        techStack: ['HubSpot', 'Buffer', 'Ahrefs', 'Google Search Console'],
+        detail:
+          'Editorial engine with quarterly themes, SEO clusters, and sales-enablement briefs. Currently scaling from 2 to 4 posts per week while maintaining quality rubrics and SME interviews.',
       },
     ],
     verification: {
@@ -191,30 +231,45 @@ export const creators: Creator[] = [
       {
         id: 'project-7',
         title: 'Brand Campaign Series',
-        description: '5-part video campaign reaching 2M+ views',
+        description: 'Five-part hero video series for product launch across paid and organic.',
         category: 'Video Production',
         image: '/projects/video-campaign.jpg',
         link: 'https://youtube.com/jordanmaxwell',
         tags: ['Video', 'Campaign', 'Social Media'],
         year: 2024,
+        status: 'completed',
+        duration: '8 weeks production',
+        techStack: ['DaVinci Resolve', 'After Effects', 'RED Komodo', 'Frame.io'],
+        detail:
+          'Concept through color grade: storyboards, location shoots, motion supers, and platform-specific cuts (9:16, 1:1, 16:9). Campaign exceeded 2.1M organic views with consistent CTA lift in paid retargeting.',
       },
       {
         id: 'project-8',
         title: 'Photography Portfolio Showcase',
-        description: 'Commercial and lifestyle photography collection',
+        description: 'Lookbook and web gallery for lifestyle and commercial stills.',
         category: 'Photography',
         image: '/projects/photography.jpg',
         tags: ['Photography', 'Commercial', 'Lifestyle'],
         year: 2023,
+        status: 'archived',
+        duration: '3 weeks',
+        techStack: ['Lightroom', 'Capture One', 'Photoshop'],
+        detail:
+          'Curated 80 selects with consistent color science and web-optimized exports. Archived after client internalized assets; gallery template reused for two follow-on shoots.',
       },
       {
         id: 'project-9',
         title: 'Motion Graphics Package',
-        description: 'Animated brand identity system for streaming platform',
+        description: 'Stream overlays, stingers, and lower-thirds for a global streaming brand.',
         category: 'Motion Design',
         image: '/projects/motion-design.jpg',
         tags: ['Animation', 'Motion Graphics', 'Branding'],
         year: 2023,
+        status: 'in-progress',
+        duration: '11 weeks (ongoing)',
+        techStack: ['After Effects', 'Cinema 4D', 'Lottie', 'OBS assets'],
+        detail:
+          'Building modular .mogrt and JSON Lottie deliverables so producers can swap text without reopening AE. Alpha-safe overlays tested on 1080p and 4K pipelines.',
       },
     ],
     verification: {
@@ -243,29 +298,44 @@ export const creators: Creator[] = [
       {
         id: 'project-10',
         title: 'Healthcare Platform Redesign',
-        description: 'User research-led redesign improving accessibility scores',
+        description: 'Research-led IA and flows for clinicians and patients, WCAG-aligned.',
         category: 'UX Research',
         image: '/projects/healthcare-ux.jpg',
         tags: ['Healthcare', 'Accessibility', 'Research'],
         year: 2024,
+        status: 'completed',
+        duration: '7 months',
+        techStack: ['Dovetail', 'Figma', 'Maze', 'NVDA'],
+        detail:
+          'Mixed-methods program: contextual inquiry in three hospitals, diary studies, and moderated usability on critical tasks (scheduling, results, messaging). Shipped prioritized roadmap tied to severity-rated findings.',
       },
       {
         id: 'project-11',
         title: 'Accessibility Audit & Improvement',
-        description: 'Complete A11y audit and implementation for major platform',
+        description: 'WCAG 2.2 gap analysis with engineering-ready remediation tickets.',
         category: 'Accessibility',
         image: '/projects/accessibility.jpg',
         tags: ['Accessibility', 'A11y', 'WCAG'],
         year: 2023,
+        status: 'completed',
+        duration: '6 weeks audit + 12 weeks fixes',
+        techStack: ['axe DevTools', 'WAVE', 'VoiceOver', 'JAWS'],
+        detail:
+          'Automated and manual passes across top 50 templates. Delivered violation backlog with effort estimates; paired with devs on live regions, focus order, and form error patterns.',
       },
       {
         id: 'project-12',
         title: 'User Research Repository',
-        description: 'Comprehensive UX research methodology guide and templates',
+        description: 'Searchable insights hub: plans, transcripts, and decision logs.',
         category: 'Research',
         image: '/projects/research.jpg',
         tags: ['Research', 'Documentation', 'Methodology'],
         year: 2023,
+        status: 'in-progress',
+        duration: 'Rolling',
+        techStack: ['Notion', 'Dovetail', 'FigJam', 'GitHub'],
+        detail:
+          'Taxonomy for “question → evidence → decision” with templates for intake, synthesis, and stakeholder readouts. Rolling adoption across three squads; migrating legacy Drive folders.',
       },
     ],
     verification: {

--- a/lib/project-helpers.ts
+++ b/lib/project-helpers.ts
@@ -1,0 +1,25 @@
+import type { Project, ProjectStatus } from '@/lib/creators-data'
+
+export function getProjectStatus(project: Project): ProjectStatus {
+  return project.status ?? 'completed'
+}
+
+export function getProjectTechStack(project: Project): string[] {
+  if (project.techStack?.length) return project.techStack
+  return project.tags
+}
+
+export function getProjectDetail(project: Project): string {
+  return project.detail ?? project.description
+}
+
+export function projectCategoryOptions(projects: Project[]): string[] {
+  const set = new Set<string>()
+  for (const p of projects) set.add(p.category)
+  return ['All', ...Array.from(set).sort((a, b) => a.localeCompare(b))]
+}
+
+export function filterProjectsByCategory(projects: Project[], category: string): Project[] {
+  if (category === 'All') return projects
+  return projects.filter((p) => p.category === category)
+}


### PR DESCRIPTION
## Summary
Improves creator profile projects: category filtering, grid vs list gallery, a full project detail modal, richer cards, and structured project metadata (status, timeline, tech stack).
closes #14 
## Changes
- **Data:** Extend `Project` with optional `status`, `duration`, `techStack`, `detail`; enrich all sample projects in `lib/creators-data.ts`.
- **Helpers:** `lib/project-helpers.ts` — category list, filter, defaults for status/tech/detail.
- **UI:** Rebuilt `ProjectCard` (Next/Image, badges, duration, tech preview, grid/list); new `ProjectModal` (dialog with image, narrative, timeline, stack, external link).
- **Page:** `app/creators/[id]/page.tsx` — category chips, grid/list toggle, modal state; hook order fixed for `notFound()`.
- **Tests:** `__tests__/project-helpers.test.ts`.

## How to test
1. Open a creator profile → Featured Work: filter categories, toggle grid/list, open Details.
2. `pnpm exec vitest run __tests__/project-helpers.test.ts`

Branch: `feature/creator-project-gallery`