### PR TITLE
feat(payments): Stripe escrow, subscriptions, webhooks, and dashboard

### DIFF
--- a/__tests__/escrow-service.test.ts
+++ b/__tests__/escrow-service.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  __resetEscrowStoreForTests,
+  computeFreelancerPayoutCents,
+  computePlatformFeeCents,
+  createEscrow,
+  attachPaymentIntent,
+  markFundedAuthorized,
+  markReleased,
+  markRefunded,
+  getEscrow,
+} from '@/lib/escrow-service'
+
+describe('escrow-service', () => {
+  beforeEach(() => {
+    __resetEscrowStoreForTests()
+  })
+
+  it('computes platform fee at 10% by default', () => {
+    expect(computePlatformFeeCents(10_000)).toBe(1000)
+    expect(computePlatformFeeCents(100)).toBe(10)
+  })
+
+  it('computes freelancer payout after fee', () => {
+    expect(computeFreelancerPayoutCents(10_000, 1000)).toBe(9000)
+  })
+
+  it('creates escrow in pending_funding', () => {
+    const e = createEscrow({
+      bountyId: 'b-1',
+      clientUserId: 'user-1',
+      amountCents: 5000,
+    })
+    expect(e.status).toBe('pending_funding')
+    expect(e.platformFeeCents).toBe(500)
+  })
+
+  it('transitions funded -> released', () => {
+    const e = createEscrow({
+      bountyId: 'b-1',
+      clientUserId: 'user-1',
+      amountCents: 2000,
+    })
+    attachPaymentIntent(e.id, 'pi_test')
+    markFundedAuthorized(e.id)
+    expect(getEscrow(e.id)?.status).toBe('funded_authorized')
+    markReleased(e.id, 'https://pay.stripe.com/receipt')
+    expect(getEscrow(e.id)?.status).toBe('released')
+    expect(getEscrow(e.id)?.receiptUrl).toBe('https://pay.stripe.com/receipt')
+  })
+
+  it('supports refund path', () => {
+    const e = createEscrow({
+      bountyId: 'b-1',
+      clientUserId: 'user-1',
+      amountCents: 2000,
+    })
+    markRefunded(e.id)
+    expect(getEscrow(e.id)?.status).toBe('refunded')
+  })
+})

--- a/__tests__/payment-validators.test.ts
+++ b/__tests__/payment-validators.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { paymentPostBodySchema } from '@/lib/payment-validators'
+
+describe('paymentPostBodySchema', () => {
+  it('accepts bounty_escrow', () => {
+    const r = paymentPostBodySchema.safeParse({
+      type: 'bounty_escrow',
+      bountyId: 'bounty-1',
+      amountCents: 5000,
+      currency: 'usd',
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects invalid amount', () => {
+    const r = paymentPostBodySchema.safeParse({
+      type: 'bounty_escrow',
+      bountyId: 'b-1',
+      amountCents: 0,
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('accepts subscription', () => {
+    const r = paymentPostBodySchema.safeParse({
+      type: 'subscription',
+      priceId: 'price_123',
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('accepts escrow_release with uuid', () => {
+    const r = paymentPostBodySchema.safeParse({
+      type: 'escrow_release',
+      escrowId: '550e8400-e29b-41d4-a716-446655440000',
+    })
+    expect(r.success).toBe(true)
+  })
+})

--- a/__tests__/stripe-webhook.test.ts
+++ b/__tests__/stripe-webhook.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type Stripe from 'stripe'
+import { processStripeWebhookEvent } from '@/app/api/webhooks/stripe/route'
+import {
+  __resetEscrowStoreForTests,
+  createEscrow,
+  attachPaymentIntent,
+  getEscrow,
+  findEscrowByPaymentIntent,
+} from '@/lib/escrow-service'
+
+describe('processStripeWebhookEvent', () => {
+  beforeEach(() => {
+    __resetEscrowStoreForTests()
+  })
+
+  it('marks escrow funded on amount_capturable_updated', async () => {
+    const e = createEscrow({
+      bountyId: 'b-1',
+      clientUserId: 'u1',
+      amountCents: 1000,
+    })
+    attachPaymentIntent(e.id, 'pi_abc')
+
+    const pi = {
+      id: 'pi_abc',
+      object: 'payment_intent',
+      status: 'requires_capture',
+      metadata: { escrowId: e.id },
+      latest_charge: null,
+    } as unknown as Stripe.PaymentIntent
+
+    const event = {
+      id: 'evt_1',
+      object: 'event',
+      type: 'payment_intent.amount_capturable_updated',
+      data: { object: pi },
+    } as Stripe.Event
+
+    await processStripeWebhookEvent(event)
+    expect(getEscrow(e.id)?.status).toBe('funded_authorized')
+  })
+
+  it('resolves escrow by payment intent id', async () => {
+    const e = createEscrow({
+      bountyId: 'b-1',
+      clientUserId: 'u1',
+      amountCents: 1000,
+    })
+    attachPaymentIntent(e.id, 'pi_xyz')
+
+    const pi = {
+      id: 'pi_xyz',
+      object: 'payment_intent',
+      status: 'requires_capture',
+      metadata: {},
+      latest_charge: null,
+    } as unknown as Stripe.PaymentIntent
+
+    await processStripeWebhookEvent({
+      type: 'payment_intent.amount_capturable_updated',
+      data: { object: pi },
+    } as Stripe.Event)
+
+    expect(findEscrowByPaymentIntent('pi_xyz')?.status).toBe('funded_authorized')
+  })
+})

--- a/app/api/payments/route.ts
+++ b/app/api/payments/route.ts
@@ -1,0 +1,204 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { getStripe, isStripeConfigured } from '@/lib/stripe'
+import {
+  createEscrow,
+  attachPaymentIntent,
+  getEscrow,
+  listEscrowsForUser,
+  markReleased,
+  markRefunded,
+} from '@/lib/escrow-service'
+import { paymentPostBodySchema } from '@/lib/payment-validators'
+import { validateRequest, formatZodErrors } from '@/lib/validators'
+
+export const runtime = 'nodejs'
+
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const escrows = listEscrowsForUser(session.user.id)
+  return NextResponse.json({
+    escrows,
+    stripeConfigured: isStripeConfigured(),
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const parsed = validateRequest(paymentPostBodySchema, body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: formatZodErrors(parsed.errors) },
+      { status: 400 },
+    )
+  }
+
+  const data = parsed.data
+
+  if (data.type === 'bounty_escrow') {
+    if (session.user.role !== 'CLIENT' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Only clients can fund bounties' }, { status: 403 })
+    }
+
+    if (!isStripeConfigured()) {
+      return NextResponse.json(
+        { error: 'Payments are not configured (missing STRIPE_SECRET_KEY)' },
+        { status: 503 },
+      )
+    }
+
+    const escrow = createEscrow({
+      bountyId: data.bountyId,
+      clientUserId: session.user.id,
+      amountCents: data.amountCents,
+      currency: data.currency,
+    })
+
+    const stripe = getStripe()
+    const pi = await stripe.paymentIntents.create({
+      amount: data.amountCents,
+      currency: data.currency,
+      capture_method: 'manual',
+      automatic_payment_methods: { enabled: true },
+      metadata: {
+        escrowId: escrow.id,
+        bountyId: data.bountyId,
+        clientUserId: session.user.id,
+        kind: 'bounty_escrow',
+      },
+    })
+
+    attachPaymentIntent(escrow.id, pi.id)
+
+    return NextResponse.json({
+      escrowId: escrow.id,
+      clientSecret: pi.client_secret,
+      publishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? null,
+      amountCents: data.amountCents,
+      currency: data.currency,
+    })
+  }
+
+  if (data.type === 'subscription') {
+    if (!isStripeConfigured()) {
+      return NextResponse.json({ error: 'Payments are not configured' }, { status: 503 })
+    }
+
+    const base = process.env.NEXTAUTH_URL ?? request.nextUrl.origin
+    const successUrl = data.successUrl ?? `${base}/dashboard/payments?session_id={CHECKOUT_SESSION_ID}`
+    const cancelUrl = data.cancelUrl ?? `${base}/dashboard/payments?canceled=1`
+
+    const stripe = getStripe()
+    const sessionCheckout = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      line_items: [{ price: data.priceId, quantity: 1 }],
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      customer_email: session.user.email ?? undefined,
+      metadata: { userId: session.user.id },
+    })
+
+    return NextResponse.json({ url: sessionCheckout.url })
+  }
+
+  if (data.type === 'escrow_release') {
+    if (session.user.role !== 'CLIENT' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const escrow = getEscrow(data.escrowId)
+    if (!escrow) {
+      return NextResponse.json({ error: 'Escrow not found' }, { status: 404 })
+    }
+    if (escrow.clientUserId !== session.user.id && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    if (escrow.status !== 'funded_authorized') {
+      return NextResponse.json({ error: 'Escrow is not in a releasable state' }, { status: 400 })
+    }
+    if (!escrow.paymentIntentId) {
+      return NextResponse.json({ error: 'Missing payment intent' }, { status: 400 })
+    }
+
+    if (!isStripeConfigured()) {
+      markReleased(escrow.id)
+      return NextResponse.json({ ok: true, escrow: getEscrow(escrow.id), mode: 'simulated' })
+    }
+
+    const stripe = getStripe()
+    const captured = await stripe.paymentIntents.capture(escrow.paymentIntentId, {
+      expand: ['latest_charge'],
+    })
+    const charge = captured.latest_charge
+    const receiptUrl =
+      typeof charge === 'object' && charge && !charge.deleted && 'receipt_url' in charge
+        ? (charge.receipt_url as string | null) ?? undefined
+        : undefined
+    markReleased(escrow.id, receiptUrl)
+
+    return NextResponse.json({ ok: true, escrow: getEscrow(escrow.id), receiptUrl })
+  }
+
+  if (data.type === 'escrow_refund') {
+    if (escrowRefundAllowed(session.user.role, session.user.id, data.escrowId) === false) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const escrow = getEscrow(data.escrowId)
+    if (!escrow) {
+      return NextResponse.json({ error: 'Escrow not found' }, { status: 404 })
+    }
+    if (escrow.status !== 'funded_authorized' && escrow.status !== 'pending_funding') {
+      return NextResponse.json({ error: 'Escrow cannot be refunded in this state' }, { status: 400 })
+    }
+
+    if (!isStripeConfigured()) {
+      markRefunded(escrow.id)
+      return NextResponse.json({ ok: true, escrow: getEscrow(escrow.id), mode: 'simulated' })
+    }
+
+    if (!escrow.paymentIntentId) {
+      markRefunded(escrow.id)
+      return NextResponse.json({ ok: true, escrow: getEscrow(escrow.id) })
+    }
+
+    const stripe = getStripe()
+    const pi = await stripe.paymentIntents.retrieve(escrow.paymentIntentId)
+    if (pi.status === 'requires_capture') {
+      await stripe.paymentIntents.cancel(escrow.paymentIntentId)
+    } else if (pi.status === 'succeeded') {
+      const chargeId = pi.latest_charge
+      if (typeof chargeId === 'string') {
+        await stripe.refunds.create({ charge: chargeId })
+      }
+    }
+
+    markRefunded(escrow.id)
+    return NextResponse.json({ ok: true, escrow: getEscrow(escrow.id) })
+  }
+
+  return NextResponse.json({ error: 'Unsupported' }, { status: 400 })
+}
+
+function escrowRefundAllowed(role: string, userId: string, escrowId: string): boolean {
+  const escrow = getEscrow(escrowId)
+  if (!escrow) return false
+  if (role === 'ADMIN') return true
+  return escrow.clientUserId === userId
+}

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server'
+import Stripe from 'stripe'
+import { getStripe, getStripeWebhookSecret } from '@/lib/stripe'
+import {
+  findEscrowByPaymentIntent,
+  getEscrow,
+  markFailed,
+  markFundedAuthorized,
+  markRefunded,
+} from '@/lib/escrow-service'
+
+export const runtime = 'nodejs'
+
+export async function POST(request: NextRequest) {
+  let secret: string
+  try {
+    secret = getStripeWebhookSecret()
+  } catch {
+    return NextResponse.json({ error: 'Webhook not configured' }, { status: 503 })
+  }
+
+  const signature = request.headers.get('stripe-signature')
+  if (!signature) {
+    return NextResponse.json({ error: 'Missing stripe-signature' }, { status: 400 })
+  }
+
+  const rawBody = await request.text()
+  let event: Stripe.Event
+  try {
+    const stripe = getStripe()
+    event = stripe.webhooks.constructEvent(rawBody, signature, secret)
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('STRIPE_SECRET_KEY')) {
+      return NextResponse.json({ error: 'Payments not configured' }, { status: 503 })
+    }
+    const message = err instanceof Error ? err.message : 'Invalid payload'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+
+  try {
+    await processStripeWebhookEvent(event)
+  } catch (e) {
+    console.error('[stripe webhook]', e)
+    return NextResponse.json({ error: 'Handler failed' }, { status: 500 })
+  }
+
+  return NextResponse.json({ received: true })
+}
+
+export async function processStripeWebhookEvent(event: Stripe.Event): Promise<void> {
+  switch (event.type) {
+    case 'payment_intent.amount_capturable_updated': {
+      const pi = event.data.object as Stripe.PaymentIntent
+      const escrowId = pi.metadata?.escrowId
+      const escrow = escrowId ? getEscrow(escrowId) : findEscrowByPaymentIntent(pi.id)
+      if (!escrow) break
+      if (pi.status === 'requires_capture' && escrow.status === 'pending_funding') {
+        const charge = pi.latest_charge
+        const receiptUrl =
+          typeof charge === 'object' && charge && 'receipt_url' in charge
+            ? (charge.receipt_url as string | null) ?? undefined
+            : undefined
+        markFundedAuthorized(escrow.id, receiptUrl)
+      }
+      break
+    }
+    case 'payment_intent.payment_failed': {
+      const pi = event.data.object as Stripe.PaymentIntent
+      const escrow = pi.metadata?.escrowId
+        ? getEscrow(pi.metadata.escrowId)
+        : findEscrowByPaymentIntent(pi.id)
+      if (escrow) {
+        markFailed(escrow.id, pi.last_payment_error?.message ?? 'Payment failed')
+      }
+      break
+    }
+    case 'payment_intent.canceled': {
+      const pi = event.data.object as Stripe.PaymentIntent
+      const escrow = pi.metadata?.escrowId
+        ? getEscrow(pi.metadata.escrowId)
+        : findEscrowByPaymentIntent(pi.id)
+      if (escrow && escrow.status === 'pending_funding') {
+        markFailed(escrow.id, 'Payment intent canceled')
+      }
+      break
+    }
+    case 'charge.refunded': {
+      const charge = event.data.object as Stripe.Charge
+      const piId = typeof charge.payment_intent === 'string' ? charge.payment_intent : charge.payment_intent?.id
+      if (!piId) break
+      const escrow = findEscrowByPaymentIntent(piId)
+      if (escrow && escrow.status !== 'refunded') {
+        markRefunded(escrow.id)
+      }
+      break
+    }
+    default:
+      break
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -232,6 +232,25 @@ export default function DashboardPage() {
               </Link>
             </CardContent>
           </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <DollarSign className="h-5 w-5" />
+                Payments & escrow
+              </CardTitle>
+              <CardDescription>
+                Fund bounties, subscriptions, and manage escrow receipts
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Link href="/dashboard/payments">
+                <Button variant="outline" className="w-full">
+                  Open payments
+                </Button>
+              </Link>
+            </CardContent>
+          </Card>
         </div>
       </main>
     </div>

--- a/app/dashboard/payments/page.tsx
+++ b/app/dashboard/payments/page.tsx
@@ -1,0 +1,306 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Header } from '@/components/header'
+import { BountyEscrowPaymentForm } from '@/components/payment-form'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { getPremiumSubscriptionPriceId } from '@/lib/payments-config'
+import type { EscrowRecord } from '@/lib/escrow-service'
+import { ExternalLink, CreditCard, RefreshCw } from 'lucide-react'
+import { Label } from '@/components/ui/label'
+
+export default function DashboardPaymentsPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [escrows, setEscrows] = useState<EscrowRecord[]>([])
+  const [stripeConfigured, setStripeConfigured] = useState(true)
+  const [loading, setLoading] = useState(true)
+  const [actionId, setActionId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/payments', { credentials: 'include' })
+      const data = (await res.json()) as {
+        escrows?: EscrowRecord[]
+        stripeConfigured?: boolean
+        error?: string
+      }
+      if (!res.ok) {
+        setError(data.error ?? 'Failed to load payments')
+        return
+      }
+      setEscrows(data.escrows ?? [])
+      setStripeConfigured(data.stripeConfigured ?? false)
+    } catch {
+      setError('Failed to load payments')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/auth/login')
+    }
+  }, [status, router])
+
+  useEffect(() => {
+    if (status === 'authenticated') {
+      void load()
+    }
+  }, [status, load])
+
+  async function postPayment(body: object) {
+    setError(null)
+    const res = await fetch('/api/payments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(body),
+    })
+    const data = (await res.json().catch(() => ({}))) as { error?: string }
+    if (!res.ok) {
+      setError(data.error ?? 'Request failed')
+      return
+    }
+    await load()
+  }
+
+  async function releaseEscrow(id: string) {
+    setActionId(id)
+    try {
+      await postPayment({ type: 'escrow_release', escrowId: id })
+    } finally {
+      setActionId(null)
+    }
+  }
+
+  async function refundEscrow(id: string) {
+    setActionId(id)
+    try {
+      await postPayment({ type: 'escrow_refund', escrowId: id })
+    } finally {
+      setActionId(null)
+    }
+  }
+
+  async function startSubscription() {
+    const priceId = getPremiumSubscriptionPriceId()
+    if (!priceId) {
+      setError('Subscription price is not configured')
+      return
+    }
+    setError(null)
+    const res = await fetch('/api/payments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ type: 'subscription', priceId }),
+    })
+    const data = (await res.json().catch(() => ({}))) as { url?: string | null; error?: string }
+    if (!res.ok || !data.url) {
+      setError(data.error ?? 'Could not start checkout')
+      return
+    }
+    window.location.href = data.url
+  }
+
+  if (status === 'loading' || (status === 'authenticated' && loading && escrows.length === 0 && !error)) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Header />
+        <div className="mx-auto max-w-4xl px-4 py-8">
+          <Skeleton className="mb-6 h-10 w-64" />
+          <Skeleton className="h-48 w-full" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!session) {
+    return null
+  }
+
+  const role = session.user.role
+  const isClient = role === 'CLIENT' || role === 'ADMIN'
+  const premiumPriceId = getPremiumSubscriptionPriceId()
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main className="mx-auto max-w-4xl px-4 py-8">
+        <div className="mb-8 flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold">Payments & escrow</h1>
+            <p className="text-muted-foreground">
+              Fund bounties, manage escrow, and view receipts. Card data is handled by the payment provider
+              (PCI scope reduction).
+            </p>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => void load()}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Refresh
+          </Button>
+        </div>
+
+        {!stripeConfigured ? (
+          <Card className="mb-8 border-amber-500/40 bg-amber-500/5">
+            <CardHeader>
+              <CardTitle className="text-amber-700 dark:text-amber-400">Payments not configured</CardTitle>
+              <CardDescription>
+                Set <code className="rounded bg-muted px-1">STRIPE_SECRET_KEY</code> and{' '}
+                <code className="rounded bg-muted px-1">NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY</code> for live
+                processing. Escrow APIs remain available for development once keys are present.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        ) : null}
+
+        {error ? (
+          <p className="mb-4 text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        {isClient ? (
+          <Card className="mb-8">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <CreditCard className="h-5 w-5" />
+                Fund a bounty (escrow)
+              </CardTitle>
+              <CardDescription>
+                Enter an amount to authorize funds. Money is captured when you release escrow after approving
+                completed work.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="mb-4 text-sm text-muted-foreground">
+                Use a bounty id from{' '}
+                <Link href="/bounties" className="underline">
+                  bounties
+                </Link>
+                . Demo ids like <code className="rounded bg-muted px-1">bounty-1</code> work for testing.
+              </p>
+              <DashboardFundForm onFunded={() => void load()} />
+            </CardContent>
+          </Card>
+        ) : null}
+
+        <Card className="mb-8">
+          <CardHeader>
+            <CardTitle>Premium subscription</CardTitle>
+            <CardDescription>
+              Unlock premium marketplace features when a subscription price is configured.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap items-center gap-4">
+            {premiumPriceId ? (
+              <Button onClick={() => void startSubscription()}>Subscribe</Button>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Set <code className="rounded bg-muted px-1">NEXT_PUBLIC_STRIPE_PRICE_PREMIUM_MONTHLY</code> to
+                your Stripe Price id to enable checkout.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Payment history</CardTitle>
+            <CardDescription>Escrow records and receipt links when available.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {escrows.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No escrow activity yet.</p>
+            ) : (
+              <ul className="space-y-4">
+                {escrows.map((e) => (
+                  <li
+                    key={e.id}
+                    className="flex flex-col gap-3 rounded-lg border border-border p-4 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-mono text-xs text-muted-foreground">{e.id}</span>
+                        <Badge variant="secondary">{e.status}</Badge>
+                      </div>
+                      <p className="mt-1 text-sm">
+                        Bounty <span className="font-medium">{e.bountyId}</span> ·{' '}
+                        {(e.amountCents / 100).toFixed(2)} {e.currency.toUpperCase()} · Fee{' '}
+                        {(e.platformFeeCents / 100).toFixed(2)}
+                      </p>
+                      {e.receiptUrl ? (
+                        <a
+                          href={e.receiptUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-2 inline-flex items-center gap-1 text-sm text-primary underline"
+                        >
+                          Receipt <ExternalLink className="h-3 w-3" />
+                        </a>
+                      ) : null}
+                      {e.failureMessage ? (
+                        <p className="mt-1 text-sm text-destructive">{e.failureMessage}</p>
+                      ) : null}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {isClient && e.status === 'funded_authorized' ? (
+                        <>
+                          <Button
+                            size="sm"
+                            onClick={() => void releaseEscrow(e.id)}
+                            disabled={actionId === e.id}
+                          >
+                            Release & capture
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => void refundEscrow(e.id)}
+                            disabled={actionId === e.id}
+                          >
+                            Refund
+                          </Button>
+                        </>
+                      ) : null}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  )
+}
+
+function DashboardFundForm({ onFunded }: { onFunded: () => void }) {
+  const [bountyId, setBountyId] = useState('bounty-1')
+  return (
+    <div className="space-y-4">
+      <div>
+        <Label htmlFor="fund-bounty-id">Bounty ID</Label>
+        <input
+          id="fund-bounty-id"
+          className="border-input bg-background mt-2 flex h-9 w-full max-w-md rounded-md border px-3 py-1 text-sm"
+          value={bountyId}
+          onChange={(e) => setBountyId(e.target.value)}
+          placeholder="bounty id"
+        />
+      </div>
+      <BountyEscrowPaymentForm bountyId={bountyId} defaultAmountDollars="50" onFunded={onFunded} />
+    </div>
+  )
+}

--- a/components/payment-form.tsx
+++ b/components/payment-form.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { Elements, PaymentElement, useStripe, useElements } from '@stripe/react-stripe-js'
+import { loadStripe } from '@stripe/stripe-js'
+import type { StripeElementsOptions } from '@stripe/stripe-js'
+import { useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+type Props = {
+  bountyId: string
+  defaultAmountDollars?: string
+  /** Used by Stripe when a payment method requires a redirect. */
+  returnUrl?: string
+  onFunded?: (escrowId: string) => void
+}
+
+function EscrowCheckoutForm({
+  returnUrl,
+  onSuccess,
+}: {
+  returnUrl: string
+  onSuccess: () => void
+}) {
+  const stripe = useStripe()
+  const elements = useElements()
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!stripe || !elements) return
+    setBusy(true)
+    setError(null)
+    const { error: err } = await stripe.confirmPayment({
+      elements,
+      confirmParams: { return_url: returnUrl },
+      redirect: 'if_required',
+    })
+    if (err) {
+      setError(err.message ?? 'Payment failed')
+      setBusy(false)
+      return
+    }
+    onSuccess()
+    setBusy(false)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <PaymentElement />
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <Button type="submit" disabled={!stripe || busy}>
+        {busy ? 'Processing…' : 'Pay and authorize escrow'}
+      </Button>
+    </form>
+  )
+}
+
+export function BountyEscrowPaymentForm({
+  bountyId,
+  defaultAmountDollars = '',
+  returnUrl,
+  onFunded,
+}: Props) {
+  const [amount, setAmount] = useState(defaultAmountDollars)
+  const [clientSecret, setClientSecret] = useState<string | null>(null)
+  const [publishableKey, setPublishableKey] = useState<string | null>(null)
+  const [escrowId, setEscrowId] = useState<string | null>(null)
+  const [phase, setPhase] = useState<'input' | 'pay' | 'done'>('input')
+  const [message, setMessage] = useState<string | null>(null)
+
+  const stripePromise = useMemo(() => {
+    if (!publishableKey) return null
+    return loadStripe(publishableKey)
+  }, [publishableKey])
+
+  const resolvedReturnUrl =
+    returnUrl ?? (typeof window !== 'undefined' ? window.location.href : '')
+
+  async function createIntent() {
+    const dollars = parseFloat(amount)
+    if (!Number.isFinite(dollars) || dollars <= 0) {
+      setMessage('Enter a valid amount')
+      return
+    }
+    const amountCents = Math.round(dollars * 100)
+    setMessage(null)
+    const res = await fetch('/api/payments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        type: 'bounty_escrow',
+        bountyId,
+        amountCents,
+        currency: 'usd',
+      }),
+    })
+    const data = (await res.json().catch(() => ({}))) as {
+      error?: string
+      clientSecret?: string
+      publishableKey?: string | null
+      escrowId?: string
+    }
+    if (!res.ok) {
+      setMessage(data.error ?? 'Could not start payment')
+      return
+    }
+    if (!data.clientSecret || !data.publishableKey) {
+      setMessage('Payment provider returned an incomplete response')
+      return
+    }
+    setClientSecret(data.clientSecret)
+    setPublishableKey(data.publishableKey)
+    setEscrowId(data.escrowId ?? null)
+    setPhase('pay')
+  }
+
+  if (phase === 'done') {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Payment authorized. Funds are held in escrow until you release them after work is approved.
+      </p>
+    )
+  }
+
+  if (phase === 'pay' && clientSecret && stripePromise) {
+    const options: StripeElementsOptions = {
+      clientSecret,
+      appearance: { theme: 'stripe' },
+    }
+    return (
+      <Elements stripe={stripePromise} options={options}>
+        <EscrowCheckoutForm
+          returnUrl={resolvedReturnUrl}
+          onSuccess={() => {
+            setPhase('done')
+            if (escrowId) onFunded?.(escrowId)
+          }}
+        />
+      </Elements>
+    )
+  }
+
+  return (
+    <div className="max-w-md space-y-4">
+      <div>
+        <Label htmlFor="escrow-amount">Amount (USD)</Label>
+        <Input
+          id="escrow-amount"
+          type="number"
+          min="0.01"
+          step="0.01"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+      </div>
+      <Button type="button" onClick={createIntent}>
+        Continue to secure payment
+      </Button>
+      {message ? <p className="text-sm text-destructive">{message}</p> : null}
+    </div>
+  )
+}

--- a/lib/escrow-service.ts
+++ b/lib/escrow-service.ts
@@ -1,0 +1,154 @@
+/**
+ * Bounty escrow state machine (Stripe PaymentIntents with `capture_method: manual`).
+ * Funds are authorized then captured on release, or cancelled/refunded.
+ * In-memory store suitable for demo; persist to DB for production.
+ */
+
+export type EscrowStatus =
+  | 'pending_funding'
+  | 'funded_authorized'
+  | 'released'
+  | 'refunded'
+  | 'failed'
+
+export interface EscrowRecord {
+  id: string
+  bountyId: string
+  clientUserId: string
+  freelancerUserId?: string
+  amountCents: number
+  currency: string
+  /** Platform fee in minor units (e.g. cents). */
+  platformFeeCents: number
+  paymentIntentId?: string
+  status: EscrowStatus
+  receiptUrl?: string
+  failureMessage?: string
+  createdAt: string
+  updatedAt: string
+}
+
+type Store = {
+  escrows: Map<string, EscrowRecord>
+  byPaymentIntent: Map<string, string>
+}
+
+function getStore(): Store {
+  const g = globalThis as unknown as { __escrowStore?: Store }
+  if (!g.__escrowStore) {
+    g.__escrowStore = {
+      escrows: new Map(),
+      byPaymentIntent: new Map(),
+    }
+  }
+  return g.__escrowStore
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+/** Default platform fee: 10% of bounty amount (basis points style via integer math). */
+export function computePlatformFeeCents(amountCents: number, feeBps: number = 1000): number {
+  if (amountCents <= 0) return 0
+  return Math.round((amountCents * feeBps) / 10000)
+}
+
+export function computeFreelancerPayoutCents(amountCents: number, platformFeeCents: number): number {
+  return Math.max(0, amountCents - platformFeeCents)
+}
+
+export function createEscrow(params: {
+  bountyId: string
+  clientUserId: string
+  amountCents: number
+  currency?: string
+  feeBps?: number
+}): EscrowRecord {
+  const currency = (params.currency ?? 'usd').toLowerCase()
+  const platformFeeCents = computePlatformFeeCents(params.amountCents, params.feeBps ?? 1000)
+  const id = crypto.randomUUID()
+  const ts = nowIso()
+  const record: EscrowRecord = {
+    id,
+    bountyId: params.bountyId,
+    clientUserId: params.clientUserId,
+    amountCents: params.amountCents,
+    currency,
+    platformFeeCents,
+    status: 'pending_funding',
+    createdAt: ts,
+    updatedAt: ts,
+  }
+  getStore().escrows.set(id, record)
+  return record
+}
+
+export function getEscrow(id: string): EscrowRecord | undefined {
+  return getStore().escrows.get(id)
+}
+
+export function attachPaymentIntent(escrowId: string, paymentIntentId: string): EscrowRecord | null {
+  const store = getStore()
+  const e = store.escrows.get(escrowId)
+  if (!e) return null
+  e.paymentIntentId = paymentIntentId
+  e.updatedAt = nowIso()
+  store.byPaymentIntent.set(paymentIntentId, escrowId)
+  return e
+}
+
+export function findEscrowByPaymentIntent(paymentIntentId: string): EscrowRecord | undefined {
+  const id = getStore().byPaymentIntent.get(paymentIntentId)
+  if (!id) return undefined
+  return getStore().escrows.get(id)
+}
+
+export function markFundedAuthorized(escrowId: string, receiptUrl?: string): EscrowRecord | null {
+  const e = getStore().escrows.get(escrowId)
+  if (!e) return null
+  e.status = 'funded_authorized'
+  e.receiptUrl = receiptUrl ?? e.receiptUrl
+  e.updatedAt = nowIso()
+  return e
+}
+
+export function markReleased(escrowId: string, receiptUrl?: string): EscrowRecord | null {
+  const e = getStore().escrows.get(escrowId)
+  if (!e) return null
+  e.status = 'released'
+  e.receiptUrl = receiptUrl ?? e.receiptUrl
+  e.updatedAt = nowIso()
+  return e
+}
+
+export function markRefunded(escrowId: string): EscrowRecord | null {
+  const e = getStore().escrows.get(escrowId)
+  if (!e) return null
+  e.status = 'refunded'
+  e.updatedAt = nowIso()
+  return e
+}
+
+export function markFailed(escrowId: string, message?: string): EscrowRecord | null {
+  const e = getStore().escrows.get(escrowId)
+  if (!e) return null
+  e.status = 'failed'
+  e.failureMessage = message
+  e.updatedAt = nowIso()
+  return e
+}
+
+export function listEscrowsForUser(userId: string): EscrowRecord[] {
+  return Array.from(getStore().escrows.values())
+    .filter((e) => e.clientUserId === userId || e.freelancerUserId === userId)
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+}
+
+export function __resetEscrowStoreForTests(): void {
+  const g = globalThis as unknown as { __escrowStore?: Store }
+  g.__escrowStore = {
+    escrows: new Map(),
+    byPaymentIntent: new Map(),
+  }
+}

--- a/lib/payment-validators.ts
+++ b/lib/payment-validators.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod'
+
+export const bountyEscrowPaymentSchema = z.object({
+  type: z.literal('bounty_escrow'),
+  bountyId: z.string().min(1).max(128),
+  amountCents: z.number().int().positive().max(99_999_999),
+  currency: z.string().length(3).optional().default('usd'),
+})
+
+export const subscriptionCheckoutSchema = z.object({
+  type: z.literal('subscription'),
+  priceId: z.string().min(1).max(128),
+  successUrl: z.string().url().optional(),
+  cancelUrl: z.string().url().optional(),
+})
+
+export const escrowReleaseSchema = z.object({
+  type: z.literal('escrow_release'),
+  escrowId: z.string().uuid(),
+})
+
+export const escrowRefundSchema = z.object({
+  type: z.literal('escrow_refund'),
+  escrowId: z.string().uuid(),
+})
+
+export const paymentPostBodySchema = z.discriminatedUnion('type', [
+  bountyEscrowPaymentSchema,
+  subscriptionCheckoutSchema,
+  escrowReleaseSchema,
+  escrowRefundSchema,
+])
+
+export type PaymentPostBody = z.infer<typeof paymentPostBodySchema>

--- a/lib/payments-config.ts
+++ b/lib/payments-config.ts
@@ -1,0 +1,5 @@
+/** Client-safe env (no server Stripe SDK). Use for UI that reads subscription Price ids. */
+export function getPremiumSubscriptionPriceId(): string | null {
+  const id = process.env.NEXT_PUBLIC_STRIPE_PRICE_PREMIUM_MONTHLY
+  return id?.trim() ? id : null
+}

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,0 +1,38 @@
+import Stripe from 'stripe'
+
+/**
+ * Server-side Stripe client. Requires `STRIPE_SECRET_KEY`.
+ * Card data never touches this server — use Stripe.js / Elements or Checkout on the client (PCI DSS scope reduction).
+ */
+let stripeSingleton: Stripe | null = null
+
+export function getStripe(): Stripe {
+  const key = process.env.STRIPE_SECRET_KEY
+  if (!key) {
+    throw new Error('STRIPE_SECRET_KEY is not configured')
+  }
+  if (!stripeSingleton) {
+    stripeSingleton = new Stripe(key)
+  }
+  return stripeSingleton
+}
+
+export function isStripeConfigured(): boolean {
+  return Boolean(process.env.STRIPE_SECRET_KEY?.trim())
+}
+
+export function getStripePublishableKey(): string {
+  const k = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  if (!k?.trim()) {
+    throw new Error('NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY is not configured')
+  }
+  return k
+}
+
+export function getStripeWebhookSecret(): string {
+  const s = process.env.STRIPE_WEBHOOK_SECRET
+  if (!s?.trim()) {
+    throw new Error('STRIPE_WEBHOOK_SECRET is not configured')
+  }
+  return s
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "@radix-ui/react-toggle": "1.1.10",
     "@radix-ui/react-toggle-group": "1.1.11",
     "@radix-ui/react-tooltip": "1.2.8",
+    "@stripe/react-stripe-js": "^6.0.0",
+    "@stripe/stripe-js": "^9.0.0",
     "@supabase/supabase-js": "^2.47.0",
     "@vercel/analytics": "1.6.1",
     "autoprefixer": "^10.4.20",
@@ -90,6 +92,7 @@
     "recharts": "2.15.0",
     "sharp": "^0.33.5",
     "sonner": "^1.7.1",
+    "stripe": "^21.0.1",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
     "zod": "^3.24.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,12 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@stripe/react-stripe-js':
+        specifier: ^6.0.0
+        version: 6.0.0(@stripe/stripe-js@9.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@stripe/stripe-js':
+        specifier: ^9.0.0
+        version: 9.0.0
       '@supabase/supabase-js':
         specifier: ^2.47.0
         version: 2.100.0
@@ -179,6 +185,9 @@ importers:
       sonner:
         specifier: ^1.7.1
         version: 1.7.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      stripe:
+        specifier: ^21.0.1
+        version: 21.0.1(@types/node@22.19.11)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.4.0
@@ -830,183 +839,155 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -1101,28 +1082,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -1879,79 +1856,66 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -2205,6 +2169,17 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@stripe/react-stripe-js@6.0.0':
+    resolution: {integrity: sha512-vJW37/uyRAJEkD3YKCh3aISmMIMrQGR3ViVBkUVQDB7CqbRCnOUyhwDe8zKg+d6K8V4d0MUcthcQdHL4meqG7A==}
+    peerDependencies:
+      '@stripe/stripe-js': '>=9.0.0 <10.0.0'
+      react: '>=16.8.0 <20.0.0'
+      react-dom: '>=16.8.0 <20.0.0'
+
+  '@stripe/stripe-js@9.0.0':
+    resolution: {integrity: sha512-UtUK7LFglQSNVIOwcRBaxfzq4wkfU8CT2f2uQVEeu65jTP6wicxFshYdYCke9Tfd0PCxhOe/b8rwJjr5EiDCfQ==}
+    engines: {node: '>=12.16'}
+
   '@supabase/auth-js@2.100.0':
     resolution: {integrity: sha512-pdT3ye3UVRN1Cg0wom6BmyY+XTtp5DiJaYnPi6j8ht5i8Lq8kfqxJMJz9GI9YDKk3w1nhGOPnh6Qz5qpyYm+1w==}
     engines: {node: '>=20.0.0'}
@@ -2273,28 +2248,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
     resolution: {integrity: sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
     resolution: {integrity: sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.0':
     resolution: {integrity: sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.0':
     resolution: {integrity: sha512-xuDjhAsFdUuFP5W9Ze4k/o4AskUtI8bcAGU4puTYprr89QaYFmhYOPfP+d1pH+k9ets6RoE23BXZM1X1jJqoyw==}
@@ -2510,49 +2481,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3789,28 +3752,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -4505,6 +4464,15 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  stripe@21.0.1:
+    resolution: {integrity: sha512-ocv0j7dWttswDWV2XL/kb6+yiLpDXNXL3RQAOB5OB2kr49z0cEatdQc12+zP/j5nrXk6rAsT4N3y/NUvBbK7Pw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   strnum@2.2.2:
     resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
@@ -7061,6 +7029,15 @@ snapshots:
       tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@stripe/react-stripe-js@6.0.0(@stripe/stripe-js@9.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@stripe/stripe-js': 9.0.0
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@stripe/stripe-js@9.0.0': {}
 
   '@supabase/auth-js@2.100.0':
     dependencies:
@@ -9629,6 +9606,10 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  stripe@21.0.1(@types/node@22.19.11):
+    optionalDependencies:
+      '@types/node': 22.19.11
 
   strnum@2.2.2: {}
 


### PR DESCRIPTION
## Summary
Adds Stripe-backed payments for bounty escrow (manual capture), subscription checkout, a signed webhook handler, a client payment form (Payment Element), and a dashboard page for history, receipts, release, and refunds. Card data stays on Stripe (PCI scope reduction).
closes #19 
## Changes
- `lib/stripe.ts` — server Stripe client, webhook secret helper
- `lib/escrow-service.ts` — in-memory escrow state machine (demo; replace with DB for production)
- `lib/payment-validators.ts` — Zod schemas for payment POST bodies
- `lib/payments-config.ts` — client-safe subscription price id (`NEXT_PUBLIC_*`)
- `app/api/payments/route.ts` — create PI / Checkout session; release (capture) and refund
- `app/api/webhooks/stripe/route.ts` — verify signatures; PI lifecycle + refunds
- `components/payment-form.tsx` — `BountyEscrowPaymentForm` (Stripe.js Elements)
- `app/dashboard/payments/page.tsx` — escrow list, receipts, release/refund, subscription CTA
- `app/dashboard/page.tsx` — link to `/dashboard/payments`
- Tests: escrow math, validators, webhook event handling

## Environment
- `STRIPE_SECRET_KEY`
- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
- `STRIPE_WEBHOOK_SECRET` (endpoint: `/api/webhooks/stripe`)
- Optional: `NEXT_PUBLIC_STRIPE_PRICE_PREMIUM_MONTHLY`

## Testing
- `pnpm run frontend:orbit-check`
- `pnpm exec vitest run`

## Notes
- Escrow capture settles to the **platform** Stripe account; freelancer bank payouts would need **Stripe Connect** (or similar) as a follow-up.
- No standalone `Stripe*.md` docs per team policy (stablecoin migration planned).

## Checklist
- [ ] Secrets configured in deployment environment
- [ ] Webhook URL registered in Stripe Dashboard (or Stripe CLI for local)