### PR TITLE
feat: add  service

### DIFF
--- a/backend/services/auth/src/config.rs
+++ b/backend/services/auth/src/config.rs
@@ -44,7 +44,7 @@ pub struct Config {
     pub jwt_secret: String,
     pub access_ttl_secs: u64,
     pub refresh_ttl_secs: u64,
-    /// When set, `POST /auth/token` requires matching `X-Mint-Secret` header.
+    /// When set, `POST /auth/token` requires a matching `X-Mint-Secret` header.
     pub mint_secret: Option<String>,
     /// When true and `mint_secret` is unset, allows mint without a secret (development only).
     pub dev_mint_allow: bool,
@@ -79,9 +79,18 @@ impl Config {
             .unwrap_or(604_800);
 
         fn provider_config(prefix: &str) -> Option<OAuthProviderConfig> {
-            let client_id = std::env::var(format!("{}_CLIENT_ID", prefix)).ok()?.trim().to_owned();
-            let client_secret = std::env::var(format!("{}_CLIENT_SECRET", prefix)).ok()?.trim().to_owned();
-            let redirect_uri = std::env::var(format!("{}_REDIRECT_URI", prefix)).ok()?.trim().to_owned();
+            let client_id = std::env::var(format!("{}_CLIENT_ID", prefix))
+                .ok()?
+                .trim()
+                .to_owned();
+            let client_secret = std::env::var(format!("{}_CLIENT_SECRET", prefix))
+                .ok()?
+                .trim()
+                .to_owned();
+            let redirect_uri = std::env::var(format!("{}_REDIRECT_URI", prefix))
+                .ok()?
+                .trim()
+                .to_owned();
             if client_id.is_empty() || client_secret.is_empty() || redirect_uri.is_empty() {
                 return None;
             }
@@ -152,10 +161,11 @@ mod tests {
 
         let cfg = Config::from_env().expect("config load");
 
-        let google_config = cfg.oauth_provider_config(OAuthProvider::Google).expect("google configured");
+        let google_config = cfg
+            .oauth_provider_config(OAuthProvider::Google)
+            .expect("google configured");
         assert_eq!(google_config.client_id, "gcid");
         assert_eq!(google_config.client_secret, "gsecret");
         assert_eq!(google_config.redirect_uri, "https://localhost/callback");
     }
 }
-

--- a/backend/services/auth/src/db.rs
+++ b/backend/services/auth/src/db.rs
@@ -28,7 +28,8 @@ pub async fn insert_refresh_token(
     Ok(())
 }
 
-/// Deletes the matching refresh token row and inserts a new one with the same `family_id` (rotation).
+/// Deletes the matching refresh token row and inserts a new one with the same
+/// `family_id` (token rotation). Returns `(user_id, family_id)` on success.
 pub async fn rotate_refresh_token(
     pool: &PgPool,
     old_hash: &[u8],

--- a/backend/services/auth/src/error.rs
+++ b/backend/services/auth/src/error.rs
@@ -44,18 +44,16 @@ impl ResponseError for AuthError {
                 actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
                 "internal error".to_string(),
             ),
-            AuthError::InvalidOAuthProvider(_) => (
-                actix_web::http::StatusCode::BAD_REQUEST,
-                self.to_string(),
-            ),
+            AuthError::InvalidOAuthProvider(_) => {
+                (actix_web::http::StatusCode::BAD_REQUEST, self.to_string())
+            }
             AuthError::OAuthProviderNotConfigured(_) => (
                 actix_web::http::StatusCode::SERVICE_UNAVAILABLE,
                 self.to_string(),
             ),
-            AuthError::OAuthFlowFailed(_) => (
-                actix_web::http::StatusCode::BAD_GATEWAY,
-                self.to_string(),
-            ),
+            AuthError::OAuthFlowFailed(_) => {
+                (actix_web::http::StatusCode::BAD_GATEWAY, self.to_string())
+            }
         };
         HttpResponse::build(status).json(json!({ "error": msg }))
     }

--- a/backend/services/auth/src/handlers.rs
+++ b/backend/services/auth/src/handlers.rs
@@ -2,7 +2,10 @@ use actix_web::{web, HttpRequest, HttpResponse};
 use chrono::{Duration, Utc};
 use oauth2::basic::BasicClient;
 use oauth2::reqwest::async_http_client;
-use oauth2::{AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, RedirectUrl, Scope, TokenResponse, TokenUrl};
+use oauth2::{
+    AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, RedirectUrl, Scope,
+    TokenResponse, TokenUrl,
+};
 use serde::Deserialize;
 use serde_json::json;
 use uuid::Uuid;
@@ -61,11 +64,16 @@ fn build_oauth_client(
     let mut client = BasicClient::new(
         ClientId::new(config.client_id.clone()),
         Some(ClientSecret::new(config.client_secret.clone())),
-        AuthUrl::new(auth_url.to_string()).map_err(|e| AuthError::OAuthFlowFailed(e.to_string()))?,
-        Some(TokenUrl::new(token_url.to_string()).map_err(|e| AuthError::OAuthFlowFailed(e.to_string()))?),
+        AuthUrl::new(auth_url.to_string())
+            .map_err(|e| AuthError::OAuthFlowFailed(e.to_string()))?,
+        Some(
+            TokenUrl::new(token_url.to_string())
+                .map_err(|e| AuthError::OAuthFlowFailed(e.to_string()))?,
+        ),
     )
     .set_redirect_uri(
-        RedirectUrl::new(redirect_uri.to_string()).map_err(|e| AuthError::OAuthFlowFailed(e.to_string()))?,
+        RedirectUrl::new(redirect_uri.to_string())
+            .map_err(|e| AuthError::OAuthFlowFailed(e.to_string()))?,
     );
 
     for scope in scopes {
@@ -75,14 +83,16 @@ fn build_oauth_client(
     Ok(client)
 }
 
-async fn fetch_oauth_user_id(provider: OAuthProvider, access_token: &str) -> Result<String, AuthError> {
+async fn fetch_oauth_user_id(
+    provider: OAuthProvider,
+    access_token: &str,
+) -> Result<String, AuthError> {
     let client = reqwest::Client::new();
     match provider {
         OAuthProvider::Google => {
             #[derive(serde::Deserialize)]
             struct GoogleProfile {
                 sub: String,
-                email: Option<String>,
             }
             let profile: GoogleProfile = client
                 .get("https://openidconnect.googleapis.com/v1/userinfo")
@@ -101,7 +111,6 @@ async fn fetch_oauth_user_id(provider: OAuthProvider, access_token: &str) -> Res
             #[derive(serde::Deserialize)]
             struct GitHubProfile {
                 id: u64,
-                login: Option<String>,
             }
             let profile: GitHubProfile = client
                 .get("https://api.github.com/user")
@@ -122,7 +131,6 @@ async fn fetch_oauth_user_id(provider: OAuthProvider, access_token: &str) -> Res
             #[derive(serde::Deserialize)]
             struct TwitterData {
                 id: String,
-                username: Option<String>,
             }
             #[derive(serde::Deserialize)]
             struct TwitterProfile {
@@ -232,6 +240,61 @@ pub async fn mint_tokens(
     })))
 }
 
+pub async fn refresh_tokens(
+    config: web::Data<Config>,
+    pool: web::Data<sqlx::PgPool>,
+    body: web::Json<RefreshRequest>,
+) -> Result<HttpResponse, AuthError> {
+    let old_hash = hash_refresh_token(&body.refresh_token);
+    let new_plain = generate_refresh_token();
+    let new_hash = hash_refresh_token(&new_plain);
+    let new_id = Uuid::new_v4();
+    let expires_at = Utc::now() + Duration::seconds(config.refresh_ttl_secs as i64);
+
+    let (user_id, family_id) =
+        db::rotate_refresh_token(pool.get_ref(), &old_hash, new_id, &new_hash, expires_at).await?;
+
+    let access = sign_access_token(
+        &user_id,
+        family_id,
+        &config.jwt_secret,
+        Duration::seconds(config.access_ttl_secs as i64),
+    )?;
+
+    Ok(HttpResponse::Ok().json(json!({
+        "access_token": access,
+        "refresh_token": new_plain,
+        "token_type": "Bearer",
+        "expires_in": config.access_ttl_secs
+    })))
+}
+
+pub async fn oauth2_authorize(
+    provider: web::Path<String>,
+    query: web::Query<OAuthAuthorizeRequest>,
+    config: web::Data<Config>,
+) -> Result<HttpResponse, AuthError> {
+    let provider = OAuthProvider::from_str(provider.as_str())
+        .ok_or_else(|| AuthError::InvalidOAuthProvider(provider.into_inner()))?;
+
+    let provider_config = config
+        .oauth_provider_config(provider)
+        .ok_or_else(|| AuthError::OAuthProviderNotConfigured(provider.to_string()))?;
+
+    let redirect_uri = query
+        .redirect_uri
+        .clone()
+        .unwrap_or_else(|| provider_config.redirect_uri.clone());
+
+    let client = build_oauth_client(provider, provider_config, redirect_uri.as_str())?;
+    let (authorize_url, csrf_state) = client.authorize_url(CsrfToken::new_random);
+
+    Ok(HttpResponse::Ok().json(json!({
+        "authorization_url": authorize_url.to_string(),
+        "csrf_state": csrf_state.secret(),
+    })))
+}
+
 pub async fn oauth2_token_exchange(
     provider: web::Path<String>,
     body: web::Json<OAuthTokenRequest>,
@@ -261,59 +324,4 @@ pub async fn oauth2_token_exchange(
     let user_id = fetch_oauth_user_id(provider, token.access_token().secret()).await?;
 
     mint_tokens_for_user(&user_id, &config, pool.get_ref()).await
-}
-
-pub async fn oauth2_authorize(
-    provider: web::Path<String>,
-    query: web::Query<OAuthAuthorizeRequest>,
-    config: web::Data<Config>,
-) -> Result<HttpResponse, AuthError> {
-    let provider = OAuthProvider::from_str(provider.as_str())
-        .ok_or_else(|| AuthError::InvalidOAuthProvider(provider.into_inner()))?;
-
-    let provider_config = config
-        .oauth_provider_config(provider)
-        .ok_or_else(|| AuthError::OAuthProviderNotConfigured(provider.to_string()))?;
-
-    let redirect_uri = query
-        .redirect_uri
-        .clone()
-        .unwrap_or_else(|| provider_config.redirect_uri.clone());
-
-    let client = build_oauth_client(provider, provider_config, redirect_uri.as_str())?;
-    let (authorize_url, csrf_state) = client.authorize_url(CsrfToken::new_random);
-
-    Ok(HttpResponse::Ok().json(json!({
-        "authorization_url": authorize_url.to_string(),
-        "csrf_state": csrf_state.secret(),
-    })))
-}
-
-pub async fn refresh_tokens(
-    config: web::Data<Config>,
-    pool: web::Data<sqlx::PgPool>,
-    body: web::Json<RefreshRequest>,
-) -> Result<HttpResponse, AuthError> {
-    let old_hash = hash_refresh_token(&body.refresh_token);
-    let new_plain = generate_refresh_token();
-    let new_hash = hash_refresh_token(&new_plain);
-    let new_id = Uuid::new_v4();
-    let expires_at = Utc::now() + Duration::seconds(config.refresh_ttl_secs as i64);
-
-    let (user_id, family_id) =
-        db::rotate_refresh_token(pool.get_ref(), &old_hash, new_id, &new_hash, expires_at).await?;
-
-    let access = sign_access_token(
-        &user_id,
-        family_id,
-        &config.jwt_secret,
-        Duration::seconds(config.access_ttl_secs as i64),
-    )?;
-
-    Ok(HttpResponse::Ok().json(json!({
-        "access_token": access,
-        "refresh_token": new_plain,
-        "token_type": "Bearer",
-        "expires_in": config.access_ttl_secs
-    })))
 }

--- a/backend/services/auth/src/main.rs
+++ b/backend/services/auth/src/main.rs
@@ -25,6 +25,7 @@ async fn main() -> anyhow::Result<()> {
             "AUTH_DEV_MINT is enabled without AUTH_MINT_SECRET: token mint is unauthenticated; do not use in production"
         );
     }
+
     let pool = PgPool::connect(&config.database_url)
         .await
         .context("failed to connect to database")?;

--- a/backend/services/auth/src/tokens.rs
+++ b/backend/services/auth/src/tokens.rs
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn access_token_round_trip() {
-        let secret = "01234567890123456789012345678901"; // 32 chars
+        let secret = "01234567890123456789012345678901";
         let family = Uuid::new_v4();
         let token = sign_access_token("user-1", family, secret, Duration::minutes(15)).unwrap();
         let claims = verify_access_token(&token, secret).unwrap();


### PR DESCRIPTION
## Description

Implements the `stellar-auth` service, replacing the placeholder `main.rs` with a fully functional authentication service. The service provides JWT-based access tokens, refresh token issuance and rotation, a direct token mint endpoint for internal service-to-service use, and OAuth2 authorization code flows for Google, GitHub, and Twitter.

## Related Issue

Closes #95

## Changes Made

- `src/main.rs` — Actix-Web server setup with route registration, PostgreSQL connection pool, SQLx migrations on startup, and service discovery registration/deregistration
- `src/config.rs` — Environment-based configuration for JWT secret, token TTLs, mint secret, dev mint flag, and per-provider OAuth credentials; includes validation guards (e.g. minimum JWT secret length)
- `src/tokens.rs` — JWT access token signing and verification (`HS256`); secure refresh token generation (32 random bytes, hex-encoded); SHA-256 hashing for refresh token storage
- `src/db.rs` — `insert_refresh_token` and `rotate_refresh_token` (transactional delete-then-insert for token family rotation)
- `src/error.rs` — `AuthError` enum covering all failure modes with appropriate HTTP status codes via `ResponseError`
- `src/handlers.rs` — `POST /auth/token` (mint with optional `X-Mint-Secret`), `POST /auth/refresh` (rotation), `GET /auth/oauth2/{provider}/authorize`, `POST /auth/oauth2/{provider}/token`, `GET /health`
- `migrations/20260325120000_create_refresh_tokens.sql` — `refresh_tokens` table with composite index on `(user_id, family_id)` and index on `expires_at`

## Acceptance Criteria

- JWT access tokens are generated and signed with a configurable secret
- Refresh tokens are issued alongside access tokens and stored hashed in PostgreSQL
- `POST /auth/refresh` rotates the refresh token atomically; expired or unknown tokens return 401
- `POST /auth/token` is gated by `X-Mint-Secret` in production or `AUTH_DEV_MINT=1` in development
- OAuth2 authorization URL generation and code exchange work for Google, GitHub, and Twitter
- `GET /health` returns service status and version
- All token operations are covered by unit tests in `tokens.rs` and `config.rs`