### PR TITLE
feat: enhances the /health endpoint

### DIFF
--- a/backend/services/api/src/main.rs
+++ b/backend/services/api/src/main.rs
@@ -389,20 +389,146 @@ fn build_http_server(
     .run())
 }
 
-/// Health check
+/// Health check — verifies database, Redis, and Stellar RPC connectivity.
 #[utoipa::path(
     get, path = "/health",
-    responses((status = 200, description = "Service is healthy"))
+    responses(
+        (status = 200, description = "Service and all dependencies are healthy"),
+        (status = 503, description = "One or more dependencies are unavailable"),
+    )
 )]
-async fn health(req: HttpRequest) -> HttpResponse {
+async fn health(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse {
     let request_id = get_request_id(&req).unwrap_or_else(|| "unknown".to_string());
     tracing::info!(request_id = %request_id, "Health check requested");
-    
-    HttpResponse::Ok().json(serde_json::json!({
-        "status": "healthy",
+
+    // ── Database ping ────────────────────────────────────────────────────
+    let db_status = match sqlx::query("SELECT 1")
+        .execute(&state.db)
+        .await
+    {
+        Ok(_) => {
+            tracing::debug!(request_id = %request_id, "Database ping OK");
+            serde_json::json!({ "status": "ok" })
+        }
+        Err(e) => {
+            tracing::error!(request_id = %request_id, error = %e, "Database ping failed");
+            serde_json::json!({ "status": "error", "message": "database unreachable" })
+        }
+    };
+    let db_healthy = db_status["status"] == "ok";
+
+    // ── Redis ping ───────────────────────────────────────────────────────
+    let redis_status = match state.redis.get().await {
+        Ok(mut conn) => {
+            match deadpool_redis::redis::cmd("PING")
+                .query_async::<String>(&mut conn)
+                .await
+            {
+                Ok(_) => {
+                    tracing::debug!(request_id = %request_id, "Redis ping OK");
+                    serde_json::json!({ "status": "ok" })
+                }
+                Err(e) => {
+                    tracing::error!(request_id = %request_id, error = %e, "Redis PING command failed");
+                    serde_json::json!({ "status": "error", "message": "redis ping failed" })
+                }
+            }
+        }
+        Err(e) => {
+            tracing::error!(request_id = %request_id, error = %e, "Failed to acquire Redis connection");
+            serde_json::json!({ "status": "error", "message": "redis connection unavailable" })
+        }
+    };
+    let redis_healthy = redis_status["status"] == "ok";
+
+    // ── Stellar RPC / contract status ────────────────────────────────────
+    // We check reachability of the RPC node and whether contract IDs are configured.
+    let contracts_configured = !state.bounty_contract_id.is_empty()
+        && !state.escrow_contract_id.is_empty()
+        && !state.freelancer_contract_id.is_empty();
+
+    let rpc_client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .unwrap_or_default();
+
+    let rpc_body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getHealth"
+    });
+
+    let stellar_status = match rpc_client
+        .post(&state.stellar_rpc_url)
+        .json(&rpc_body)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::debug!(request_id = %request_id, "Stellar RPC reachable");
+            serde_json::json!({
+                "status": "ok",
+                "rpc_url": state.stellar_rpc_url,
+                "contracts_configured": contracts_configured,
+                "contracts": {
+                    "bounty": if state.bounty_contract_id.is_empty() { "not_configured" } else { "configured" },
+                    "escrow": if state.escrow_contract_id.is_empty() { "not_configured" } else { "configured" },
+                    "freelancer": if state.freelancer_contract_id.is_empty() { "not_configured" } else { "configured" },
+                }
+            })
+        }
+        Ok(resp) => {
+            tracing::warn!(
+                request_id = %request_id,
+                status = %resp.status(),
+                "Stellar RPC returned non-success status"
+            );
+            serde_json::json!({
+                "status": "degraded",
+                "rpc_url": state.stellar_rpc_url,
+                "message": format!("rpc returned status {}", resp.status()),
+                "contracts_configured": contracts_configured,
+            })
+        }
+        Err(e) => {
+            tracing::error!(request_id = %request_id, error = %e, "Stellar RPC unreachable");
+            serde_json::json!({
+                "status": "error",
+                "rpc_url": state.stellar_rpc_url,
+                "message": "stellar rpc unreachable",
+                "contracts_configured": contracts_configured,
+            })
+        }
+    };
+    // Stellar RPC being unreachable is degraded, not critical — the API still
+    // functions without live contract calls in most read paths.
+    let stellar_healthy = stellar_status["status"] != "error";
+
+    let all_healthy = db_healthy && redis_healthy;
+    let overall = if all_healthy && stellar_healthy {
+        "healthy"
+    } else if all_healthy {
+        "degraded"
+    } else {
+        "unhealthy"
+    };
+
+    let body = serde_json::json!({
+        "status": overall,
         "service": "stellar-api",
-        "version": env!("CARGO_PKG_VERSION")
-    }))
+        "version": env!("CARGO_PKG_VERSION"),
+        "dependencies": {
+            "database": db_status,
+            "redis": redis_status,
+            "stellar": stellar_status,
+        }
+    });
+
+    if all_healthy {
+        HttpResponse::Ok().json(body)
+    } else {
+        HttpResponse::ServiceUnavailable().json(body)
+    }
 }
 
 /// Create a new bounty
@@ -1151,6 +1277,18 @@ async fn release_escrow(path: web::Path<u64>, pool: web::Data<PgPool>) -> Result
 )]
 pub struct ApiDoc;
 
+#[derive(Clone)]
+pub struct AppState {
+    pub db: PgPool,
+    pub redis: deadpool_redis::Pool,
+    /// Soroban RPC endpoint, used for contract reachability check.
+    pub stellar_rpc_url: String,
+    /// Contract IDs populated from env — empty string means not configured.
+    pub bounty_contract_id: String,
+    pub escrow_contract_id: String,
+    pub freelancer_contract_id: String,
+}
+
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
@@ -1179,6 +1317,21 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|error| panic!("Failed to connect to PostgreSQL using DATABASE_URL: {error}"));
 
     tracing::info!("Connected to database");
+
+    let stellar_rpc_url = std::env::var("STELLAR_RPC_URL")
+        .unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string());
+    let bounty_contract_id = std::env::var("BOUNTY_CONTRACT_ID").unwrap_or_default();
+    let escrow_contract_id = std::env::var("ESCROW_CONTRACT_ID").unwrap_or_default();
+    let freelancer_contract_id = std::env::var("FREELANCER_CONTRACT_ID").unwrap_or_default();
+
+    let state = AppState {
+        db: db_pool,
+        redis: redis_pool,
+        stellar_rpc_url,
+        bounty_contract_id,
+        escrow_contract_id,
+        freelancer_contract_id,
+    };
 
     let redis_url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
     let cfg = RedisConfig::from_url(redis_url);


### PR DESCRIPTION
## Description

Enhances the `/health` endpoint on the `stellar-api` service to perform real dependency checks instead of always returning a static healthy response. The handler now pings PostgreSQL, Redis, and the Stellar RPC node, and returns an accurate overall status so load balancers and orchestrators can make informed routing decisions.

## Related Issue

Closes #87 

## Changes Made

- `AppState` struct updated to carry `stellar_rpc_url`, `bounty_contract_id`, `escrow_contract_id`, and `freelancer_contract_id` fields sourced from environment variables.
- `main()` updated to populate the new `AppState` fields before constructing the server.
- `health()` handler updated to accept `web::Data<AppState>` and perform:
  - `SELECT 1` query against PostgreSQL to verify database connectivity.
  - `PING` command against Redis via a pooled connection.
  - `getHealth` JSON-RPC call to the Stellar RPC endpoint with a 5-second timeout.
  - Contract configuration presence check for bounty, escrow, and freelancer contracts.
- Response body now includes a `dependencies` object with per-dependency status details.
- Overall status is `healthy` (200) when all critical dependencies are up, `degraded` (200) when only Stellar RPC is unreachable, and `unhealthy` (503) when database or Redis is down.

## Acceptance Criteria

- Health endpoint returns 503 when the database is unreachable.
- Health endpoint returns 503 when Redis is unreachable.
- Health endpoint returns 200 with `"status": "degraded"` when the Stellar RPC node is unreachable but DB and Redis are healthy.
- Response body includes per-dependency breakdown under the `dependencies` key.
- Contract configuration status is surfaced in the Stellar dependency block.