### PR TITLE
feat: add PostgreSQL full-text search to the bounty and freelancer 

### DIFF
--- a/backend/services/api/migrations/20260327000000_add_fts_indexes.sql
+++ b/backend/services/api/migrations/20260327000000_add_fts_indexes.sql
@@ -1,0 +1,29 @@
+-- Full-text search indexes for bounties and freelancers.
+--
+-- We use generated tsvector columns (stored) so that the document is kept
+-- up-to-date automatically on INSERT/UPDATE and the index never falls behind.
+-- english stemming handles plurals, stop-words, etc.
+
+-- ── Bounties ──────────────────────────────────────────────────────────────────
+
+ALTER TABLE bounties
+    ADD COLUMN IF NOT EXISTS fts tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+            setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
+            setweight(to_tsvector('english', coalesce(status, '')), 'C')
+        ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_bounties_fts ON bounties USING GIN (fts);
+
+-- ── Freelancers ───────────────────────────────────────────────────────────────
+
+ALTER TABLE freelancers
+    ADD COLUMN IF NOT EXISTS fts tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
+            setweight(to_tsvector('english', coalesce(discipline, '')), 'A') ||
+            setweight(to_tsvector('english', coalesce(bio, '')), 'B')
+        ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_freelancers_fts ON freelancers USING GIN (fts);

--- a/backend/services/api/src/main.rs
+++ b/backend/services/api/src/main.rs
@@ -473,46 +473,71 @@ async fn create_bounty(pool: web::Data<PgPool>, body: web::Json<BountyRequest>) 
     Ok(HttpResponse::Created().json(ApiResponse::ok(data, Some("Bounty created successfully".to_string()))))
 }
 
-/// List bounties (paginated)
+/// List bounties (paginated, optionally full-text searched)
 #[utoipa::path(
     get, path = "/api/bounties",
     params(
-        PaginationParams,
+        ("q"      = Option<String>, Query, description = "Full-text search query"),
         ("status" = Option<String>, Query, description = "Filter by status: open | in-progress | completed"),
+        ("page"   = Option<i64>,   Query, description = "Page number (default 1)"),
+        ("limit"  = Option<i64>,   Query, description = "Results per page, 1-100 (default 10)"),
     ),
     responses(
         (status = 200, description = "Paginated list of bounties"),
         (status = 500, description = "Database error"),
     )
 )]
-async fn list_bounties() -> HttpResponse {
-    HttpResponse::Ok().json(ApiResponse::ok(
-        serde_json::json!({ "bounties": [], "total": 0, "page": 1, "limit": 10 }),
-        None::<String>,
-    ))
 async fn list_bounties(
+    req: HttpRequest,
     pool: web::Data<PgPool>,
     query: web::Query<std::collections::HashMap<String, String>>,
 ) -> Result<HttpResponse, ApiError> {
-    let page = query.get("page").and_then(|value| value.parse::<i64>().ok()).unwrap_or(1).max(1);
-    let limit = query.get("limit").and_then(|value| value.parse::<i64>().ok()).unwrap_or(10).clamp(1, 100);
+    let request_id = get_request_id(&req).unwrap_or_else(|| "unknown".to_string());
+
+    let page  = query.get("page").and_then(|v| v.parse::<i64>().ok()).unwrap_or(1).max(1);
+    let limit = query.get("limit").and_then(|v| v.parse::<i64>().ok()).unwrap_or(10).clamp(1, 100);
     let offset = (page - 1) * limit;
     let status = query.get("status").cloned();
 
+    // Sanitise and normalise the search query.
+    // websearch_to_tsquery understands quoted phrases and `-word` exclusions,
+    // which is friendlier for end-users than plainto_tsquery.
+    let search_query: Option<String> = query
+        .get("q")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    tracing::info!(
+        request_id = %request_id,
+        ?status,
+        search = ?search_query,
+        page,
+        limit,
+        "Listing bounties"
+    );
+
+    // ── Count ────────────────────────────────────────────────────────────────
     let total = match sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*)::BIGINT FROM bounties WHERE ($1::TEXT IS NULL OR status = $1)",
+        r#"
+        SELECT COUNT(*)::BIGINT
+        FROM   bounties
+        WHERE  ($1::TEXT IS NULL OR status = $1)
+          AND  ($2::TEXT IS NULL OR fts @@ websearch_to_tsquery('english', $2))
+        "#,
     )
     .bind(status.clone())
+    .bind(search_query.clone())
     .fetch_one(pool.get_ref())
     .await
     {
-        Ok(count) => count,
+        Ok(n) => n,
         Err(error) => {
-            tracing::error!("Failed to count bounties: {error}");
+            tracing::error!(request_id = %request_id, "Failed to count bounties: {error}");
             return Err(ApiError::Database(error));
         }
     };
 
+    // ── Rows — ranked by relevance when a query is present ──────────────────
     let bounties = match sqlx::query_as::<_, BountyRecord>(
         r#"
         SELECT
@@ -526,11 +551,20 @@ async fn list_bounties(
             EXTRACT(EPOCH FROM created_at)::BIGINT AS created_at
         FROM bounties
         WHERE ($1::TEXT IS NULL OR status = $1)
-        ORDER BY created_at DESC, id DESC
-        LIMIT $2 OFFSET $3
+          AND ($2::TEXT IS NULL OR fts @@ websearch_to_tsquery('english', $2))
+        ORDER BY
+            CASE WHEN $2::TEXT IS NOT NULL
+                 THEN ts_rank(fts, websearch_to_tsquery('english', $2))
+                 ELSE 0
+            END DESC,
+            created_at DESC,
+            id DESC
+        LIMIT  $3
+        OFFSET $4
         "#,
     )
-    .bind(status)
+    .bind(status.clone())
+    .bind(search_query.clone())
     .bind(limit)
     .bind(offset)
     .fetch_all(pool.get_ref())
@@ -538,7 +572,7 @@ async fn list_bounties(
     {
         Ok(rows) => rows,
         Err(error) => {
-            tracing::error!("Failed to list bounties: {error}");
+            tracing::error!(request_id = %request_id, "Failed to list bounties: {error}");
             return Err(ApiError::Database(error));
         }
     };
@@ -546,9 +580,13 @@ async fn list_bounties(
     Ok(HttpResponse::Ok().json(ApiResponse::ok(
         serde_json::json!({
             "bounties": bounties,
-            "total": total,
-            "page": page,
-            "limit": limit
+            "total":    total,
+            "page":     page,
+            "limit":    limit,
+            "filters": {
+                "status": status.unwrap_or_default(),
+                "q":      search_query.unwrap_or_default(),
+            }
         }),
         None,
     )))


### PR DESCRIPTION
## Description

Adds PostgreSQL full-text search to the bounty and freelancer listing endpoints using generated `tsvector` columns and GIN indexes. No external dependency is introduced — everything runs inside the existing PostgreSQL instance. Search results are ranked by `ts_rank` when a query is present, so the most relevant records surface first. Existing status and discipline filters compose cleanly with the search predicate.

## Related Issue

Closes #72 

## Changes Made

- `migrations/20260327000000_add_fts_indexes.sql` (new) — adds a `GENERATED ALWAYS AS ... STORED` `tsvector` column to both `bounties` and `freelancers`, and a GIN index on each. The generated column is maintained automatically by PostgreSQL on every insert and update.
  - Bounties: `title` (weight A), `description` (weight B), `status` (weight C).
  - Freelancers: `name` (weight A), `discipline` (weight A), `bio` (weight B).
- `src/main.rs` — `list_bounties` and `list_freelancers` updated:
  - Accept optional `q` query parameter.
  - Both the count and the row query use `websearch_to_tsquery('english', $2)` with `IS NULL` short-circuit so the existing filter-only path is unchanged when `q` is absent.
  - Rows are `ORDER BY ts_rank(...) DESC` when a search query is supplied, falling back to the previous default sort otherwise.
  - Response envelope gains a `q` field inside `filters` for client transparency.

## Acceptance Criteria

- `GET /api/bounties?q=rust+smart+contract` returns bounties whose title or description matches, ranked by relevance.
- `GET /api/freelancers?q=frontend` returns freelancers whose name, discipline, or bio matches.
- Filters compose: `GET /api/bounties?q=rust&status=open` returns only open bounties matching "rust".
- Omitting `q` produces identical behaviour to the previous implementation.
- Pagination (`page`, `limit`) and total count remain accurate with search active.