### PR TITLE
fix(freelancer): secure update_earnings with escrow authorization (#190)

### DIFF
--- a/backend/contracts/freelancer/src/lib.rs
+++ b/backend/contracts/freelancer/src/lib.rs
@@ -28,6 +28,11 @@ pub enum DataKey {
     FreelancerCount,
     Profile(Address),
     AllFreelancers,
+    // Governance / admin configuration
+    Governance,
+    Deployer,
+    // Trusted escrow contract allowed to call update_earnings
+    EscrowContract,
 }
 
 #[contract]
@@ -200,26 +205,114 @@ impl FreelancerContract {
 
     /// Adds to freelancer's total earnings.
     ///
+    /// **Restricted:** Only the registered escrow contract may call this
+    /// function. Call `set_escrow_contract` once after deployment to configure
+    /// the trusted escrow address. Any other caller will be rejected.
+    ///
     /// # Parameters
     /// - `env`: Soroban environment.
+    /// - `escrow`: The escrow contract address (must authenticate).
     /// - `freelancer`: Target freelancer.
-    /// - `amount`: Earnings amount to add (positive).
+    /// - `amount`: Earnings amount to add. Must be positive (> 0).
+    ///
+    /// # Returns
+    /// - `bool`: Always `true` on success.
+    ///
+    /// # Errors
+    /// - Panics with "Escrow contract not configured" if no escrow address is
+    ///   registered yet.
+    /// - Panics with "Unauthorized: only escrow contract may update earnings"
+    ///   if `escrow` is not the registered escrow contract.
+    /// - Panics with "Amount must be positive" if `amount` <= 0.
+    /// - Panics with "Freelancer not registered" if the freelancer profile
+    ///   does not exist.
+    ///
+    /// # State Changes
+    /// - Increments `profile.total_earnings` by `amount`.
+    pub fn update_earnings(env: Env, escrow: Address, freelancer: Address, amount: i128) -> bool {
+        // Require the escrow contract to sign this transaction
+        escrow.require_auth();
+
+        // Load and validate the configured escrow contract address
+        let registered_escrow: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EscrowContract)
+            .expect("Escrow contract not configured");
+
+        // Reject if the caller is not the trusted escrow contract
+        if escrow != registered_escrow {
+            panic!("Unauthorized: only escrow contract may update earnings");
+        }
+
+        // Reject non-positive amounts to prevent earnings manipulation
+        if amount <= 0 {
+            panic!("Amount must be positive");
+        }
+
+        let key = DataKey::Profile(freelancer.clone());
+        let mut profile: FreelancerProfile = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Freelancer not registered");
+
+        profile.total_earnings += amount;
+        env.storage().persistent().set(&key, &profile);
+
+        let new_total = profile.total_earnings;
+
+        // Emit EarningsUpdated event
+        env.events().publish(
+            (FREELANCER, symbol_short!("earnings"), freelancer),
+            (amount, new_total),
+        );
+
+        true
+    }
+
+    /// Registers the trusted escrow contract address.
+    ///
+    /// Only the deployer (first caller of this function) may set or update
+    /// the escrow contract address, using the same deployer-lock pattern as
+    /// `set_governance_contract`.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `setter`: Address calling this function (must authenticate).
+    /// - `escrow`: The escrow contract address that will be allowed to call
+    ///   `update_earnings`.
     ///
     /// # Returns
     /// - `bool`: Always `true`.
     ///
     /// # Errors
-    /// - Panics if freelancer not registered.
-    pub fn update_earnings(env: Env, freelancer: Address, amount: i128) -> bool {
-        let key = DataKey::Profile(freelancer);
-        let mut profile: FreelancerProfile = env
+    /// - Panics with "Only deployer may set escrow contract" if called by an
+    ///   address other than the first setter.
+    pub fn set_escrow_contract(env: Env, setter: Address, escrow: Address) -> bool {
+        setter.require_auth();
+
+        // Reuse the same deployer slot as set_governance_contract so both
+        // functions share a single deployer identity.
+        let maybe_deployer: Option<Address> = env
             .storage()
             .persistent()
-            .get(&key)
-            .expect(\"Freelancer not registered\");
+            .get(&DataKey::Deployer);
 
-        profile.total_earnings += amount;
-        env.storage().persistent().set(&key, &profile);
+        if let Some(deployer) = maybe_deployer {
+            if deployer != setter {
+                panic!("Only deployer may set escrow contract");
+            }
+        } else {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Deployer, &setter);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::EscrowContract, &escrow);
+
         true
     }
 
@@ -725,5 +818,159 @@ mod tests {
         let devs = client.query_freelancers(&filters_dev);
         assert_eq!(devs.len(), 1);
         assert_eq!(devs.get(0).unwrap().name, String::from_str(&env, "Charlie"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests for update_earnings authorization (Issue #190)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_update_earnings_success() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(FreelancerContract, ());
+        let client = FreelancerContractClient::new(&env, &contract_id);
+
+        let deployer = Address::generate(&env);
+        let escrow = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+
+        // Configure trusted escrow contract
+        client.set_escrow_contract(&deployer, &escrow);
+
+        // Register freelancer
+        client.register_freelancer(
+            &freelancer,
+            &String::from_str(&env, "Alice"),
+            &String::from_str(&env, "Design"),
+            &String::from_str(&env, "Bio"),
+        );
+
+        // Escrow updates earnings
+        let result = client.update_earnings(&escrow, &freelancer, &500i128);
+        assert!(result);
+
+        let profile = client.get_profile(&freelancer);
+        assert_eq!(profile.total_earnings, 500i128);
+
+        // Second update accumulates
+        client.update_earnings(&escrow, &freelancer, &250i128);
+        let profile = client.get_profile(&freelancer);
+        assert_eq!(profile.total_earnings, 750i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: only escrow contract may update earnings")]
+    fn test_update_earnings_unauthorized_caller() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(FreelancerContract, ());
+        let client = FreelancerContractClient::new(&env, &contract_id);
+
+        let deployer = Address::generate(&env);
+        let escrow = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+
+        client.set_escrow_contract(&deployer, &escrow);
+        client.register_freelancer(
+            &freelancer,
+            &String::from_str(&env, "Alice"),
+            &String::from_str(&env, "Design"),
+            &String::from_str(&env, "Bio"),
+        );
+
+        // Attacker tries to inflate earnings
+        client.update_earnings(&attacker, &freelancer, &9999i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Escrow contract not configured")]
+    fn test_update_earnings_no_escrow_configured() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(FreelancerContract, ());
+        let client = FreelancerContractClient::new(&env, &contract_id);
+
+        let escrow = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+
+        client.register_freelancer(
+            &freelancer,
+            &String::from_str(&env, "Alice"),
+            &String::from_str(&env, "Design"),
+            &String::from_str(&env, "Bio"),
+        );
+
+        // No escrow configured yet — should panic
+        client.update_earnings(&escrow, &freelancer, &100i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Amount must be positive")]
+    fn test_update_earnings_zero_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(FreelancerContract, ());
+        let client = FreelancerContractClient::new(&env, &contract_id);
+
+        let deployer = Address::generate(&env);
+        let escrow = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+
+        client.set_escrow_contract(&deployer, &escrow);
+        client.register_freelancer(
+            &freelancer,
+            &String::from_str(&env, "Alice"),
+            &String::from_str(&env, "Design"),
+            &String::from_str(&env, "Bio"),
+        );
+
+        // Zero amount should be rejected
+        client.update_earnings(&escrow, &freelancer, &0i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Amount must be positive")]
+    fn test_update_earnings_negative_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(FreelancerContract, ());
+        let client = FreelancerContractClient::new(&env, &contract_id);
+
+        let deployer = Address::generate(&env);
+        let escrow = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+
+        client.set_escrow_contract(&deployer, &escrow);
+        client.register_freelancer(
+            &freelancer,
+            &String::from_str(&env, "Alice"),
+            &String::from_str(&env, "Design"),
+            &String::from_str(&env, "Bio"),
+        );
+
+        // Negative amount (attempting to reduce earnings) should be rejected
+        client.update_earnings(&escrow, &freelancer, &-100i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Only deployer may set escrow contract")]
+    fn test_set_escrow_contract_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(FreelancerContract, ());
+        let client = FreelancerContractClient::new(&env, &contract_id);
+
+        let deployer = Address::generate(&env);
+        let escrow = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let new_escrow = Address::generate(&env);
+
+        // Deployer sets the escrow contract
+        client.set_escrow_contract(&deployer, &escrow);
+
+        // Attacker tries to replace the escrow with their own address
+        client.set_escrow_contract(&attacker, &new_escrow);
     }
 }


### PR DESCRIPTION
closes #190 

- Add missing Governance, Deployer, EscrowContract variants to DataKey enum (fixes latent compile error from undeclared variants used in erify_freelancer and set_governance_contract)
- Add EscrowContract DataKey variant to store the trusted escrow address
- Add set_escrow_contract(setter, escrow): deployer-locked function to register the one escrow contract allowed to update earnings (uses same deployer-lock pattern as set_governance_contract)
- Secure update_earnings: now requires escrow.require_auth() and validates caller matches the registered escrow address
  - Panics: 'Escrow contract not configured' if not set up yet
  - Panics: 'Unauthorized: only escrow contract may update earnings'
  - Panics: 'Amount must be positive' (guards against zero/negative)
- Emit earnings event on every successful update
- Add 6 tests covering: success, unauthorized caller, unconfigured escrow, zero amount, negative amount, unauthorized escrow setter