### PR TITLE
feat(bounty): integrate escrow for payment handling (#161)

### DIFF
--- a/backend/contracts/bounty/src/lib.rs
+++ b/backend/contracts/bounty/src/lib.rs
@@ -3,6 +3,13 @@
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Vec, Symbol};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Vec};
 
+#[derive(Clone)]
+#[contracttype]
+pub enum ReleaseCondition {
+    OnCompletion,
+    Timelock(u64),
+}
+
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[contracttype]
 pub enum BountyStatus {
@@ -33,6 +40,8 @@ pub struct Bounty {
     pub deadline: u64,
     pub status: BountyStatus,
     pub created_at: u64,
+    pub token: Address,
+    pub escrow_id: Option<u64>,
 }
 
 #[contracttype]
@@ -100,6 +109,9 @@ pub enum DataKey {
     // Persistent storage - application tracking for rate limiting
     ApplicationsPerBounty(u64),
     ApplicationsPerFreelancer(Address),
+    // Config
+    Deployer,
+    EscrowContract,
 }
 
 #[contract]
@@ -133,6 +145,7 @@ impl BountyContract {
         description: String,
         budget: i128,
         deadline: u64,
+        token: Address,
     ) -> u64 {
         creator.require_auth();
 
@@ -153,6 +166,8 @@ impl BountyContract {
             deadline,
             status: BountyStatus::Open,
             created_at: env.ledger().timestamp(),
+            token: token.clone(),
+            escrow_id: None,
         };
 
         // Persistent storage for permanent bounty record
@@ -171,6 +186,34 @@ impl BountyContract {
         );
 
         counter
+    }
+
+    /// Registers the trusted escrow contract address.
+    ///
+    /// Only the deployer (first caller) may set the escrow contract address.
+    pub fn set_escrow_contract(env: Env, setter: Address, escrow: Address) -> bool {
+        setter.require_auth();
+
+        let maybe_deployer: Option<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Deployer);
+
+        if let Some(deployer) = maybe_deployer {
+            if deployer != setter {
+                panic!("Only deployer may set escrow contract");
+            }
+        } else {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Deployer, &setter);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::EscrowContract, &escrow);
+
+        true
     }
 
     /// Retrieves bounty details by ID.
@@ -320,16 +363,37 @@ impl BountyContract {
             "Application does not match bounty"
         );
 
+        let escrow_contract: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EscrowContract)
+            .expect("Escrow contract not configured");
+
+        let escrow_id: u64 = env.invoke_contract(
+            &escrow_contract,
+            &soroban_sdk::symbol_short!("deposit"),
+            (
+                bounty.creator.clone(),
+                application.freelancer.clone(),
+                bounty.budget,
+                bounty.token.clone(),
+                ReleaseCondition::OnCompletion,
+            ),
+        );
+
         // Use instance storage for active workflow state
         env.storage().instance().set(
             &DataKey::SelectedFreelancer(bounty_id),
             &application.freelancer,
         );
 
-        bounty.status = BountyStatus::InProgress;
+        let mut updated_bounty = bounty;
+        updated_bounty.status = BountyStatus::InProgress;
+        updated_bounty.escrow_id = Some(escrow_id);
+        
         env.storage()
             .persistent()
-            .set(&DataKey::Bounty(bounty_id), &bounty);
+            .set(&DataKey::Bounty(bounty_id), &updated_bounty);
 
         true
     }
@@ -409,10 +473,25 @@ impl BountyContract {
         // Note: Work submission tracking can be added via separate function
         // For now, we allow completion without requiring prior submission
 
-        bounty.status = BountyStatus::Completed;
+        if let Some(escrow_id) = bounty.escrow_id {
+            let escrow_contract: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::EscrowContract)
+                .expect("Escrow contract not configured");
+                
+            env.invoke_contract::<bool>(
+                &escrow_contract,
+                &soroban_sdk::symbol_short!("release_funds"),
+                (escrow_id, bounty.creator.clone()),
+            );
+        }
+
+        let mut updated_bounty = bounty;
+        updated_bounty.status = BountyStatus::Completed;
         env.storage()
             .persistent()
-            .set(&DataKey::Bounty(bounty_id), &bounty);
+            .set(&DataKey::Bounty(bounty_id), &updated_bounty);
 
         true
     }
@@ -755,12 +834,16 @@ mod tests {
         let client = BountyContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+        let escrow = env.register(MockEscrowContract, ());
+        client.set_escrow_contract(&creator, &escrow);
         let bounty_id = client.create_bounty(
             &creator,
             &String::from_str(&env, "Test Bounty"),
             &String::from_str(&env, "Test Description"),
             &5000i128,
             &100u64,
+            &token,
         );
 
         assert_eq!(bounty_id, 1);
@@ -777,6 +860,9 @@ mod tests {
         let client = BountyContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+        let escrow = env.register(MockEscrowContract, ());
+        client.set_escrow_contract(&creator, &escrow);
         let freelancer = Address::generate(&env);
 
         let bounty_id = client.create_bounty(
@@ -785,6 +871,7 @@ mod tests {
             &String::from_str(&env, "Test Description"),
             &5000i128,
             &100u64,
+            &token,
         );
 
         let app_id = client.apply_for_bounty(
@@ -809,6 +896,9 @@ mod tests {
         let client = BountyContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+        let escrow = env.register(MockEscrowContract, ());
+        client.set_escrow_contract(&creator, &escrow);
         let freelancer = Address::generate(&env);
 
         let bounty_id = client.create_bounty(
@@ -819,6 +909,7 @@ mod tests {
 
             &5000i128,
             &100u64,
+            &token,
         );
 
         let app_id = client.apply_for_bounty(
@@ -853,6 +944,9 @@ mod tests {
         let client = BountyContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+        let escrow = env.register(MockEscrowContract, ());
+        client.set_escrow_contract(&creator, &escrow);
         let freelancer = Address::generate(&env);
 
         let bounty_id = client.create_bounty(
@@ -861,6 +955,7 @@ mod tests {
             &String::from_str(&env, "Test Description"),
             &5000i128,
             &100u64,
+            &token,
         );
 
         let app_id = client.apply_for_bounty(
@@ -898,6 +993,9 @@ mod tests {
         let client = BountyContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+        let escrow = env.register(MockEscrowContract, ());
+        client.set_escrow_contract(&creator, &escrow);
         let freelancer = Address::generate(&env);
 
         let bounty_id = client.create_bounty(
@@ -906,6 +1004,7 @@ mod tests {
             &String::from_str(&env, "Test Description"),
             &5000i128,
             &100u64,
+            &token,
         );
 
         let app_id = client.apply_for_bounty(
@@ -942,6 +1041,9 @@ mod tests {
         let client = BountyContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+        let escrow = env.register(MockEscrowContract, ());
+        client.set_escrow_contract(&creator, &escrow);
         let freelancer = Address::generate(&env);
         let random = Address::generate(&env);
 
@@ -951,6 +1053,7 @@ mod tests {
             &String::from_str(&env, "Test Description"),
             &5000i128,
             &100u64,
+            &token,
         );
 
         let app_id = client.apply_for_bounty(
@@ -979,6 +1082,9 @@ mod tests {
         let client = BountyContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+        let escrow = env.register(MockEscrowContract, ());
+        client.set_escrow_contract(&creator, &escrow);
         let freelancer = Address::generate(&env);
 
         let bounty_id = client.create_bounty(
@@ -987,6 +1093,7 @@ mod tests {
             &String::from_str(&env, "Test Description"),
             &5000i128,
             &100u64,
+            &token,
         );
 
         let app_id = client.apply_for_bounty(
@@ -1036,6 +1143,9 @@ mod tests {
         let client = BountyContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+        let escrow = env.register(MockEscrowContract, ());
+        client.set_escrow_contract(&creator, &escrow);
         let freelancer = Address::generate(&env);
         let admin = Address::generate(&env);
 
@@ -1045,6 +1155,7 @@ mod tests {
             &String::from_str(&env, "Test Description"),
             &5000i128,
             &100u64,
+            &token,
         );
 
         let app_id = client.apply_for_bounty(
@@ -1089,6 +1200,9 @@ mod tests {
         let client = BountyContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+        let escrow = env.register(MockEscrowContract, ());
+        client.set_escrow_contract(&creator, &escrow);
         let freelancer = Address::generate(&env);
         let admin = Address::generate(&env);
 
@@ -1098,6 +1212,7 @@ mod tests {
             &String::from_str(&env, "Test Description"),
             &5000i128,
             &100u64,
+            &token,
         );
 
         let app_id = client.apply_for_bounty(
@@ -1142,6 +1257,9 @@ mod tests {
         let client = BountyContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+        let escrow = env.register(MockEscrowContract, ());
+        client.set_escrow_contract(&creator, &escrow);
         let freelancer = Address::generate(&env);
         let admin = Address::generate(&env);
 
@@ -1151,6 +1269,7 @@ mod tests {
             &String::from_str(&env, "Test Description"),
             &5000i128,
             &100u64,
+            &token,
         );
 
         let app_id = client.apply_for_bounty(
@@ -1193,6 +1312,9 @@ mod tests {
         let client = BountyContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+        let escrow = env.register(MockEscrowContract, ());
+        client.set_escrow_contract(&creator, &escrow);
         let freelancer = Address::generate(&env);
 
         let bounty_id = client.create_bounty(
@@ -1201,6 +1323,7 @@ mod tests {
             &String::from_str(&env, "Test Description"),
             &5000i128,
             &100u64,
+            &token,
         );
 
         let app_id = client.apply_for_bounty(
@@ -1228,3 +1351,5 @@ mod tests {
         );
     }
 }
+
+


### PR DESCRIPTION
Closes #161

- Added 	oken: Address parameter to create_bounty to specify payment asset
- Adeded escrow_id field to Bounty state to track locked funds
- Configured a deployer-locked set_escrow_contract method
- Added cross-contract deposit call to Escrow contract during select_freelancer to secure funds
- Added cross-contract 
elease_funds call to Escrow contract during complete_bounty to pay the freelancer
- Updated all existing tests with MockEscrowContract to allow testing escrow cross-calls seamlessly without breaking them