### PR TITLE
feat(governance): implement full proposal execution logic (#192)

### DIFF
--- a/backend/contracts/governance/src/lib.rs
+++ b/backend/contracts/governance/src/lib.rs
@@ -6,6 +6,36 @@ use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, E
 pub enum DataKey {
 	Owner,
 	Admin(Address),
+    ProposalCounter,
+    Proposal(u64),
+    HasVoted(u64, Address),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProposalType {
+    AddAdmin(Address),
+    RemoveAdmin(Address),
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ProposalStatus {
+    Pending = 0,
+    Executed = 1,
+    Rejected = 2,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Proposal {
+    pub id: u64,
+    pub creator: Address,
+    pub prop_type: ProposalType,
+    pub status: ProposalStatus,
+    pub votes_for: u32,
+    pub votes_against: u32,
+    pub created_at: u64,
 }
 
 #[contract]
@@ -64,7 +94,151 @@ impl GovernanceContract {
 			.get::<DataKey, bool>(&DataKey::Admin(addr))
 			.unwrap_or(false)
 	}
+
+	// -------------------------------------------------------------------------
+	// Proposal logic (Issue #192)
+	// -------------------------------------------------------------------------
+
+	/// Creates a new governance proposal.
+	/// Only an active admin can create a proposal.
+	pub fn create_proposal(env: Env, creator: Address, prop_type: ProposalType) -> u64 {
+		creator.require_auth();
+		if !Self::is_admin(env.clone(), creator.clone()) {
+			panic!("Only admins can create proposals");
+		}
+
+		let mut counter: u64 = env.storage().persistent().get(&DataKey::ProposalCounter).unwrap_or(0);
+		counter += 1;
+
+		let proposal = Proposal {
+			id: counter,
+			creator: creator.clone(),
+			prop_type,
+			status: ProposalStatus::Pending,
+			votes_for: 0,
+			votes_against: 0,
+			created_at: env.ledger().timestamp(),
+		};
+
+		env.storage().persistent().set(&DataKey::Proposal(counter), &proposal);
+		env.storage().persistent().set(&DataKey::ProposalCounter, &counter);
+
+		env.events().publish(
+			(GOVERNANCE, symbol_short!("prop_create"), counter),
+			(creator.clone(),),
+		);
+
+		counter
+	}
+
+	/// Cast a vote on a Pending proposal.
+	/// Only admins can vote. An admin can only vote once per proposal.
+	pub fn vote(env: Env, voter: Address, proposal_id: u64, support: bool) -> bool {
+		voter.require_auth();
+		if !Self::is_admin(env.clone(), voter.clone()) {
+			panic!("Only admins can vote");
+		}
+
+		let key = DataKey::Proposal(proposal_id);
+		let mut proposal: Proposal = env
+			.storage()
+			.persistent()
+			.get(&key)
+			.expect("Proposal not found");
+
+		if proposal.status != ProposalStatus::Pending {
+			panic!("Proposal is not in Pending status");
+		}
+
+		let voted_key = DataKey::HasVoted(proposal_id, voter.clone());
+		if env.storage().persistent().has(&voted_key) {
+			panic!("Already voted");
+		}
+
+		if support {
+			proposal.votes_for += 1;
+		} else {
+			proposal.votes_against += 1;
+		}
+
+		env.storage().persistent().set(&key, &proposal);
+		env.storage().persistent().set(&voted_key, &true);
+
+		env.events().publish(
+			(GOVERNANCE, symbol_short!("voted"), proposal_id),
+			(voter.clone(), support),
+		);
+
+		true
+	}
+
+	/// Executes a proposal.
+	/// Only admins can trigger execution, and the proposal must be Pending.
+	/// If `votes_for > votes_against` and `votes_for > 0`, it executes the specific State Change Action.
+	/// Otherwise, it marks the proposal as Rejected.
+	pub fn execute_proposal(env: Env, caller: Address, proposal_id: u64) -> bool {
+		caller.require_auth();
+		if !Self::is_admin(env.clone(), caller.clone()) {
+			panic!("Only admins can execute proposals");
+		}
+
+		let key = DataKey::Proposal(proposal_id);
+		let mut proposal: Proposal = env
+			.storage()
+			.persistent()
+			.get(&key)
+			.expect("Proposal not found");
+
+		if proposal.status != ProposalStatus::Pending {
+			panic!("Proposal is not in Pending status");
+		}
+
+		// Execution condition
+		if proposal.votes_for > proposal.votes_against && proposal.votes_for > 0 {
+			proposal.status = ProposalStatus::Executed;
+
+			// Apply State Changes directly mapped to enum
+			match &proposal.prop_type {
+				ProposalType::AddAdmin(new_admin) => {
+					env.storage()
+						.persistent()
+						.set(&DataKey::Admin(new_admin.clone()), &true);
+					env.events().publish(
+						(GOVERNANCE, symbol_short!("admin_added"), new_admin.clone()),
+						(Symbol::new(&env, "proposal"),),
+					);
+				}
+				ProposalType::RemoveAdmin(old_admin) => {
+					env.storage().persistent().remove(&DataKey::Admin(old_admin.clone()));
+					env.events().publish(
+						(GOVERNANCE, symbol_short!("admin_removed"), old_admin.clone()),
+						(Symbol::new(&env, "proposal"),),
+					);
+				}
+			}
+		} else {
+			proposal.status = ProposalStatus::Rejected;
+		}
+
+		env.storage().persistent().set(&key, &proposal);
+
+		env.events().publish(
+			(GOVERNANCE, symbol_short!("prop_exec"), proposal_id),
+			(proposal.status as u32,),
+		);
+
+		true
+	}
+
+	/// Retrieves the full details of a proposal by ID.
+	pub fn get_proposal(env: Env, proposal_id: u64) -> Proposal {
+		env.storage()
+			.persistent()
+			.get(&DataKey::Proposal(proposal_id))
+			.expect("Proposal not found")
+	}
 }
+
 
 #[cfg(test)]
 mod tests {
@@ -90,6 +264,83 @@ mod tests {
 		assert!(client.remove_admin(&owner, &admin));
 		assert!(!client.is_admin(&admin));
 	}
+#[test]
+fn test_proposal_lifecycle() {
+let env = Env::default();
+env.mock_all_auths();
+let contract_id = env.register(GovernanceContract, ());
+let client = GovernanceContractClient::new(&env, &contract_id);
+
+let owner = Address::generate(&env);
+let admin1 = Address::generate(&env);
+let admin2 = Address::generate(&env);
+let new_admin = Address::generate(&env);
+
+// Initialize & setup admins
+client.init(&owner);
+client.add_admin(&owner, &admin1);
+client.add_admin(&owner, &admin2);
+
+// admin1 creates proposal to add new_admin
+let prop_id = client.create_proposal(&admin1, &ProposalType::AddAdmin(new_admin.clone()));
+assert_eq!(prop_id, 1);
+
+let prop = client.get_proposal(&prop_id);
+assert_eq!(prop.status, ProposalStatus::Pending);
+assert_eq!(prop.votes_for, 0);
+
+// admin1 votes FOR
+assert!(client.vote(&admin1, &prop_id, &true));
+
+let prop_after_vote = client.get_proposal(&prop_id);
+assert_eq!(prop_after_vote.votes_for, 1);
+
+// admin2 executes the proposal (1 vote for > 0 against)
+assert!(client.execute_proposal(&admin2, &prop_id));
+
+let prop_executed = client.get_proposal(&prop_id);
+assert_eq!(prop_executed.status, ProposalStatus::Executed);
+
+// Verify effect: new_admin is now an admin
+assert!(client.is_admin(&new_admin));
 }
 
-use soroban_sdk::{contract,
+#[test]
+#[should_panic(expected = "Already voted")]
+fn test_double_vote_panic() {
+let env = Env::default();
+env.mock_all_auths();
+let contract_id = env.register(GovernanceContract, ());
+let client = GovernanceContractClient::new(&env, &contract_id);
+
+let owner = Address::generate(&env);
+let admin = Address::generate(&env);
+let new_admin = Address::generate(&env);
+
+client.init(&owner);
+client.add_admin(&owner, &admin);
+
+let prop_id = client.create_proposal(&admin, &ProposalType::AddAdmin(new_admin.clone()));
+
+client.vote(&admin, &prop_id, &true);
+// Should panic here
+client.vote(&admin, &prop_id, &true);
+}
+
+#[test]
+#[should_panic(expected = "Only admins can create proposals")]
+fn test_unauthorized_propose_panic() {
+let env = Env::default();
+env.mock_all_auths();
+let contract_id = env.register(GovernanceContract, ());
+let client = GovernanceContractClient::new(&env, &contract_id);
+
+let owner = Address::generate(&env);
+let rando = Address::generate(&env);
+let new_admin = Address::generate(&env);
+
+client.init(&owner);
+// rando is NOT an admin
+client.create_proposal(&rando, &ProposalType::AddAdmin(new_admin));
+}
+}


### PR DESCRIPTION
Closes #192

- Added ProposalType enum supporting AddAdmin and RemoveAdmin
- Added ProposalStatus enum (Pending, Executed, Rejected)
- Added Proposal struct with voting metrics and creation data
- Extended DataKey to support Proposals and Voting history
- Implemented create_proposal allowing admins to initiate governance actions
- Implemented ote allowing admins to vote on proposals, preventing double voting
- Implemented execute_proposal to apply intended state changes based on ProposalType if votes favor the proposal
- Secured execution logic ensuring proposals run exactly once and only actively pass if otes_for > 0 and otes_for > votes_against
- Removed garbage artifact lines at bottom of lib.rs
- Added full 	est_proposal_lifecycle, 	est_double_vote_panic, and 	est_unauthorized_propose_panic tests