### PR TITLE
fix(#53): add Docker health checks for api and indexer services

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -70,6 +70,12 @@ services:
       consul:
         condition: service_healthy
     command: cargo run --bin stellar-api
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3001/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
 
   indexer:
     image: rust:1.81-slim
@@ -90,6 +96,12 @@ services:
       consul:
         condition: service_healthy
     command: cargo run --bin stellar-indexer
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h postgres -U stellar -d stellar_db || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
 
   pgadmin:
     image: dpage/pgadmin4:latest


### PR DESCRIPTION
- api: curl -sf http://localhost:3001/health — uses the existing /health endpoint; start_period=60s allows time for cargo build on first run
- indexer: pg_isready against the postgres dependency — confirms the indexer's DB connection is reachable (indexer has no HTTP server); start_period=60s for the same reason
- Both use interval=15s, timeout=5s, retries=5

Closes #53 