### PR TITLE
feat: AI-style matching engine, recommendations API, and matches UI

### DIFF
--- a/__tests__/lib/matching-engine.test.ts
+++ b/__tests__/lib/matching-engine.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import {
+  assignStrategy,
+  scoreCreatorBountyPair,
+  rankBountiesForCreator,
+  rankCreatorsForBounty,
+  tokenize,
+  jaccard,
+  aggregateStrategyInsights,
+  type BountyFeatures,
+  type CreatorFeatures,
+} from '@/lib/matching-engine'
+
+const sampleBounty = (over: Partial<BountyFeatures> = {}): BountyFeatures => ({
+  id: 'b1',
+  title: 'React dashboard',
+  description: 'Build analytics dashboard with charts and TypeScript',
+  budget: 4000,
+  category: 'Development',
+  tags: ['react', 'typescript', 'analytics'],
+  ...over,
+})
+
+const sampleCreator = (over: Partial<CreatorFeatures> = {}): CreatorFeatures => ({
+  profileId: 'p1',
+  userId: 'u1',
+  displayName: 'Alex Dev',
+  bio: 'Frontend engineer focused on React and data visualization',
+  discipline: 'Development',
+  skills: ['react', 'typescript', 'figma'],
+  rating: 4.5,
+  completedProjects: 12,
+  ...over,
+})
+
+describe('matching-engine', () => {
+  it('tokenize removes stop words and punctuation', () => {
+    const t = tokenize('Hello, the React & TypeScript!')
+    expect(t).toContain('react')
+    expect(t).toContain('typescript')
+    expect(t).not.toContain('the')
+  })
+
+  it('jaccard is symmetric', () => {
+    const a = new Set(['x', 'y'])
+    const b = new Set(['y', 'z'])
+    expect(jaccard(a, b)).toBeCloseTo(1 / 3, 5)
+  })
+
+  it('scoreCreatorBountyPair increases when skills align with tags', () => {
+    const high = scoreCreatorBountyPair(sampleBounty(), sampleCreator())
+    const low = scoreCreatorBountyPair(
+      sampleBounty({ tags: ['legal'], category: 'Law', description: 'contract review' }),
+      sampleCreator({ skills: ['react'], bio: 'developer', discipline: 'Development' }),
+    )
+    expect(high.score).toBeGreaterThan(low.score)
+  })
+
+  it('treatment_skill weighs overlap more than treatment_budget', () => {
+    const bounty = sampleBounty()
+    const creator = sampleCreator()
+    const sSkill = scoreCreatorBountyPair(bounty, creator, 'treatment_skill')
+    const sBudget = scoreCreatorBountyPair(bounty, creator, 'treatment_budget')
+    expect(sSkill.components.skillOverlap).toBe(sBudget.components.skillOverlap)
+    expect(sSkill.score).not.toBe(sBudget.score)
+  })
+
+  it('assignStrategy is stable for same userId', () => {
+    expect(assignStrategy('user-abc')).toBe(assignStrategy('user-abc'))
+  })
+
+  it('rankBountiesForCreator sorts by score descending', () => {
+    const creator = sampleCreator()
+    const ranked = rankBountiesForCreator(
+      [
+        sampleBounty({ id: 'a', tags: ['rust'] }),
+        sampleBounty({ id: 'b', tags: ['react', 'typescript'] }),
+      ],
+      creator,
+      'control',
+      10,
+    )
+    expect(ranked[0]!.bounty.id).toBe('b')
+  })
+
+  it('rankCreatorsForBounty respects limit', () => {
+    const bounty = sampleBounty()
+    const creators = [
+      sampleCreator({ profileId: '1', userId: 'u1', skills: ['vue'] }),
+      sampleCreator({ profileId: '2', userId: 'u2', skills: ['react', 'typescript'] }),
+      sampleCreator({ profileId: '3', userId: 'u3', skills: ['rust'] }),
+    ]
+    const ranked = rankCreatorsForBounty(bounty, creators, 'control', 2)
+    expect(ranked).toHaveLength(2)
+  })
+
+  it('aggregateStrategyInsights computes helpful rates', () => {
+    const out = aggregateStrategyInsights([
+      { strategy: 'control', helpful: true },
+      { strategy: 'control', helpful: false },
+      { strategy: 'treatment_skill', helpful: true },
+    ])
+    const ctrl = out.find((s) => s.strategy === 'control')
+    expect(ctrl?.helpfulRate).toBe(50)
+    expect(ctrl?.samples).toBe(2)
+  })
+
+  it('ranks hundreds of bounties within performance budget', () => {
+    const bounties = Array.from({ length: 400 }, (_, i) =>
+      sampleBounty({ id: `b${i}`, tags: i % 2 === 0 ? ['react'] : ['legal'] }),
+    )
+    const creator = sampleCreator()
+    const t0 = performance.now()
+    rankBountiesForCreator(bounties, creator, 'control', 50)
+    expect(performance.now() - t0).toBeLessThan(2000)
+  })
+})

--- a/app/api/matching/notify/route.ts
+++ b/app/api/matching/notify/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { PrismaClient } from '@prisma/client'
+import { z } from 'zod'
+import { authOptions } from '@/lib/auth'
+
+const prisma = new PrismaClient()
+
+const bodySchema = z.object({
+  title: z.string().min(1).max(120).optional(),
+  lines: z.array(z.string().min(1)).min(1).max(12),
+  relatedBountyId: z.string().optional(),
+})
+
+/**
+ * Stores a match digest the user can read later (separate from global app notifications).
+ */
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let json: unknown
+  try {
+    json = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const parsed = bodySchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const title = parsed.data.title ?? 'New personalized matches'
+  const bodyText = parsed.data.lines.slice(0, 8).join('\n')
+
+  await prisma.matchNotification.create({
+    data: {
+      userId: session.user.id,
+      title,
+      body: bodyText,
+      relatedBountyId: parsed.data.relatedBountyId ?? null,
+    },
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/matching/route.ts
+++ b/app/api/matching/route.ts
@@ -1,0 +1,254 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { PrismaClient } from '@prisma/client'
+import { z } from 'zod'
+import { authOptions } from '@/lib/auth'
+import {
+  assignStrategy,
+  rankBountiesForCreator,
+  rankCreatorsForBounty,
+  aggregateStrategyInsights,
+  type BountyFeatures,
+  type CreatorFeatures,
+  type MatchingStrategy,
+  MATCHING_STRATEGIES,
+} from '@/lib/matching-engine'
+
+const prisma = new PrismaClient()
+
+const feedbackSchema = z.object({
+  strategy: z.string(),
+  mode: z.enum(['FOR_CREATOR', 'FOR_CLIENT']),
+  contextId: z.string().nullable().optional(),
+  matchId: z.string().min(1),
+  score: z.number().optional(),
+  helpful: z.boolean(),
+})
+
+function toBountyFeatures(b: {
+  id: string
+  title: string
+  description: string
+  budget: number
+  category: string | null
+  tags: string[]
+}): BountyFeatures {
+  return {
+    id: b.id,
+    title: b.title,
+    description: b.description,
+    budget: b.budget,
+    category: b.category,
+    tags: b.tags ?? [],
+  }
+}
+
+function toCreatorFeatures(p: {
+  id: string
+  userId: string
+  displayName: string
+  bio: string | null
+  discipline: string | null
+  skills: string[]
+  rating: number
+  completedProjects: number
+}): CreatorFeatures {
+  return {
+    profileId: p.id,
+    userId: p.userId,
+    displayName: p.displayName,
+    bio: p.bio,
+    discipline: p.discipline,
+    skills: p.skills ?? [],
+    rating: p.rating,
+    completedProjects: p.completedProjects,
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const metrics = searchParams.get('metrics') === '1'
+
+  if (metrics) {
+    if (session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    const rows = await prisma.matchFeedback.findMany({
+      select: { strategy: true, helpful: true },
+    })
+    return NextResponse.json({
+      insights: aggregateStrategyInsights(rows),
+      totalFeedback: rows.length,
+    })
+  }
+
+  const role = session.user.role
+  const forParam = searchParams.get('for')
+  const bountyId = searchParams.get('bountyId')
+  const strategyOverride = searchParams.get('strategy')
+  const limit = Math.min(50, Math.max(1, Number(searchParams.get('limit') ?? '12') || 12))
+
+  const strategy = assignStrategy(session.user.id, strategyOverride) as MatchingStrategy
+
+  const wantCreatorFeed =
+    forParam === 'creator' ||
+    (forParam == null && (role === 'CREATOR' || role === 'ADMIN'))
+
+  if (wantCreatorFeed && role !== 'CREATOR' && role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  if (wantCreatorFeed) {
+    const profile = await prisma.creatorProfile.findUnique({
+      where: { userId: session.user.id },
+    })
+    if (!profile) {
+      if (role !== 'ADMIN') {
+        return NextResponse.json(
+          { error: 'Creator profile required', matches: [], strategy },
+          { status: 400 },
+        )
+      }
+      /* Admin without creator profile: fall through to client recommendations */
+    } else {
+      const open = await prisma.bounty.findMany({
+        where: {
+          status: 'OPEN',
+          creatorId: { not: session.user.id },
+        },
+      })
+
+      const creator = toCreatorFeatures(profile)
+      const ranked = rankBountiesForCreator(
+        open.map(toBountyFeatures),
+        creator,
+        strategy,
+        limit,
+      )
+
+      return NextResponse.json({
+        strategy,
+        mode: 'FOR_CREATOR' as const,
+        matches: ranked.map((r) => ({
+          type: 'bounty' as const,
+          id: r.bounty.id,
+          title: r.bounty.title,
+          budget: r.bounty.budget,
+          category: r.bounty.category,
+          tags: r.bounty.tags,
+          score: r.breakdown.score,
+          reasons: r.breakdown.reasons,
+          components: r.breakdown.components,
+          href: '/bounties',
+        })),
+      })
+    }
+  }
+
+  if (role !== 'CLIENT' && role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const bounty =
+    bountyId != null
+      ? await prisma.bounty.findFirst({
+          where: {
+            id: bountyId,
+            creatorId: session.user.id,
+            status: 'OPEN',
+          },
+        })
+      : await prisma.bounty.findFirst({
+          where: { creatorId: session.user.id, status: 'OPEN' },
+          orderBy: { updatedAt: 'desc' },
+        })
+
+  if (!bounty) {
+    return NextResponse.json({
+      strategy,
+      mode: 'FOR_CLIENT' as const,
+      matches: [],
+      message: 'Create an open bounty to see recommended creators.',
+    })
+  }
+
+  const profiles = await prisma.creatorProfile.findMany({
+    where: { userId: { not: session.user.id } },
+  })
+
+  const bountyFeat = toBountyFeatures(bounty)
+  const ranked = rankCreatorsForBounty(
+    bountyFeat,
+    profiles.map(toCreatorFeatures),
+    strategy,
+    limit,
+  )
+
+  return NextResponse.json({
+    strategy,
+    mode: 'FOR_CLIENT' as const,
+    contextBounty: {
+      id: bounty.id,
+      title: bounty.title,
+      budget: bounty.budget,
+      category: bounty.category,
+    },
+    matches: ranked.map((r) => ({
+      type: 'creator' as const,
+      id: r.creator.profileId,
+      userId: r.creator.userId,
+      title: r.creator.displayName,
+      discipline: r.creator.discipline,
+      skills: r.creator.skills,
+      rating: r.creator.rating,
+      completedProjects: r.creator.completedProjects,
+      score: r.breakdown.score,
+      reasons: r.breakdown.reasons,
+      components: r.breakdown.components,
+      href: '/creators',
+    })),
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const parsed = feedbackSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const { strategy, mode, contextId, matchId, score, helpful } = parsed.data
+  if (!MATCHING_STRATEGIES.includes(strategy as MatchingStrategy)) {
+    return NextResponse.json({ error: 'Unknown strategy' }, { status: 400 })
+  }
+
+  await prisma.matchFeedback.create({
+    data: {
+      userId: session.user.id,
+      strategy,
+      mode,
+      contextId: contextId ?? null,
+      matchId,
+      score: score ?? null,
+      helpful,
+    },
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -1,0 +1,309 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Header } from '@/components/layout/header'
+import { Footer } from '@/components/layout/footer'
+import { MatchCard, type MatchCardModel } from '@/components/match-card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from '@/components/ui/empty'
+import { Sparkles, Bell, BarChart3 } from 'lucide-react'
+
+type ApiMatch = {
+  type: 'bounty' | 'creator'
+  id: string
+  title: string
+  score: number
+  reasons: string[]
+  href: string
+  budget?: number
+  category?: string | null
+  tags?: string[]
+  discipline?: string | null
+  skills?: string[]
+  rating?: number
+  completedProjects?: number
+}
+
+type MatchResponse = {
+  strategy: string
+  mode: 'FOR_CREATOR' | 'FOR_CLIENT'
+  matches: ApiMatch[]
+  message?: string
+  contextBounty?: { id: string; title: string; budget: number; category: string | null }
+}
+
+function toCard(m: ApiMatch): MatchCardModel {
+  if (m.type === 'bounty') {
+    return {
+      type: 'bounty',
+      id: m.id,
+      title: m.title,
+      score: m.score,
+      reasons: m.reasons,
+      href: m.href,
+      subtitle: m.category ?? undefined,
+      meta: m.budget != null ? `Budget ~$${m.budget.toLocaleString()} · ${(m.tags ?? []).slice(0, 4).join(', ')}` : undefined,
+    }
+  }
+  return {
+    type: 'creator',
+    id: m.id,
+    title: m.title,
+    score: m.score,
+    reasons: m.reasons,
+    href: m.href,
+    subtitle: m.discipline ?? undefined,
+    meta:
+      m.rating != null
+        ? `★ ${m.rating.toFixed(1)} · ${m.completedProjects ?? 0} projects · ${(m.skills ?? []).slice(0, 4).join(', ')}`
+        : undefined,
+  }
+}
+
+export default function MatchesPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [data, setData] = useState<MatchResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [insights, setInsights] = useState<{ strategy: string; samples: number; helpfulRate: number | null }[] | null>(
+    null,
+  )
+  const [digestBusy, setDigestBusy] = useState(false)
+
+  const load = useCallback(async () => {
+    if (status !== 'authenticated') return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/matching')
+      const json = (await res.json()) as MatchResponse & { error?: string }
+      if (!res.ok) {
+        setError(json.error ?? 'Could not load matches')
+        setData(null)
+        return
+      }
+      setData(json)
+    } catch {
+      setError('Network error')
+      setData(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [status])
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/auth/login')
+    }
+  }, [status, router])
+
+  useEffect(() => {
+    if (status === 'authenticated') void load()
+  }, [status, load])
+
+  useEffect(() => {
+    if (status !== 'authenticated' || session?.user.role !== 'ADMIN') return
+    void (async () => {
+      const res = await fetch('/api/matching?metrics=1')
+      if (!res.ok) return
+      const j = await res.json()
+      setInsights(j.insights ?? null)
+    })()
+  }, [status, session?.user.role])
+
+  const saveDigest = async () => {
+    if (!data?.matches.length) return
+    setDigestBusy(true)
+    try {
+      const lines = data.matches.slice(0, 5).map((m, i) => `${i + 1}. ${m.title} (${m.score}%)`)
+      await fetch('/api/matching/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          lines: [`Strategy: ${data.strategy}`, ...lines],
+          relatedBountyId: data.contextBounty?.id,
+        }),
+      })
+    } finally {
+      setDigestBusy(false)
+    }
+  }
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen bg-background">
+        <Header />
+        <div className="max-w-6xl mx-auto px-4 py-10 space-y-4">
+          <Skeleton className="h-10 w-72" />
+          <Skeleton className="h-48 w-full" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!session) return null
+
+  const role = session.user.role
+  const eligible = role === 'CREATOR' || role === 'CLIENT' || role === 'ADMIN'
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background">
+      <Header />
+
+      <main className="flex-1">
+        <section className="border-b border-border bg-muted/30 py-10 sm:py-14">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+              <div>
+                <h1 className="text-3xl sm:text-4xl font-bold text-foreground flex items-center gap-2">
+                  <Sparkles className="h-8 w-8 text-primary shrink-0" aria-hidden />
+                  For you
+                </h1>
+                <p className="text-muted-foreground mt-2 max-w-2xl">
+                  Personalized bounty and creator suggestions from skill overlap, brief alignment, reputation, and budget
+                  fit. Feedback trains future ranking experiments.
+                </p>
+              </div>
+              {data ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline" className="text-xs">
+                    A/B: {data.strategy}
+                  </Badge>
+                  {eligible ? (
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      className="gap-1.5"
+                      disabled={!data.matches.length || digestBusy}
+                      onClick={() => void saveDigest()}
+                    >
+                      <Bell className="h-4 w-4" aria-hidden />
+                      Save digest
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </section>
+
+        <section className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+          {!eligible ? (
+            <Empty>
+              <EmptyHeader>
+                <EmptyTitle>Switch to a creator or client account</EmptyTitle>
+                <EmptyDescription>
+                  Matching runs from your creator profile (open bounties) or your client bounties (recommended talent).
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          ) : loading ? (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-64 rounded-xl" />
+              ))}
+            </div>
+          ) : error ? (
+            <Empty>
+              <EmptyHeader>
+                <EmptyTitle>{error}</EmptyTitle>
+                <EmptyDescription>
+                  <Button type="button" variant="outline" onClick={() => void load()}>
+                    Retry
+                  </Button>
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          ) : data && data.matches.length === 0 ? (
+            <Empty>
+              <EmptyHeader>
+                <EmptyTitle>No matches yet</EmptyTitle>
+                <EmptyDescription>
+                  {data.message ?? 'Add skills to your profile or post an open bounty, then check back.'}
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          ) : data ? (
+            <>
+              {data.contextBounty ? (
+                <p className="text-sm text-muted-foreground mb-6">
+                  Suggestions for{' '}
+                  <span className="font-medium text-foreground">{data.contextBounty.title}</span> (~$
+                  {data.contextBounty.budget.toLocaleString()})
+                </p>
+              ) : null}
+
+              {session.user.role === 'ADMIN' && insights?.length ? (
+                <div className="mb-8 rounded-lg border border-border bg-card p-4">
+                  <div className="flex items-center gap-2 text-sm font-medium mb-3">
+                    <BarChart3 className="h-4 w-4" aria-hidden />
+                    Match feedback by strategy
+                  </div>
+                  <ul className="grid sm:grid-cols-3 gap-2 text-sm">
+                    {insights.map((row) => (
+                      <li key={row.strategy} className="rounded-md bg-muted/50 px-3 py-2">
+                        <span className="font-mono text-xs">{row.strategy}</span>
+                        <div className="text-muted-foreground">
+                          n={row.samples}
+                          {row.helpfulRate != null ? ` · ${row.helpfulRate}% helpful` : ''}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {data.matches.map((m) => (
+                  <MatchCard
+                    key={`${m.type}-${m.id}`}
+                    match={toCard(m)}
+                    strategy={data.strategy}
+                    mode={data.mode}
+                    contextId={data.contextBounty?.id ?? null}
+                  />
+                ))}
+              </div>
+
+              <p className="text-xs text-muted-foreground mt-8 max-w-3xl">
+                Scores use public profile and bounty text only. For production ML, swap the scorer in{' '}
+                <code className="rounded bg-muted px-1">lib/matching-engine.ts</code> for embeddings + vector search;
+                keep the same API contract for A/B and feedback.
+              </p>
+            </>
+          ) : null}
+
+          <div className="mt-10 flex flex-wrap gap-3">
+            <Button variant="outline" asChild>
+              <Link href="/dashboard">Back to dashboard</Link>
+            </Button>
+            {role === 'CREATOR' || role === 'ADMIN' ? (
+              <Button variant="outline" asChild>
+                <Link href="/bounties">Browse bounties</Link>
+              </Button>
+            ) : null}
+            {role === 'CLIENT' || role === 'ADMIN' ? (
+              <Button variant="outline" asChild>
+                <Link href="/creators">Browse creators</Link>
+              </Button>
+            ) : null}
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { useTheme } from 'next-themes';
-import { Moon, Sun, Menu, X, User, LogOut, LayoutDashboard } from 'lucide-react';
+import { Moon, Sun, Menu, X, User, LogOut, LayoutDashboard, Sparkles } from 'lucide-react';
 import { useRef, useState, useEffect } from 'react';
 import { useSession, signOut } from 'next-auth/react';
 import { Button } from '@/components/ui/button';
@@ -107,9 +107,18 @@ export function Header() {
               About
             </Link>
             {session && (
-              <Link href="/disputes" className="px-4 py-2 text-sm font-medium text-foreground hover:text-primary transition-colors rounded-lg hover:bg-secondary/50">
-                Disputes
-              </Link>
+              <>
+                <Link
+                  href="/matches"
+                  className="px-4 py-2 text-sm font-medium text-foreground hover:text-primary transition-colors rounded-lg hover:bg-secondary/50 inline-flex items-center gap-1.5"
+                >
+                  <Sparkles size={15} className="text-primary shrink-0" aria-hidden />
+                  Matches
+                </Link>
+                <Link href="/disputes" className="px-4 py-2 text-sm font-medium text-foreground hover:text-primary transition-colors rounded-lg hover:bg-secondary/50">
+                  Disputes
+                </Link>
+              </>
             )}
           </nav>
 
@@ -146,6 +155,12 @@ export function Header() {
                       <Link href="/dashboard" className="flex items-center">
                         <LayoutDashboard className="mr-2 h-4 w-4" />
                         Dashboard
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <Link href="/matches" className="flex items-center">
+                        <Sparkles className="mr-2 h-4 w-4 text-primary" />
+                        Matches
                       </Link>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from 'react'
 import type { Session } from 'next-auth'
-import { ChevronDown, LayoutDashboard, LogOut, User, X } from 'lucide-react'
+import { ChevronDown, LayoutDashboard, LogOut, Sparkles, User, X } from 'lucide-react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { cn } from '@/lib/utils'
 import {
@@ -280,6 +280,10 @@ export function MobileNav({
                 <Link href="/dashboard" onClick={close} className={navLinkClass}>
                   <LayoutDashboard className="mr-2 h-5 w-5 shrink-0" aria-hidden />
                   Dashboard
+                </Link>
+                <Link href="/matches" onClick={close} className={navLinkClass}>
+                  <Sparkles className="mr-2 h-5 w-5 shrink-0 text-primary" aria-hidden />
+                  Matches
                 </Link>
                 <Link href="/dashboard" onClick={close} className={navLinkClass}>
                   <User className="mr-2 h-5 w-5 shrink-0" aria-hidden />

--- a/components/match-card.tsx
+++ b/components/match-card.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
+import { ThumbsDown, ThumbsUp, ExternalLink } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface MatchCardModel {
+  type: 'bounty' | 'creator'
+  id: string
+  title: string
+  score: number
+  reasons: string[]
+  href: string
+  subtitle?: string
+  meta?: string
+}
+
+interface MatchCardProps {
+  match: MatchCardModel
+  strategy: string
+  mode: 'FOR_CREATOR' | 'FOR_CLIENT'
+  contextId?: string | null
+  onFeedbackSent?: () => void
+}
+
+export function MatchCard({ match, strategy, mode, contextId, onFeedbackSent }: MatchCardProps) {
+  const [busy, setBusy] = useState(false)
+  const [done, setDone] = useState<'up' | 'down' | null>(null)
+
+  const sendFeedback = async (helpful: boolean) => {
+    if (done || busy) return
+    setBusy(true)
+    try {
+      const res = await fetch('/api/matching', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          strategy,
+          mode,
+          contextId: contextId ?? null,
+          matchId: match.id,
+          score: match.score,
+          helpful,
+        }),
+      })
+      if (res.ok) {
+        setDone(helpful ? 'up' : 'down')
+        onFeedbackSent?.()
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Card className="flex flex-col h-full border-border/80 shadow-sm hover:shadow-md transition-shadow">
+      <CardHeader className="pb-2 space-y-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <h3 className="font-semibold text-foreground leading-snug line-clamp-2">{match.title}</h3>
+            {match.subtitle ? (
+              <p className="text-sm text-muted-foreground mt-0.5 line-clamp-1">{match.subtitle}</p>
+            ) : null}
+          </div>
+          <Badge variant="secondary" className="shrink-0 tabular-nums">
+            {match.score}%
+          </Badge>
+        </div>
+        {match.meta ? <p className="text-xs text-muted-foreground font-mono truncate">{match.meta}</p> : null}
+      </CardHeader>
+      <CardContent className="flex-1 pt-0">
+        <p className="text-xs font-medium text-muted-foreground mb-1.5">Why this match</p>
+        <ul className="text-sm text-muted-foreground space-y-1 list-disc pl-4">
+          {match.reasons.map((r, i) => (
+            <li key={i}>{r}</li>
+          ))}
+        </ul>
+      </CardContent>
+      <CardFooter className="flex flex-col gap-2 pt-2 border-t border-border/60">
+        <Button variant="outline" size="sm" className="w-full gap-2" asChild>
+          <Link href={match.href}>
+            Open
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+          </Link>
+        </Button>
+        <div className="flex gap-2 w-full">
+          <Button
+            type="button"
+            variant={done === 'up' ? 'default' : 'secondary'}
+            size="sm"
+            className={cn('flex-1 gap-1', done && done !== 'up' && 'opacity-40')}
+            disabled={busy || !!done}
+            onClick={() => void sendFeedback(true)}
+          >
+            <ThumbsUp className="h-3.5 w-3.5" aria-hidden />
+            Helpful
+          </Button>
+          <Button
+            type="button"
+            variant={done === 'down' ? 'destructive' : 'secondary'}
+            size="sm"
+            className={cn('flex-1 gap-1', done && done !== 'down' && 'opacity-40')}
+            disabled={busy || !!done}
+            onClick={() => void sendFeedback(false)}
+          >
+            <ThumbsDown className="h-3.5 w-3.5" aria-hidden />
+            Not for me
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/lib/matching-engine.ts
+++ b/lib/matching-engine.ts
@@ -1,0 +1,246 @@
+/**
+ * Skill- and preference-based matching with deterministic A/B strategy weights.
+ * Uses only public profile and bounty fields (no demographics) to reduce bias surface.
+ * Replace inner scoring with an embedding model + vector search when you wire real ML.
+ */
+
+export const MATCHING_STRATEGIES = ['control', 'treatment_skill', 'treatment_budget'] as const
+export type MatchingStrategy = (typeof MATCHING_STRATEGIES)[number]
+
+export type MatchMode = 'FOR_CREATOR' | 'FOR_CLIENT'
+
+export interface BountyFeatures {
+  id: string
+  title: string
+  description: string
+  budget: number
+  category: string | null
+  tags: string[]
+}
+
+export interface CreatorFeatures {
+  profileId: string
+  userId: string
+  displayName: string
+  bio: string | null
+  discipline: string | null
+  skills: string[]
+  rating: number
+  completedProjects: number
+}
+
+export interface MatchScoreBreakdown {
+  score: number
+  /** 0–100 before strategy multiplier noise */
+  rawScore: number
+  reasons: string[]
+  components: {
+    skillOverlap: number
+    textRelevance: number
+    disciplineMatch: number
+    reputation: number
+    budgetFit: number
+  }
+}
+
+const STOP = new Set([
+  'the', 'a', 'an', 'and', 'or', 'for', 'to', 'of', 'in', 'on', 'with', 'your', 'our', 'we', 'you',
+  'is', 'are', 'be', 'this', 'that', 'from', 'as', 'at', 'by', 'it', 'will', 'can', 'need', 'looking',
+])
+
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9+#\s]/g, ' ')
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 1 && !STOP.has(t))
+}
+
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0
+  let inter = 0
+  for (const x of a) {
+    if (b.has(x)) inter++
+  }
+  const union = a.size + b.size - inter
+  return union === 0 ? 0 : inter / union
+}
+
+export function bagOverlap(a: string[], b: string[]): number {
+  const A = new Set(a.map((s) => s.toLowerCase().trim()).filter(Boolean))
+  const B = new Set(b.map((s) => s.toLowerCase().trim()).filter(Boolean))
+  return jaccard(A, B)
+}
+
+function textRelevance(bounty: BountyFeatures, creator: CreatorFeatures): number {
+  const bountyTokens = new Set(
+    tokenize(`${bounty.title} ${bounty.description} ${bounty.category ?? ''} ${bounty.tags.join(' ')}`),
+  )
+  const creatorTokens = new Set(
+    tokenize(`${creator.displayName} ${creator.bio ?? ''} ${creator.discipline ?? ''} ${creator.skills.join(' ')}`),
+  )
+  return jaccard(bountyTokens, creatorTokens)
+}
+
+function skillTagOverlap(bounty: BountyFeatures, creator: CreatorFeatures): number {
+  const bountySide = [...bounty.tags, bounty.category].filter(Boolean) as string[]
+  return bagOverlap(bountySide, creator.skills)
+}
+
+function disciplineMatch(bounty: BountyFeatures, creator: CreatorFeatures): number {
+  if (!creator.discipline || !bounty.category) return 0.35
+  const d = creator.discipline.toLowerCase()
+  const c = bounty.category.toLowerCase()
+  if (d === c) return 1
+  if (c.includes(d) || d.includes(c)) return 0.75
+  return 0.2
+}
+
+function reputation(creator: CreatorFeatures): number {
+  const r = Math.min(1, creator.rating / 5)
+  const exp = Math.min(1, creator.completedProjects / 25)
+  return r * 0.65 + exp * 0.35
+}
+
+/** Heuristic: higher completion count → comfortable with larger briefs */
+function budgetFit(bounty: BountyFeatures, creator: CreatorFeatures): number {
+  const b = bounty.budget
+  const tier = Math.min(1, creator.completedProjects / 20)
+  const softMin = 300 + tier * 1500
+  const softMax = 5000 + tier * 25000
+  if (b >= softMin && b <= softMax) return 1
+  const dist =
+    b < softMin ? (softMin - b) / softMin : (b - softMax) / Math.max(softMax, 1)
+  return Math.max(0, 1 - Math.min(1, dist))
+}
+
+const WEIGHTS = {
+  control: { skill: 1, text: 1, disc: 1, rep: 1, budget: 1 },
+  treatment_skill: { skill: 1.85, text: 1, disc: 1.1, rep: 0.95, budget: 0.85 },
+  treatment_budget: { skill: 0.9, text: 1, disc: 1, rep: 1, budget: 1.75 },
+} as const
+
+function clamp01(x: number): number {
+  return Math.max(0, Math.min(1, x))
+}
+
+/**
+ * Compatibility score for pairing a creator with a bounty (symmetric use).
+ */
+export function scoreCreatorBountyPair(
+  bounty: BountyFeatures,
+  creator: CreatorFeatures,
+  strategy: MatchingStrategy = 'control',
+): MatchScoreBreakdown {
+  const w = WEIGHTS[strategy] ?? WEIGHTS.control
+  const skillOverlap = skillTagOverlap(bounty, creator)
+  const textRel = textRelevance(bounty, creator)
+  const disc = disciplineMatch(bounty, creator)
+  const rep = reputation(creator)
+  const budget = budgetFit(bounty, creator)
+
+  const weighted =
+    skillOverlap * 0.34 * w.skill +
+    textRel * 0.22 * w.text +
+    disc * 0.14 * w.disc +
+    rep * 0.18 * w.rep +
+    budget * 0.12 * w.budget
+
+  const norm = 0.34 * w.skill + 0.22 * w.text + 0.14 * w.disc + 0.18 * w.rep + 0.12 * w.budget
+  const raw = clamp01(weighted / norm)
+  const score = Math.round(raw * 1000) / 10
+
+  const reasons: string[] = []
+  if (skillOverlap >= 0.35) reasons.push('Strong overlap between bounty tags and your skills')
+  if (textRel >= 0.12) reasons.push('Brief aligns with your profile and bio')
+  if (disc >= 0.75) reasons.push('Category fits your discipline')
+  if (rep >= 0.72) reasons.push('Solid track record on the platform')
+  if (budget >= 0.85) reasons.push('Budget tier fits your experience level')
+  if (reasons.length === 0) reasons.push('Exploratory match — review the brief to decide fit')
+
+  return {
+    score,
+    rawScore: Math.round(raw * 1000) / 10,
+    reasons,
+    components: {
+      skillOverlap: Math.round(skillOverlap * 100) / 100,
+      textRelevance: Math.round(textRel * 100) / 100,
+      disciplineMatch: Math.round(disc * 100) / 100,
+      reputation: Math.round(rep * 100) / 100,
+      budgetFit: Math.round(budget * 100) / 100,
+    },
+  }
+}
+
+export function assignStrategy(userId: string, override?: string | null): MatchingStrategy {
+  if (override && MATCHING_STRATEGIES.includes(override as MatchingStrategy)) {
+    return override as MatchingStrategy
+  }
+  let h = 0
+  for (let i = 0; i < userId.length; i++) {
+    h = (h * 31 + userId.charCodeAt(i)) >>> 0
+  }
+  const bucket = h % 3
+  return MATCHING_STRATEGIES[bucket]!
+}
+
+export function rankBountiesForCreator(
+  bounties: BountyFeatures[],
+  creator: CreatorFeatures,
+  strategy: MatchingStrategy,
+  limit = 20,
+): Array<{ bounty: BountyFeatures; breakdown: MatchScoreBreakdown }> {
+  const ranked = bounties
+    .map((bounty) => ({
+      bounty,
+      breakdown: scoreCreatorBountyPair(bounty, creator, strategy),
+    }))
+    .sort((a, b) => b.breakdown.score - a.breakdown.score)
+  return ranked.slice(0, limit)
+}
+
+export function rankCreatorsForBounty(
+  bounty: BountyFeatures,
+  creators: CreatorFeatures[],
+  strategy: MatchingStrategy,
+  limit = 20,
+): Array<{ creator: CreatorFeatures; breakdown: MatchScoreBreakdown }> {
+  const ranked = creators
+    .map((creator) => ({
+      creator,
+      breakdown: scoreCreatorBountyPair(bounty, creator, strategy),
+    }))
+    .sort((a, b) => b.breakdown.score - a.breakdown.score)
+  return ranked.slice(0, limit)
+}
+
+export interface StrategyInsight {
+  strategy: string
+  samples: number
+  helpfulRate: number | null
+}
+
+/**
+ * Aggregate helpful rate per strategy for dashboards (A/B readout).
+ */
+export function aggregateStrategyInsights(
+  rows: { strategy: string; helpful: boolean }[],
+): StrategyInsight[] {
+  const map = new Map<string, { yes: number; no: number }>()
+  for (const r of rows) {
+    const cur = map.get(r.strategy) ?? { yes: 0, no: 0 }
+    if (r.helpful) cur.yes++
+    else cur.no++
+    map.set(r.strategy, cur)
+  }
+  return MATCHING_STRATEGIES.map((strategy) => {
+    const c = map.get(strategy) ?? { yes: 0, no: 0 }
+    const n = c.yes + c.no
+    return {
+      strategy,
+      samples: n,
+      helpfulRate: n === 0 ? null : Math.round((c.yes / n) * 1000) / 10,
+    }
+  })
+}

--- a/prisma/migrations/20260328120000_match_feedback/migration.sql
+++ b/prisma/migrations/20260328120000_match_feedback/migration.sql
@@ -1,0 +1,40 @@
+-- CreateTable
+CREATE TABLE "MatchFeedback" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "strategy" TEXT NOT NULL,
+    "mode" TEXT NOT NULL,
+    "contextId" TEXT,
+    "matchId" TEXT NOT NULL,
+    "score" DOUBLE PRECISION,
+    "helpful" BOOLEAN NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MatchFeedback_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MatchFeedback_userId_createdAt_idx" ON "MatchFeedback"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "MatchFeedback_strategy_helpful_idx" ON "MatchFeedback"("strategy", "helpful");
+
+-- AddForeignKey
+ALTER TABLE "MatchFeedback" ADD CONSTRAINT "MatchFeedback_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable
+CREATE TABLE "MatchNotification" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "read" BOOLEAN NOT NULL DEFAULT false,
+    "relatedBountyId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MatchNotification_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "MatchNotification_userId_createdAt_idx" ON "MatchNotification"("userId", "createdAt");
+
+ALTER TABLE "MatchNotification" ADD CONSTRAINT "MatchNotification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,8 @@ model User {
   clientProfile  ClientProfile?
   bounties       Bounty[]
   applications   BountyApplication[]
+  matchFeedback       MatchFeedback[]
+  matchNotifications  MatchNotification[]
 
   @@index([email])
 }
@@ -207,4 +209,33 @@ enum ReviewStatus {
   PENDING
   APPROVED
   REJECTED
+}
+
+model MatchFeedback {
+  id        String   @id @default(cuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  strategy  String
+  mode      String
+  contextId String?
+  matchId   String
+  score     Float?
+  helpful   Boolean
+  createdAt DateTime @default(now())
+
+  @@index([userId, createdAt])
+  @@index([strategy, helpful])
+}
+
+model MatchNotification {
+  id              String   @id @default(cuid())
+  userId          String
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  title           String
+  body            String   @db.Text
+  read            Boolean  @default(false)
+  relatedBountyId String?
+  createdAt       DateTime @default(now())
+
+  @@index([userId, createdAt])
 }


### PR DESCRIPTION
## Summary

Adds personalized creator–bounty matching using a deterministic scoring model (skill/tag overlap, text relevance, discipline, reputation, budget fit) with three A/B strategies. Feedback is stored for analytics and future model improvements; digests can be saved as in-app match notifications.

## What changed
closes #33
- **`lib/matching-engine.ts`** — Tokenization, Jaccard overlap, weighted compatibility score, `assignStrategy` for sticky A/B buckets, ranking helpers, strategy insight aggregation.
- **`app/api/matching/route.ts`** — `GET` recommendations (creators → open bounties; clients → creators for an open bounty), optional `?bountyId=` / `?strategy=` / `?limit=`; `GET ?metrics=1` for **ADMIN** feedback rates; `POST` match feedback.
- **`app/api/matching/notify/route.ts`** — `POST` to persist a text digest as `MatchNotification`.
- **`app/matches/page.tsx`** + **`components/match-card.tsx`** — Matches UI, helpful / not-for-me, save digest, admin metrics panel.
- **Navigation** — “Matches” links in header, user menu, and mobile nav.
- **Prisma** — `MatchFeedback`, `MatchNotification`, migration `20260328120000_match_feedback`.

## Deploy / ops

- Run **`pnpm exec prisma migrate deploy`** (or your usual migration step) before using the new tables in production.

## How to test

- `pnpm exec vitest run __tests__/lib/matching-engine.test.ts`
- `pnpm exec eslint` on touched files (or `pnpm run frontend:orbit-check` for the whole app).
- Log in as **CREATOR** (with `CreatorProfile`) or **CLIENT** (with an **OPEN** bounty), open **`/matches`**, submit feedback, and (optional) “Save digest”.

## Notes

- Scoring is **not** a hosted ML API yet; it is structured so embeddings + vector search can replace the inner scorer later without changing the HTTP contract.
- “Open” links for bounties/creators point to **`/bounties`** and **`/creators`** until listing/detail pages are fully wired to Prisma IDs.

## Checklist

- [ ] Migration applied in target environment
- [ ] Smoke test `/matches` for creator and client roles