### PR TITLE
feat(auth): implement GET /auth/challenge endpoint

### DIFF
--- a/backend/services/auth/Cargo.toml
+++ b/backend/services/auth/Cargo.toml
@@ -25,3 +25,5 @@ qrcode = "0.14"
 sha2.workspace = true
 hex.workspace = true
 thiserror.workspace = true
+rand = { version = "0.8", features = ["getrandom"] }
+urlencoding = "2.1"

--- a/backend/services/auth/src/main.rs
+++ b/backend/services/auth/src/main.rs
@@ -1,4 +1,5 @@
 use actix_web::{middleware, web, App, HttpResponse, HttpServer};
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use totp_lite::{totp_custom, Sha1};
@@ -142,6 +143,24 @@ fn generate_qr_code_url(user_id: &str, secret: &str, issuer: &str) -> String {
     otpauth_url
 }
 
+/// Generate a cryptographically secure random nonce (32 bytes, hex-encoded)
+fn generate_nonce() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+#[derive(Serialize)]
+pub struct ChallengeResponse {
+    pub nonce: String,
+}
+
+async fn get_challenge() -> HttpResponse {
+    let nonce = generate_nonce();
+    tracing::debug!("Generated auth challenge nonce");
+    HttpResponse::Ok().json(ApiResponse::ok(ChallengeResponse { nonce }))
+}
+
 async fn health() -> HttpResponse {
     HttpResponse::Ok().json(serde_json::json!({
         "status": "healthy",
@@ -240,6 +259,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(middleware::Logger::default())
             .wrap(middleware::NormalizePath::trim())
             .route("/health", web::get().to(health))
+            .route("/api/auth/challenge", web::get().to(get_challenge))
             .route("/api/auth/mfa/setup", web::post().to(setup_mfa))
             .route("/api/auth/mfa/verify", web::post().to(verify_mfa))
             .route("/api/auth/mfa/backup-codes", web::post().to(generate_backup_codes))
@@ -293,5 +313,47 @@ mod tests {
         let formatted = format!("{}-{}", &code[..4], &code[4..]);
         assert_eq!(formatted.len(), 9); // 4 + 1 (dash) + 4
         assert!(formatted.contains('-'));
+    }
+
+    #[test]
+    fn test_generate_nonce_length() {
+        let nonce = generate_nonce();
+        // 32 bytes hex-encoded = 64 hex characters
+        assert_eq!(nonce.len(), 64);
+    }
+
+    #[test]
+    fn test_generate_nonce_is_hex() {
+        let nonce = generate_nonce();
+        assert!(nonce.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_generate_nonce_uniqueness() {
+        let n1 = generate_nonce();
+        let n2 = generate_nonce();
+        assert_ne!(n1, n2, "Two nonces should not be identical");
+    }
+
+    #[actix_web::test]
+    async fn test_get_challenge_endpoint() {
+        use actix_web::test;
+        let app = test::init_service(
+            App::new().route("/api/auth/challenge", web::get().to(get_challenge)),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/api/auth/challenge")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert!(resp.status().is_success());
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["success"], true);
+        let nonce = body["data"]["nonce"].as_str().expect("nonce must be a string");
+        assert_eq!(nonce.len(), 64);
+        assert!(nonce.chars().all(|c| c.is_ascii_hexdigit()));
     }
 }


### PR DESCRIPTION
- Add GET /api/auth/challenge route that returns a cryptographically secure random nonce (32 bytes, hex-encoded) for signature verification
- Use rand::thread_rng().fill_bytes() for OS-backed CSPRNG instead of the timestamp-based rand_string helper used elsewhere in the file
- Add ChallengeResponse struct and generate_nonce() helper function
- Register route in HttpServer alongside existing MFA routes

Tests added:
- test_generate_nonce_length: verifies 64-char hex output (32 bytes)
- test_generate_nonce_is_hex: verifies all characters are valid hex
- test_generate_nonce_uniqueness: verifies two calls produce different nonces
- test_get_challenge_endpoint: integration test via actix-web test harness confirming HTTP 200, success:true, and correct nonce format

Closes #307