### PR TITLE
feat(api): add domain models for consistent API responses

### DIFF
--- a/backend/services/api/src/main.rs
+++ b/backend/services/api/src/main.rs
@@ -1,9 +1,115 @@
 use actix_web::{web, App, HttpServer, HttpResponse, middleware};
 use serde::{Deserialize, Serialize};
-use std::sync::Mutex;
 use tracing_subscriber;
 
-// ==================== Data Models ====================
+// ==================== Domain Models ====================
+
+/// Machine-readable error codes returned by the API.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ApiErrorCode {
+    BadRequest,
+    ValidationError,
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    Conflict,
+    UnprocessableEntity,
+    InternalServerError,
+    ServiceUnavailable,
+}
+
+/// Per-field validation error detail.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct FieldError {
+    pub field: String,
+    pub message: String,
+}
+
+/// Structured error payload included in failed responses.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct ApiError {
+    pub code: ApiErrorCode,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field_errors: Option<Vec<FieldError>>,
+}
+
+impl ApiError {
+    pub fn new(code: ApiErrorCode, message: impl Into<String>) -> Self {
+        ApiError { code, message: message.into(), field_errors: None }
+    }
+
+    pub fn with_field_errors(
+        code: ApiErrorCode,
+        message: impl Into<String>,
+        field_errors: Vec<FieldError>,
+    ) -> Self {
+        ApiError { code, message: message.into(), field_errors: Some(field_errors) }
+    }
+
+    pub fn not_found(resource: impl Into<String>) -> Self {
+        ApiError::new(ApiErrorCode::NotFound, format!("{} not found", resource.into()))
+    }
+
+    pub fn internal() -> Self {
+        ApiError::new(ApiErrorCode::InternalServerError, "An unexpected error occurred")
+    }
+}
+
+/// Pagination metadata for list responses.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct PaginationMeta {
+    pub page: u32,
+    pub limit: u32,
+    pub total: u64,
+    pub total_pages: u32,
+}
+
+impl PaginationMeta {
+    pub fn new(page: u32, limit: u32, total: u64) -> Self {
+        let total_pages = ((total as f64) / (limit as f64)).ceil() as u32;
+        PaginationMeta { page, limit, total, total_pages }
+    }
+}
+
+/// Paginated list payload.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct PaginatedData<T> {
+    pub items: Vec<T>,
+    pub pagination: PaginationMeta,
+}
+
+impl<T> PaginatedData<T> {
+    pub fn new(items: Vec<T>, page: u32, limit: u32, total: u64) -> Self {
+        PaginatedData { items, pagination: PaginationMeta::new(page, limit, total) }
+    }
+}
+
+/// Envelope wrapping every API response.
+///
+/// On success: `success=true`, `data=Some(T)`, `error=None`.
+/// On failure: `success=false`, `data=None`, `error=Some(ApiError)`.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct ApiResponse<T> {
+    pub success: bool,
+    pub data: Option<T>,
+    pub error: Option<ApiError>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+impl<T> ApiResponse<T> {
+    pub fn ok(data: T, message: Option<String>) -> Self {
+        ApiResponse { success: true, data: Some(data), error: None, message }
+    }
+
+    pub fn err(error: ApiError) -> Self {
+        ApiResponse { success: false, data: None, error: Some(error), message: None }
+    }
+}
+
+// ==================== Request Models ====================
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct BountyRequest {
@@ -30,37 +136,6 @@ pub struct FreelancerRegistration {
     pub bio: String,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct ApiResponse<T> {
-    pub success: bool,
-    pub data: Option<T>,
-    pub error: Option<String>,
-    pub message: Option<String>,
-}
-
-impl<T> ApiResponse<T> {
-    fn ok(data: T, message: Option<String>) -> Self {
-        ApiResponse {
-            success: true,
-            data: Some(data),
-            error: None,
-            message,
-        }
-    }
-
-    fn err(error: String) -> Self
-    where
-        T: Default,
-    {
-        ApiResponse {
-            success: false,
-            data: None,
-            error: Some(error),
-            message: None,
-        }
-    }
-}
-
 // ==================== Routes ====================
 
 /// Health check endpoint
@@ -78,7 +153,6 @@ async fn create_bounty(
 ) -> HttpResponse {
     tracing::info!("Creating bounty: {:?}", body.title);
 
-    // In a real implementation, this would interact with Soroban contract
     let response: ApiResponse<serde_json::Value> = ApiResponse::ok(
         serde_json::json!({
             "bounty_id": 1,
@@ -285,17 +359,109 @@ async fn main() -> std::io::Result<()> {
 mod tests {
     use super::*;
 
+    // ── ApiResponse ───────────────────────────────────────────────────────────
+
     #[test]
     fn test_api_response_ok() {
         let response: ApiResponse<String> = ApiResponse::ok("test".to_string(), None);
         assert!(response.success);
         assert_eq!(response.data, Some("test".to_string()));
+        assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn test_api_response_ok_with_message() {
+        let response: ApiResponse<u32> =
+            ApiResponse::ok(42, Some("Created successfully".to_string()));
+        assert!(response.success);
+        assert_eq!(response.data, Some(42));
+        assert_eq!(response.message, Some("Created successfully".to_string()));
     }
 
     #[test]
     fn test_api_response_err() {
-        let response: ApiResponse<String> = ApiResponse::err("error".to_string());
+        let error = ApiError::new(ApiErrorCode::NotFound, "Bounty not found");
+        let response: ApiResponse<String> = ApiResponse::err(error.clone());
         assert!(!response.success);
-        assert_eq!(response.error, Some("error".to_string()));
+        assert!(response.data.is_none());
+        assert_eq!(response.error, Some(error));
+    }
+
+    // ── ApiError ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_api_error_not_found() {
+        let err = ApiError::not_found("Bounty");
+        assert_eq!(err.code, ApiErrorCode::NotFound);
+        assert_eq!(err.message, "Bounty not found");
+        assert!(err.field_errors.is_none());
+    }
+
+    #[test]
+    fn test_api_error_internal() {
+        let err = ApiError::internal();
+        assert_eq!(err.code, ApiErrorCode::InternalServerError);
+    }
+
+    #[test]
+    fn test_api_error_with_field_errors() {
+        let field_errors = vec![
+            FieldError { field: "title".to_string(), message: "Title is required".to_string() },
+            FieldError { field: "budget".to_string(), message: "Budget must be positive".to_string() },
+        ];
+        let err = ApiError::with_field_errors(
+            ApiErrorCode::ValidationError,
+            "Validation failed",
+            field_errors.clone(),
+        );
+        assert_eq!(err.code, ApiErrorCode::ValidationError);
+        assert_eq!(err.field_errors, Some(field_errors));
+    }
+
+    // ── PaginationMeta ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_pagination_meta_exact_pages() {
+        let meta = PaginationMeta::new(1, 10, 30);
+        assert_eq!(meta.total_pages, 3);
+        assert_eq!(meta.total, 30);
+    }
+
+    #[test]
+    fn test_pagination_meta_partial_last_page() {
+        let meta = PaginationMeta::new(1, 10, 25);
+        assert_eq!(meta.total_pages, 3);
+    }
+
+    #[test]
+    fn test_pagination_meta_zero_total() {
+        let meta = PaginationMeta::new(1, 10, 0);
+        assert_eq!(meta.total_pages, 0);
+    }
+
+    // ── PaginatedData ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_paginated_data() {
+        let items = vec!["a", "b", "c"];
+        let pd = PaginatedData::new(items.clone(), 2, 3, 9);
+        assert_eq!(pd.items, items);
+        assert_eq!(pd.pagination.page, 2);
+        assert_eq!(pd.pagination.total_pages, 3);
+    }
+
+    // ── Serialisation ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_api_error_code_serialises_screaming_snake_case() {
+        let json = serde_json::to_string(&ApiErrorCode::ValidationError).unwrap();
+        assert_eq!(json, "\"VALIDATION_ERROR\"");
+    }
+
+    #[test]
+    fn test_field_errors_omitted_when_none() {
+        let err = ApiError::new(ApiErrorCode::NotFound, "not found");
+        let json = serde_json::to_value(&err).unwrap();
+        assert!(json.get("field_errors").is_none());
     }
 }

--- a/lib/api-models.ts
+++ b/lib/api-models.ts
@@ -1,0 +1,119 @@
+/**
+ * Domain models for API responses.
+ *
+ * Provides consistent data formatting and error handling for all
+ * communication between the frontend and the Stellar backend API.
+ * The shape mirrors the Rust `ApiResponse<T>` struct in
+ * `backend/services/api/src/main.rs`.
+ */
+
+// ── Core envelope ────────────────────────────────────────────────────────────
+
+/** Successful API response envelope. */
+export interface ApiSuccess<T> {
+  success: true;
+  data: T;
+  message?: string;
+  error: null;
+}
+
+/** Failed API response envelope. */
+export interface ApiFailure {
+  success: false;
+  data: null;
+  error: ApiError;
+  message?: string;
+}
+
+/** Discriminated union covering every API response shape. */
+export type ApiResponse<T> = ApiSuccess<T> | ApiFailure;
+
+// ── Error models ─────────────────────────────────────────────────────────────
+
+/** Structured error returned by the API. */
+export interface ApiError {
+  /** Machine-readable error code (e.g. "NOT_FOUND", "VALIDATION_ERROR"). */
+  code: ApiErrorCode;
+  /** Human-readable description of the error. */
+  message: string;
+  /** Per-field validation errors, present when code === "VALIDATION_ERROR". */
+  fieldErrors?: FieldError[];
+}
+
+/** Per-field validation error detail. */
+export interface FieldError {
+  field: string;
+  message: string;
+}
+
+/** Exhaustive set of error codes the API may return. */
+export type ApiErrorCode =
+  | 'BAD_REQUEST'
+  | 'VALIDATION_ERROR'
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'CONFLICT'
+  | 'UNPROCESSABLE_ENTITY'
+  | 'INTERNAL_SERVER_ERROR'
+  | 'SERVICE_UNAVAILABLE';
+
+// ── Pagination ────────────────────────────────────────────────────────────────
+
+/** Pagination metadata included in list responses. */
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+/** Paginated list response data. */
+export interface PaginatedData<T> {
+  items: T[];
+  pagination: PaginationMeta;
+}
+
+// ── Helper constructors ───────────────────────────────────────────────────────
+
+/** Build a successful response envelope. */
+export function apiSuccess<T>(data: T, message?: string): ApiSuccess<T> {
+  return { success: true, data, error: null, ...(message ? { message } : {}) };
+}
+
+/** Build a failed response envelope. */
+export function apiFailure(
+  code: ApiErrorCode,
+  message: string,
+  fieldErrors?: FieldError[],
+): ApiFailure {
+  const error: ApiError = { code, message, ...(fieldErrors ? { fieldErrors } : {}) };
+  return { success: false, data: null, error };
+}
+
+/** Build a paginated data payload. */
+export function paginatedData<T>(
+  items: T[],
+  page: number,
+  limit: number,
+  total: number,
+): PaginatedData<T> {
+  return { items, pagination: { page, limit, total, totalPages: Math.ceil(total / limit) } };
+}
+
+// ── Type guards ───────────────────────────────────────────────────────────────
+
+/** Narrow an `ApiResponse<T>` to `ApiSuccess<T>`. */
+export function isApiSuccess<T>(res: ApiResponse<T>): res is ApiSuccess<T> {
+  return res.success === true;
+}
+
+/** Narrow an `ApiResponse<T>` to `ApiFailure`. */
+export function isApiFailure<T>(res: ApiResponse<T>): res is ApiFailure {
+  return res.success === false;
+}
+
+/** Return true when the failure carries per-field validation errors. */
+export function isValidationError(error: ApiError): boolean {
+  return error.code === 'VALIDATION_ERROR' && Array.isArray(error.fieldErrors);
+}


### PR DESCRIPTION
Frontend (lib/api-models.ts):
- Add ApiSuccess<T> / ApiFailure discriminated union and ApiResponse<T> alias for type-safe response handling across the frontend.
- Add ApiError interface with machine-readable ApiErrorCode union type (BAD_REQUEST, VALIDATION_ERROR, UNAUTHORIZED, FORBIDDEN, NOT_FOUND, CONFLICT, UNPROCESSABLE_ENTITY, INTERNAL_SERVER_ERROR, SERVICE_UNAVAILABLE).
- Add FieldError interface for per-field validation error details.
- Add PaginationMeta and PaginatedData<T> interfaces for list responses.
- Add helper constructors: apiSuccess(), apiFailure(), paginatedData().
- Add type guards: isApiSuccess(), isApiFailure(), isValidationError().

Backend (backend/services/api/src/main.rs):
- Replace bare error string in ApiResponse with a structured ApiError type carrying ApiErrorCode, message, and optional field_errors.
- Add ApiErrorCode enum serialised as SCREAMING_SNAKE_CASE to match the TypeScript ApiErrorCode union.
- Add FieldError struct for per-field validation details.
- Add PaginationMeta (with total_pages calculation) and PaginatedData<T> for consistent list response formatting.
- Remove unused std::sync::Mutex import (pre-existing warning).
- Expand test suite from 2 to 12 tests covering all new types, serialisation behaviour, and edge cases (zero total, partial pages).

Why: The issue requires consistent data formatting and error handling across lib/ and backend/services/api/. Both sides now share the same envelope shape, error codes, and pagination contract.

Assumptions:
- ApiErrorCode variants are serialised as SCREAMING_SNAKE_CASE strings so they are directly usable as string literals on the frontend.
- field_errors is omitted from JSON when None to keep responses lean.
- The TypeScript helpers are pure functions with no runtime deps beyond the standard library, keeping the module side-effect-free.

Closes #327