### PR TITLE
feat: add JWT validation middleware to protect sensitive endpoints

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -39,6 +39,10 @@ sha2 = "0.10"
 hex = "0.4"
 stellar-sdk = "21.0"
 
+# Auth
+jsonwebtoken = "9"
+actix-web-httpauth = "0.8"
+
 # Utilities
 thiserror = "1.0"
 tracing = "0.1"

--- a/backend/services/api/Cargo.toml
+++ b/backend/services/api/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 actix-web.workspace = true
 actix-cors = "0.7"
 actix-rt.workspace = true
+actix-web-httpauth.workspace = true
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -23,6 +24,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 anyhow.workspace = true
 futures.workspace = true
+jsonwebtoken.workspace = true
 
 [profile.release]
 opt-level = 3

--- a/backend/services/api/src/auth.rs
+++ b/backend/services/api/src/auth.rs
@@ -1,0 +1,327 @@
+//! JWT authentication middleware for Actix-web.
+//!
+//! Protected routes must carry a `Bearer <token>` header.
+//! The secret is read from the `JWT_SECRET` environment variable
+//! (falls back to `"stellar-dev-secret"` in development).
+
+use actix_web::{
+    body::{BoxBody, MessageBody},
+    dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
+    Error, HttpMessage, HttpResponse,
+};
+use futures::future::{ok, LocalBoxFuture, Ready};
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+use serde::{Deserialize, Serialize};
+use std::rc::Rc;
+
+use crate::{ApiError, ApiErrorCode, ApiResponse};
+
+// ── Claims ────────────────────────────────────────────────────────────────────
+
+/// JWT payload stored inside every access token.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Claims {
+    /// Subject — typically the user's wallet address or UUID.
+    pub sub: String,
+    /// Expiry (Unix timestamp).
+    pub exp: u64,
+    /// Role: `"creator"`, `"freelancer"`, or `"admin"`.
+    pub role: String,
+}
+
+// ── Validation helper ─────────────────────────────────────────────────────────
+
+fn jwt_secret() -> String {
+    std::env::var("JWT_SECRET").unwrap_or_else(|_| "stellar-dev-secret".to_string())
+}
+
+/// Decode and validate a raw JWT string.
+/// Returns `Claims` on success or an error message on failure.
+pub fn validate_token(token: &str) -> Result<Claims, String> {
+    let key = DecodingKey::from_secret(jwt_secret().as_bytes());
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.validate_exp = true;
+
+    decode::<Claims>(token, &key, &validation)
+        .map(|data| data.claims)
+        .map_err(|e| e.to_string())
+}
+
+// ── Middleware factory ────────────────────────────────────────────────────────
+
+/// Wrap a route scope with `JwtMiddleware` to require a valid Bearer token.
+///
+/// ```rust,ignore
+/// web::scope("/api/protected")
+///     .wrap(JwtMiddleware)
+///     .route(...)
+/// ```
+pub struct JwtMiddleware;
+
+impl<S, B> Transform<S, ServiceRequest> for JwtMiddleware
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<BoxBody>;
+    type Error = Error;
+    type Transform = JwtMiddlewareService<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ok(JwtMiddlewareService { service: Rc::new(service) })
+    }
+}
+
+pub struct JwtMiddlewareService<S> {
+    service: Rc<S>,
+}
+
+impl<S, B> Service<ServiceRequest> for JwtMiddlewareService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<BoxBody>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let svc = Rc::clone(&self.service);
+
+        let token_result = req
+            .headers()
+            .get("Authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .map(|t| validate_token(t))
+            .unwrap_or(Err("Missing Authorization header".to_string()));
+
+        Box::pin(async move {
+            match token_result {
+                Ok(claims) => {
+                    req.extensions_mut().insert(claims);
+                    svc.call(req).await.map(|r| r.map_into_boxed_body())
+                }
+                Err(reason) => {
+                    tracing::warn!("JWT auth failed: {}", reason);
+                    let body = ApiResponse::<()>::err(ApiError::new(
+                        ApiErrorCode::Unauthorized,
+                        "Invalid or missing token",
+                    ));
+                    let http_resp = HttpResponse::Unauthorized().json(body);
+                    Ok(req.into_response(http_resp).map_into_boxed_body())
+                }
+            }
+        })
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use actix_web::{test as awtest, web, App, HttpRequest, HttpResponse};
+    use jsonwebtoken::{encode, EncodingKey, Header};
+
+    /// Generate a signed token for tests (uses the dev secret).
+    pub fn make_token(sub: &str, role: &str, exp_offset_secs: i64) -> String {
+        let exp = (chrono_exp(exp_offset_secs)) as u64;
+        let claims = Claims { sub: sub.to_string(), exp, role: role.to_string() };
+        encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(b"stellar-dev-secret"),
+        )
+        .unwrap()
+    }
+
+    fn chrono_exp(offset: i64) -> u64 {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        (now + offset).max(0) as u64
+    }
+
+    async fn protected_handler(_req: HttpRequest) -> HttpResponse {
+        HttpResponse::Ok().json(serde_json::json!({ "ok": true }))
+    }
+
+    // ── validate_token unit tests ─────────────────────────────────────────────
+
+    #[test]
+    fn valid_token_decodes_claims() {
+        std::env::remove_var("JWT_SECRET");
+        let token = make_token("user-1", "creator", 3600);
+        let claims = validate_token(&token).unwrap();
+        assert_eq!(claims.sub, "user-1");
+        assert_eq!(claims.role, "creator");
+    }
+
+    #[test]
+    fn expired_token_is_rejected() {
+        std::env::remove_var("JWT_SECRET");
+        let token = make_token("user-1", "creator", -10); // already expired
+        assert!(validate_token(&token).is_err());
+    }
+
+    #[test]
+    fn tampered_token_is_rejected() {
+        std::env::remove_var("JWT_SECRET");
+        let token = make_token("user-1", "creator", 3600);
+        let tampered = format!("{}x", token);
+        assert!(validate_token(&tampered).is_err());
+    }
+
+    #[test]
+    fn wrong_secret_is_rejected() {
+        let token = {
+            let claims = Claims {
+                sub: "user-1".to_string(),
+                exp: 9_999_999_999,
+                role: "creator".to_string(),
+            };
+            encode(
+                &Header::default(),
+                &claims,
+                &EncodingKey::from_secret(b"wrong-secret"),
+            )
+            .unwrap()
+        };
+        std::env::remove_var("JWT_SECRET");
+        assert!(validate_token(&token).is_err());
+    }
+
+    // ── middleware integration tests ──────────────────────────────────────────
+
+    #[actix_web::test]
+    async fn valid_bearer_token_passes_middleware() {
+        std::env::remove_var("JWT_SECRET");
+        let token = make_token("user-1", "creator", 3600);
+
+        let app = awtest::init_service(
+            App::new()
+                .service(
+                    web::scope("/protected")
+                        .wrap(JwtMiddleware)
+                        .route("", web::get().to(protected_handler)),
+                ),
+        )
+        .await;
+
+        let req = awtest::TestRequest::get()
+            .uri("/protected")
+            .insert_header(("Authorization", format!("Bearer {}", token)))
+            .to_request();
+
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+    }
+
+    #[actix_web::test]
+    async fn missing_token_returns_401() {
+        std::env::remove_var("JWT_SECRET");
+
+        let app = awtest::init_service(
+            App::new().service(
+                web::scope("/protected")
+                    .wrap(JwtMiddleware)
+                    .route("", web::get().to(protected_handler)),
+            ),
+        )
+        .await;
+
+        let req = awtest::TestRequest::get().uri("/protected").to_request();
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+    }
+
+    #[actix_web::test]
+    async fn expired_token_returns_401() {
+        std::env::remove_var("JWT_SECRET");
+        let token = make_token("user-1", "creator", -60);
+
+        let app = awtest::init_service(
+            App::new().service(
+                web::scope("/protected")
+                    .wrap(JwtMiddleware)
+                    .route("", web::get().to(protected_handler)),
+            ),
+        )
+        .await;
+
+        let req = awtest::TestRequest::get()
+            .uri("/protected")
+            .insert_header(("Authorization", format!("Bearer {}", token)))
+            .to_request();
+
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+    }
+
+    #[actix_web::test]
+    async fn invalid_token_returns_401_with_error_body() {
+        std::env::remove_var("JWT_SECRET");
+
+        let app = awtest::init_service(
+            App::new().service(
+                web::scope("/protected")
+                    .wrap(JwtMiddleware)
+                    .route("", web::get().to(protected_handler)),
+            ),
+        )
+        .await;
+
+        let req = awtest::TestRequest::get()
+            .uri("/protected")
+            .insert_header(("Authorization", "Bearer not.a.jwt"))
+            .to_request();
+
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+
+        let body = awtest::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["success"], false);
+        assert_eq!(json["error"]["code"], "UNAUTHORIZED");
+    }
+
+    #[actix_web::test]
+    async fn claims_are_injected_into_request_extensions() {
+        std::env::remove_var("JWT_SECRET");
+        let token = make_token("wallet-abc", "freelancer", 3600);
+
+        async fn claims_handler(req: HttpRequest) -> HttpResponse {
+            let claims = req.extensions().get::<Claims>().cloned().unwrap();
+            HttpResponse::Ok().json(serde_json::json!({
+                "sub": claims.sub,
+                "role": claims.role,
+            }))
+        }
+
+        let app = awtest::init_service(
+            App::new().service(
+                web::scope("/protected")
+                    .wrap(JwtMiddleware)
+                    .route("", web::get().to(claims_handler)),
+            ),
+        )
+        .await;
+
+        let req = awtest::TestRequest::get()
+            .uri("/protected")
+            .insert_header(("Authorization", format!("Bearer {}", token)))
+            .to_request();
+
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+
+        let body = awtest::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["sub"], "wallet-abc");
+        assert_eq!(json["role"], "freelancer");
+    }
+}

--- a/backend/services/api/src/main.rs
+++ b/backend/services/api/src/main.rs
@@ -3,6 +3,7 @@ use actix_web::{http, web, App, HttpServer, HttpResponse, middleware};
 use serde::{Deserialize, Serialize};
 use tracing_subscriber;
 
+mod auth;
 mod reputation;
 
 // ==================== Domain Models ====================
@@ -615,27 +616,26 @@ async fn main() -> std::io::Result<()> {
             .wrap(cors_middleware())
             .wrap(middleware::Logger::default())
             .wrap(middleware::NormalizePath::trim())
-            // Health check
+            // Health check (public)
             .route("/health", web::get().to(health))
-            // Bounty routes
-            .route("/api/bounties", web::post().to(create_bounty))
+            // Public read-only routes
             .route("/api/bounties", web::get().to(list_bounties))
             .route("/api/bounties/{id}", web::get().to(get_bounty))
-            .route("/api/bounties/{id}/apply", web::post().to(apply_for_bounty))
-            // Creator routes
             .route("/api/creators", web::get().to(list_creators))
             .route("/api/creators/{id}", web::get().to(get_creator))
-            .route(
-                "/api/creators/{id}/reputation",
-                web::get().to(get_creator_reputation),
-            )
-            // Freelancer routes
-            .route("/api/freelancers/register", web::post().to(register_freelancer))
+            .route("/api/creators/{id}/reputation", web::get().to(get_creator_reputation))
             .route("/api/freelancers", web::get().to(list_freelancers))
             .route("/api/freelancers/{address}", web::get().to(get_freelancer))
-            // Escrow routes
             .route("/api/escrow/{id}", web::get().to(get_escrow))
-            .route("/api/escrow/{id}/release", web::post().to(release_escrow))
+            // Protected write routes — require valid JWT
+            .service(
+                web::scope("")
+                    .wrap(auth::JwtMiddleware)
+                    .route("/api/bounties", web::post().to(create_bounty))
+                    .route("/api/bounties/{id}/apply", web::post().to(apply_for_bounty))
+                    .route("/api/freelancers/register", web::post().to(register_freelancer))
+                    .route("/api/escrow/{id}/release", web::post().to(release_escrow)),
+            )
     })
     .bind((host.parse::<std::net::IpAddr>().unwrap(), port))?
     .run()
@@ -845,6 +845,21 @@ mod tests {
         let req = awtest::TestRequest::get()
             .uri("/api/creators/alex-studio/reputation")
             .to_request();
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+
+        let body = awtest::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["success"], true);
+        assert_eq!(json["data"]["creatorId"], "alex-studio");
+        let total = json["data"]["aggregation"]["totalReviews"].as_u64().unwrap();
+        assert!(total >= 1);
+        let avg = json["data"]["aggregation"]["averageRating"].as_f64().unwrap();
+        assert!(avg > 0.0);
+        assert!(json["data"]["recentReviews"].as_array().unwrap().len() >= 1);
+    }
+
+    #[actix_web::test]
     async fn escrow_get_integration_returns_active_payload() {
         use actix_web::test as awtest;
 
@@ -860,12 +875,8 @@ mod tests {
         let body = awtest::read_body(resp).await;
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["success"], true);
-        assert_eq!(json["data"]["creatorId"], "alex-studio");
-        let total = json["data"]["aggregation"]["totalReviews"].as_u64().unwrap();
-        assert!(total >= 1);
-        let avg = json["data"]["aggregation"]["averageRating"].as_f64().unwrap();
-        assert!(avg > 0.0);
-        assert!(json["data"]["recentReviews"].as_array().unwrap().len() >= 1);
+        assert_eq!(json["data"]["id"], 7);
+        assert_eq!(json["data"]["status"], "active");
     }
 
     #[actix_web::test]
@@ -882,8 +893,14 @@ mod tests {
 
         let req = awtest::TestRequest::get()
             .uri("/api/creators/unknown-creator/reputation")
-        assert_eq!(json["data"]["id"], 7);
-        assert_eq!(json["data"]["status"], "active");
+            .to_request();
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+
+        let body = awtest::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["data"]["aggregation"]["totalReviews"], 0);
+        assert_eq!(json["data"]["aggregation"]["averageRating"], 0.0);
     }
 
     #[actix_web::test]
@@ -903,10 +920,153 @@ mod tests {
 
         let body = awtest::read_body(resp).await;
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(json["data"]["aggregation"]["totalReviews"], 0);
-        assert_eq!(json["data"]["aggregation"]["averageRating"], 0.0);
         assert_eq!(json["success"], true);
         assert_eq!(json["data"]["status"], "released");
         assert!(json["data"]["transaction_id"].is_string());
+    }
+
+    // ── JWT-protected route integration tests ─────────────────────────────────
+
+    fn build_protected_app() -> actix_web::App<
+        impl actix_web::dev::ServiceFactory<
+            actix_web::dev::ServiceRequest,
+            Config = (),
+            Response = actix_web::dev::ServiceResponse,
+            Error = actix_web::Error,
+            InitError = (),
+        >,
+    > {
+        App::new().service(
+            web::scope("")
+                .wrap(auth::JwtMiddleware)
+                .route("/api/bounties", web::post().to(create_bounty))
+                .route("/api/bounties/{id}/apply", web::post().to(apply_for_bounty))
+                .route("/api/freelancers/register", web::post().to(register_freelancer))
+                .route("/api/escrow/{id}/release", web::post().to(release_escrow)),
+        )
+    }
+
+    #[actix_web::test]
+    async fn create_bounty_without_token_returns_401() {
+        use actix_web::test as awtest;
+        std::env::remove_var("JWT_SECRET");
+
+        let app = awtest::init_service(build_protected_app()).await;
+        let req = awtest::TestRequest::post()
+            .uri("/api/bounties")
+            .set_json(serde_json::json!({
+                "creator": "wallet-1",
+                "title": "Test",
+                "description": "desc",
+                "budget": 1000,
+                "deadline": 9999999999u64
+            }))
+            .to_request();
+
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+    }
+
+    #[actix_web::test]
+    async fn create_bounty_with_valid_token_returns_201() {
+        use actix_web::test as awtest;
+        std::env::remove_var("JWT_SECRET");
+        let token = auth::tests::make_token("wallet-1", "creator", 3600);
+
+        let app = awtest::init_service(build_protected_app()).await;
+        let req = awtest::TestRequest::post()
+            .uri("/api/bounties")
+            .insert_header(("Authorization", format!("Bearer {}", token)))
+            .set_json(serde_json::json!({
+                "creator": "wallet-1",
+                "title": "Design Bounty",
+                "description": "desc",
+                "budget": 2000,
+                "deadline": 9999999999u64
+            }))
+            .to_request();
+
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::CREATED);
+
+        let body = awtest::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["success"], true);
+        assert_eq!(json["data"]["title"], "Design Bounty");
+    }
+
+    #[actix_web::test]
+    async fn apply_for_bounty_without_token_returns_401() {
+        use actix_web::test as awtest;
+        std::env::remove_var("JWT_SECRET");
+
+        let app = awtest::init_service(build_protected_app()).await;
+        let req = awtest::TestRequest::post()
+            .uri("/api/bounties/1/apply")
+            .set_json(serde_json::json!({
+                "bounty_id": 1,
+                "freelancer": "wallet-2",
+                "proposal": "I can do this",
+                "proposed_budget": 1800,
+                "timeline": 7
+            }))
+            .to_request();
+
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+    }
+
+    #[actix_web::test]
+    async fn register_freelancer_without_token_returns_401() {
+        use actix_web::test as awtest;
+        std::env::remove_var("JWT_SECRET");
+
+        let app = awtest::init_service(build_protected_app()).await;
+        let req = awtest::TestRequest::post()
+            .uri("/api/freelancers/register")
+            .set_json(serde_json::json!({
+                "name": "Jane",
+                "discipline": "Writing",
+                "bio": "Writer"
+            }))
+            .to_request();
+
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+    }
+
+    #[actix_web::test]
+    async fn release_escrow_without_token_returns_401() {
+        use actix_web::test as awtest;
+        std::env::remove_var("JWT_SECRET");
+
+        let app = awtest::init_service(build_protected_app()).await;
+        let req = awtest::TestRequest::post()
+            .uri("/api/escrow/5/release")
+            .to_request();
+
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+    }
+
+    #[actix_web::test]
+    async fn release_escrow_with_valid_token_returns_200() {
+        use actix_web::test as awtest;
+        std::env::remove_var("JWT_SECRET");
+        let token = auth::tests::make_token("wallet-1", "creator", 3600);
+
+        let app = awtest::init_service(build_protected_app()).await;
+        let req = awtest::TestRequest::post()
+            .uri("/api/escrow/5/release")
+            .insert_header(("Authorization", format!("Bearer {}", token)))
+            .to_request();
+
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+
+        let body = awtest::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["success"], true);
+        assert_eq!(json["data"]["status"], "released");
     }
 }


### PR DESCRIPTION
- Add jsonwebtoken v9 and actix-web-httpauth to workspace deps
- New auth.rs: Claims struct, validate_token(), JwtMiddleware factory
- Protected POST routes: create_bounty, apply_for_bounty, register_freelancer, release_escrow
- Public GET routes remain unauthenticated
- Unit tests: valid/expired/tampered/wrong-secret token validation
- Integration tests: 401 without token, 200/201 with valid token, claims injected into request extensions
closes #314 