### PR TITLE
feat(#358): add POST /api/reviews endpoint, aggregation tests, and Cr…

### DIFF
--- a/backend/services/api/src/main.rs
+++ b/backend/services/api/src/main.rs
@@ -134,6 +134,19 @@ pub struct BountyApplication {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct ReviewSubmission {
+    #[serde(rename = "bountyId")]
+    pub bounty_id: String,
+    #[serde(rename = "creatorId")]
+    pub creator_id: String,
+    pub rating: u8,
+    pub title: String,
+    pub body: String,
+    #[serde(rename = "reviewerName")]
+    pub reviewer_name: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct FreelancerRegistration {
     pub name: String,
     pub discipline: String,
@@ -621,6 +634,50 @@ async fn get_creator_reputation(path: web::Path<String>) -> HttpResponse {
         .json(response)
 }
 
+/// Submit a review after bounty completion.
+async fn submit_review(body: web::Json<ReviewSubmission>) -> HttpResponse {
+    tracing::info!("Submitting review for creator: {}", body.creator_id);
+
+    let mut field_errors: Vec<FieldError> = Vec::new();
+    if body.bounty_id.trim().is_empty() {
+        field_errors.push(FieldError { field: "bountyId".into(), message: "Bounty ID is required".into() });
+    }
+    if body.creator_id.trim().is_empty() {
+        field_errors.push(FieldError { field: "creatorId".into(), message: "Creator ID is required".into() });
+    }
+    if !(1..=5).contains(&body.rating) {
+        field_errors.push(FieldError { field: "rating".into(), message: "Rating must be between 1 and 5".into() });
+    }
+    if body.title.trim().is_empty() {
+        field_errors.push(FieldError { field: "title".into(), message: "Title is required".into() });
+    }
+    if body.body.trim().is_empty() {
+        field_errors.push(FieldError { field: "body".into(), message: "Feedback is required".into() });
+    }
+    if body.reviewer_name.trim().is_empty() {
+        field_errors.push(FieldError { field: "reviewerName".into(), message: "Your name is required".into() });
+    }
+    if !field_errors.is_empty() {
+        let resp: ApiResponse<()> = ApiResponse::err(ApiError::with_field_errors(
+            ApiErrorCode::ValidationError,
+            "Validation failed",
+            field_errors,
+        ));
+        return HttpResponse::UnprocessableEntity()
+            .content_type("application/json")
+            .json(resp);
+    }
+
+    let review_id = format!("rev-{}-{}", body.creator_id, body.bounty_id);
+    let response: ApiResponse<serde_json::Value> = ApiResponse::ok(
+        serde_json::json!({ "reviewId": review_id }),
+        Some("Review submitted successfully".to_string()),
+    );
+    HttpResponse::Created()
+        .content_type("application/json")
+        .json(response)
+}
+
 /// Escape escrow
 async fn get_escrow(path: web::Path<u64>) -> HttpResponse {
     let escrow_id = path.into_inner();
@@ -729,6 +786,7 @@ async fn main() -> std::io::Result<()> {
             .route("/api/creators", web::get().to(list_creators))
             .route("/api/creators/{id}", web::get().to(get_creator))
             .route("/api/creators/{id}/reputation", web::get().to(get_creator_reputation))
+            .route("/api/reviews", web::post().to(submit_review))
             .route("/api/freelancers", web::get().to(list_freelancers))
             .route("/api/freelancers/{address}", web::get().to(get_freelancer))
             .route("/api/escrow/{id}", web::get().to(get_escrow))
@@ -1335,6 +1393,95 @@ mod tests {
             .map(|e| e["field"].as_str().unwrap())
             .collect();
         assert!(fields.contains(&"proposal"));
+    }
+
+    // ── submit_review ─────────────────────────────────────────────────────────
+
+    fn build_review_app() -> actix_web::App<
+        impl actix_web::dev::ServiceFactory<
+            actix_web::dev::ServiceRequest,
+            Config = (),
+            Response = actix_web::dev::ServiceResponse,
+            Error = actix_web::Error,
+            InitError = (),
+        >,
+    > {
+        App::new().route("/api/reviews", web::post().to(submit_review))
+    }
+
+    #[actix_web::test]
+    async fn submit_review_valid_returns_201_with_review_id() {
+        use actix_web::test as awtest;
+        let app = awtest::init_service(build_review_app()).await;
+        let req = awtest::TestRequest::post()
+            .uri("/api/reviews")
+            .set_json(serde_json::json!({
+                "bountyId": "b-1",
+                "creatorId": "alex-studio",
+                "rating": 5,
+                "title": "Excellent work",
+                "body": "Delivered on time and exceeded expectations.",
+                "reviewerName": "Jane D."
+            }))
+            .to_request();
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::CREATED);
+        let body = awtest::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["success"], true);
+        assert!(json["data"]["reviewId"].is_string());
+    }
+
+    #[actix_web::test]
+    async fn submit_review_missing_fields_returns_422_with_all_errors() {
+        use actix_web::test as awtest;
+        let app = awtest::init_service(build_review_app()).await;
+        let req = awtest::TestRequest::post()
+            .uri("/api/reviews")
+            .set_json(serde_json::json!({
+                "bountyId": "",
+                "creatorId": "",
+                "rating": 0,
+                "title": "",
+                "body": "",
+                "reviewerName": ""
+            }))
+            .to_request();
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::UNPROCESSABLE_ENTITY);
+        let body = awtest::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["success"], false);
+        assert_eq!(json["error"]["code"], "VALIDATION_ERROR");
+        let count = json["error"]["fieldErrors"].as_array().unwrap().len();
+        assert_eq!(count, 6);
+    }
+
+    #[actix_web::test]
+    async fn submit_review_rating_out_of_range_returns_422() {
+        use actix_web::test as awtest;
+        let app = awtest::init_service(build_review_app()).await;
+        let req = awtest::TestRequest::post()
+            .uri("/api/reviews")
+            .set_json(serde_json::json!({
+                "bountyId": "b-1",
+                "creatorId": "c-1",
+                "rating": 6,
+                "title": "Good",
+                "body": "Nice work.",
+                "reviewerName": "Alice"
+            }))
+            .to_request();
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::UNPROCESSABLE_ENTITY);
+        let body = awtest::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let fields: Vec<&str> = json["error"]["fieldErrors"]
+            .as_array().unwrap()
+            .iter()
+            .map(|e| e["field"].as_str().unwrap())
+            .collect();
+        assert!(fields.contains(&"rating"));
     }
 
     #[actix_web::test]

--- a/backend/services/api/src/reputation.rs
+++ b/backend/services/api/src/reputation.rs
@@ -259,6 +259,55 @@ mod tests {
     }
 
     #[test]
+    fn to_public_review_maps_fields() {
+        let r = Review {
+            id: "r-1".into(),
+            creator_id: "c-1".into(),
+            rating: 4,
+            title: "Good".into(),
+            body: "Nice.".into(),
+            reviewer_name: "Bob".into(),
+            created_at: "2025-01-01".into(),
+        };
+        let p = to_public_review(&r);
+        assert_eq!(p.id, "r-1");
+        assert_eq!(p.rating, 4);
+        assert_eq!(p.reviewer_name, "Bob");
+    }
+
+    #[test]
+    fn recent_reviews_respects_limit() {
+        let revs = sample_reviews();
+        let recent = recent_reviews(&revs, 1);
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].id, "a");
+    }
+
+    #[test]
+    fn aggregate_single_review() {
+        let reviews = vec![Review {
+            id: "x".into(),
+            creator_id: "c1".into(),
+            rating: 3,
+            title: "".into(),
+            body: "".into(),
+            reviewer_name: "".into(),
+            created_at: "2025-01-01".into(),
+        }];
+        let agg = aggregate_reviews(&reviews);
+        assert_eq!(agg.total_reviews, 1);
+        assert_eq!(agg.average_rating, 3.0);
+        assert_eq!(agg.stars_3, 1);
+        assert_eq!(agg.stars_5, 0);
+    }
+
+    #[test]
+    fn reviews_for_creator_returns_only_matching() {
+        let all = reviews_for_creator("alex-studio");
+        assert!(all.iter().all(|r| r.creator_id == "alex-studio"));
+    }
+
+    #[test]
     fn seed_covers_profile_creator_ids() {
         let ids = ["alex-studio", "maya-writes", "jordan-creative", "sophia-ux"];
         for id in ids {

--- a/components/creator-reputation.test.tsx
+++ b/components/creator-reputation.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CreatorReputation } from './creator-reputation';
+import { apiSuccess, apiFailure } from '@/lib/api-models';
+import type { CreatorReputationPayload } from '@/lib/api-models';
+
+const mockPayload: CreatorReputationPayload = {
+  creatorId: 'alex-studio',
+  aggregation: {
+    averageRating: 4.67,
+    totalReviews: 3,
+    stars5: 2,
+    stars4: 1,
+    stars3: 0,
+    stars2: 0,
+    stars1: 0,
+  },
+  recentReviews: [
+    {
+      id: 'r-1',
+      rating: 5,
+      title: 'Exceptional design partner',
+      body: 'Delivered a full design system on time.',
+      reviewerName: 'Sam K.',
+      createdAt: new Date(Date.now() - 86400000).toISOString(),
+    },
+  ],
+};
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status,
+      json: () => Promise.resolve(body),
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('CreatorReputation', () => {
+  it('renders nothing while loading (no reviews yet)', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+    const { container } = render(<CreatorReputation creatorId="alex-studio" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders aggregation and reviews on success', async () => {
+    mockFetch(apiSuccess(mockPayload));
+    render(<CreatorReputation creatorId="alex-studio" />);
+    expect(await screen.findByText('Client reviews')).toBeInTheDocument();
+    expect(await screen.findByText('4.67')).toBeInTheDocument();
+    expect(await screen.findByText('Exceptional design partner')).toBeInTheDocument();
+  });
+
+  it('renders rating breakdown histogram', async () => {
+    mockFetch(apiSuccess(mockPayload));
+    render(<CreatorReputation creatorId="alex-studio" />);
+    expect(await screen.findByLabelText('Rating distribution')).toBeInTheDocument();
+  });
+
+  it('shows error alert on fetch failure', async () => {
+    mockFetch({}, false, 500);
+    render(<CreatorReputation creatorId="alex-studio" />);
+    expect(await screen.findByText('Failed to load reviews')).toBeInTheDocument();
+  });
+
+  it('shows error alert on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network')));
+    render(<CreatorReputation creatorId="alex-studio" />);
+    expect(await screen.findByText('Failed to load reviews')).toBeInTheDocument();
+  });
+
+  it('renders nothing when totalReviews is 0', async () => {
+    const emptyPayload: CreatorReputationPayload = {
+      ...mockPayload,
+      aggregation: { ...mockPayload.aggregation, totalReviews: 0, averageRating: 0 },
+      recentReviews: [],
+    };
+    mockFetch(apiSuccess(emptyPayload));
+    const { container } = render(<CreatorReputation creatorId="alex-studio" />);
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it('dismisses error alert when onDismiss is called', async () => {
+    mockFetch({}, false, 500);
+    render(<CreatorReputation creatorId="alex-studio" />);
+    const dismissBtn = await screen.findByRole('button', { name: /dismiss error/i });
+    await userEvent.click(dismissBtn);
+    await waitFor(() => {
+      expect(screen.queryByText('Failed to load reviews')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows review count in summary text', async () => {
+    mockFetch(apiSuccess(mockPayload));
+    render(<CreatorReputation creatorId="alex-studio" />);
+    expect(await screen.findByText(/Based on 3 reviews/)).toBeInTheDocument();
+  });
+
+  it('uses singular "review" for count of 1', async () => {
+    const singleReview: CreatorReputationPayload = {
+      ...mockPayload,
+      aggregation: { ...mockPayload.aggregation, totalReviews: 1 },
+    };
+    mockFetch(apiSuccess(singleReview));
+    render(<CreatorReputation creatorId="alex-studio" />);
+    expect(await screen.findByText(/Based on 1 review/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
PR closes #329 
closes #347 

- Add ReviewSubmission model and submit_review handler in main.rs
  - Validates all 6 fields (bountyId, creatorId, rating 1-5, title, body, reviewerName)
  - Returns 201 with reviewId on success, 422 with fieldErrors on failure
  - Wired as public route: POST /api/reviews
- Add 3 integration tests for submit_review in main.rs
  - valid submission returns 201 with reviewId
  - all-empty fields returns 422 with 6 field errors
  - rating out of range (6) returns 422 with rating field error
- Add 5 unit tests in reputation.rs
  - to_public_review field mapping
  - recent_reviews respects limit
  - aggregate_reviews single review
  - reviews_for_creator returns only matching creator
- Add creator-reputation.test.tsx with 8 UI tests
  - loading state renders nothing
  - success renders aggregation, histogram, and reviews
  - error on fetch failure and network error
  - empty totalReviews renders nothing
  - dismiss clears error alert
  - singular/plural review count text