### PR TITLE
feat: add review aggregate score

### DIFF
--- a/__tests__/reviews.test.ts
+++ b/__tests__/reviews.test.ts
@@ -8,7 +8,10 @@ describe('calculateAggregate', () => {
     const { calculateAggregate } = await import('@/lib/review-service')
     const result = calculateAggregate([])
     expect(result.average).toBe(0)
+    expect(result.score).toBe(0)
+    expect(result.confidence).toBe(0)
     expect(result.total).toBe(0)
+    expect(result.verifiedCount).toBe(0)
     expect(result.breakdown[5]).toBe(0)
   })
 
@@ -22,6 +25,8 @@ describe('calculateAggregate', () => {
 
     const result = calculateAggregate(reviews)
     expect(result.average).toBe(4)
+    expect(result.score).toBe(80)
+    expect(result.confidence).toBe(30)
     expect(result.total).toBe(3)
     expect(result.breakdown[5]).toBe(1)
     expect(result.breakdown[4]).toBe(1)
@@ -48,7 +53,29 @@ describe('calculateAggregate', () => {
     ] as any[]
     const result = calculateAggregate(reviews)
     expect(result.average).toBe(5)
+    expect(result.score).toBe(83)
     expect(result.total).toBe(1)
+  })
+
+  it('tracks verified reviews in the aggregate', async () => {
+    const { calculateAggregate } = await import('@/lib/review-service')
+    const reviews = [
+      { rating: 5, status: 'approved', isVerifiedPurchase: true },
+      { rating: 4, status: 'approved', isVerifiedPurchase: false },
+      { rating: 4, status: 'approved', isVerifiedPurchase: true },
+    ] as any[]
+    const result = calculateAggregate(reviews)
+
+    expect(result.verifiedCount).toBe(2)
+  })
+})
+
+describe('calculateAggregateScore', () => {
+  it('uses a bayesian prior so small sample scores are not overconfident', async () => {
+    const { calculateAggregateScore } = await import('@/lib/review-service')
+
+    expect(calculateAggregateScore(5, 1)).toBe(83)
+    expect(calculateAggregateScore(50, 10)).toBe(93)
   })
 })
 

--- a/app/creators/[id]/page.tsx
+++ b/app/creators/[id]/page.tsx
@@ -260,7 +260,7 @@ export default function CreatorProfilePage({ params }: CreatorProfilePageProps) 
                   className="gap-1.5"
                 >
                   <Star size={14} />
-                  See all {aggregate.total} reviews
+                  Score {aggregate.score} · See all {aggregate.total} reviews
                 </Button>
               </div>
               <AggregateRatingDisplay aggregate={aggregate} />

--- a/app/creators/[id]/reviews/page.tsx
+++ b/app/creators/[id]/reviews/page.tsx
@@ -25,7 +25,14 @@ export default function CreatorReviewsPage({ params }: ReviewsPageProps) {
   const creator = creators.find((c) => c.id === params.id);
 
   const [reviews, setReviews] = useState<Review[]>([]);
-  const [aggregate, setAggregate] = useState<AggregateRating>({ average: 0, total: 0, breakdown: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 } });
+  const [aggregate, setAggregate] = useState<AggregateRating>({
+    average: 0,
+    score: 0,
+    confidence: 0,
+    total: 0,
+    verifiedCount: 0,
+    breakdown: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
+  });
   const [sort, setSort] = useState<SortOption>('recent');
   const [filterRating, setFilterRating] = useState<number | undefined>();
   const [page, setPage] = useState(1);

--- a/backend/services/api/src/main.rs
+++ b/backend/services/api/src/main.rs
@@ -129,6 +129,20 @@ fn parse_u64_to_i64(value: u64, field: &str) -> Result<i64, HttpResponse> {
         .map_err(|_| json_error(StatusCode::BAD_REQUEST, format!("{field} is outside the supported range")))
 }
 
+const REVIEW_SCORE_PRIOR_RATING: f64 = 4.0;
+const REVIEW_SCORE_PRIOR_WEIGHT: f64 = 5.0;
+
+#[allow(dead_code)]
+fn calculate_review_aggregate_score(rating_sum: i64, total_reviews: i64) -> i64 {
+    if total_reviews <= 0 {
+        return 0;
+    }
+
+    let weighted_average = (rating_sum as f64 + REVIEW_SCORE_PRIOR_RATING * REVIEW_SCORE_PRIOR_WEIGHT)
+        / (total_reviews as f64 + REVIEW_SCORE_PRIOR_WEIGHT);
+    ((weighted_average / 5.0) * 100.0).round() as i64
+}
+
 /// Health check
 #[utoipa::path(
     get, path = "/health",
@@ -868,6 +882,17 @@ mod tests {
         assert!(paths.contains_key("/api/bounties"));
         assert!(paths.contains_key("/api/freelancers"));
         assert!(paths.contains_key("/api/escrow/{id}"));
+    }
+
+    #[test]
+    fn review_aggregate_score_uses_bayesian_prior() {
+        assert_eq!(calculate_review_aggregate_score(5, 1), 83);
+        assert_eq!(calculate_review_aggregate_score(50, 10), 93);
+    }
+
+    #[test]
+    fn review_aggregate_score_is_zero_without_reviews() {
+        assert_eq!(calculate_review_aggregate_score(0, 0), 0);
     }
 
     #[test]

--- a/components/rating-display.tsx
+++ b/components/rating-display.tsx
@@ -88,7 +88,7 @@ interface AggregateRatingDisplayProps {
 }
 
 export function AggregateRatingDisplay({ aggregate, className }: AggregateRatingDisplayProps) {
-  const { average, total, breakdown } = aggregate;
+  const { average, score, confidence, total, verifiedCount, breakdown } = aggregate;
 
   return (
     <div className={cn('flex flex-col sm:flex-row gap-6 items-start sm:items-center', className)}>
@@ -97,6 +97,22 @@ export function AggregateRatingDisplay({ aggregate, className }: AggregateRating
         <div className="text-5xl font-bold text-foreground">{average.toFixed(1)}</div>
         <StarRating value={average} size="sm" className="justify-center mt-1" />
         <p className="text-xs text-muted-foreground mt-1">{total} review{total !== 1 ? 's' : ''}</p>
+      </div>
+
+      <div className="min-w-[140px] rounded-xl border border-border bg-background/70 p-4 text-center shadow-sm">
+        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          Reputation
+        </div>
+        <div className="mt-1 text-4xl font-black text-primary">{score}</div>
+        <div className="mt-2 h-2 overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-all duration-500"
+            style={{ width: `${score}%` }}
+          />
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          {confidence}% confidence · {verifiedCount} verified
+        </p>
       </div>
 
       {/* Breakdown bars */}

--- a/lib/review-service.ts
+++ b/lib/review-service.ts
@@ -28,8 +28,22 @@ export interface ReviewVote {
 
 export interface AggregateRating {
   average: number
+  score: number
+  confidence: number
   total: number
+  verifiedCount: number
   breakdown: Record<1 | 2 | 3 | 4 | 5, number>
+}
+
+const SCORE_PRIOR_RATING = 4
+const SCORE_PRIOR_WEIGHT = 5
+const SCORE_CONFIDENCE_TARGET = 10
+
+export function calculateAggregateScore(ratingSum: number, total: number): number {
+  if (total <= 0) return 0
+
+  const weightedAverage = (ratingSum + SCORE_PRIOR_RATING * SCORE_PRIOR_WEIGHT) / (total + SCORE_PRIOR_WEIGHT)
+  return Math.round((weightedAverage / 5) * 100)
 }
 
 // In-memory store (replace with DB calls in production)
@@ -41,18 +55,30 @@ export function calculateAggregate(reviews: Review[]): AggregateRating {
   const breakdown: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
 
   if (approved.length === 0) {
-    return { average: 0, total: 0, breakdown: breakdown as AggregateRating['breakdown'] }
+    return {
+      average: 0,
+      score: 0,
+      confidence: 0,
+      total: 0,
+      verifiedCount: 0,
+      breakdown: breakdown as AggregateRating['breakdown'],
+    }
   }
 
   let sum = 0
+  let verifiedCount = 0
   for (const r of approved) {
     sum += r.rating
     breakdown[r.rating] = (breakdown[r.rating] || 0) + 1
+    if (r.isVerifiedPurchase) verifiedCount++
   }
 
   return {
     average: Math.round((sum / approved.length) * 10) / 10,
+    score: calculateAggregateScore(sum, approved.length),
+    confidence: Math.round(Math.min(1, approved.length / SCORE_CONFIDENCE_TARGET) * 100),
     total: approved.length,
+    verifiedCount,
     breakdown: breakdown as AggregateRating['breakdown'],
   }
 }


### PR DESCRIPTION
## Summary
- Adds a Bayesian aggregate reputation score on top of raw review averages.
- Extends aggregate review data with score, confidence, and verified review count.
- Displays the reputation score in creator profile/review UI.
- Adds frontend and backend unit coverage for aggregate score behavior.

## Tests
- `git diff --check` passed.
- Edited frontend files have no linter errors.
- `pnpm test -- __tests__/reviews.test.ts` could not run because `node_modules` is missing.
- Rust test build was blocked by sandbox native build permissions for `zstd-sys`; existing API diagnostics are also still present.

Closes #362