### PR TITLE
feat:rustdoc cmts

### DIFF
--- a/backend/services/common/src/circuit_breaker.rs
+++ b/backend/services/common/src/circuit_breaker.rs
@@ -116,8 +116,20 @@ impl Clone for ServiceCircuitBreaker {
     }
 }
 
+/// Configuration for a circuit breaker.
 pub struct CircuitBreakerConfig {
+    /// The number of consecutive failures that will cause the circuit to open.
+    /// 
+    /// A lower threshold makes the circuit more sensitive to failures, which
+    /// protects downstream services but may cause false positives during
+    /// transient network blips.
     pub failure_threshold: u32,
+
+    /// The duration to wait before attempting to close the circuit again.
+    /// 
+    /// After this timeout expires, the circuit enters a "half-open" state where
+    /// a single successful call will close it, while a failure will immediately
+    /// re-open it.
     pub recovery_timeout: Duration,
 }
 
@@ -131,6 +143,11 @@ impl Default for CircuitBreakerConfig {
 }
 
 impl CircuitBreakerConfig {
+    /// Predefined configuration for database operations.
+    /// 
+    /// Uses a low failure threshold (3) and moderate recovery timeout (10s)
+    /// as database connectivity issues are often critical and should be
+    /// reacted to quickly.
     pub fn for_database() -> Self {
         Self {
             failure_threshold: 3,
@@ -138,6 +155,11 @@ impl CircuitBreakerConfig {
         }
     }
 
+    /// Predefined configuration for cache operations.
+    /// 
+    /// Uses a standard failure threshold (5) and aggressive recovery timeout (5s)
+    /// since cache failures are often transient and we want to resume normal
+    /// operation as soon as possible.
     pub fn for_cache() -> Self {
         Self {
             failure_threshold: 5,
@@ -145,6 +167,10 @@ impl CircuitBreakerConfig {
         }
     }
 
+    /// Predefined configuration for RPC/external service calls.
+    /// 
+    /// Uses a standard failure threshold (5) and conservative recovery timeout (30s)
+    /// to avoid overwhelming external services that might be struggling.
     pub fn for_rpc() -> Self {
         Self {
             failure_threshold: 5,

--- a/docs/circuit_breaker_tuning.md
+++ b/docs/circuit_breaker_tuning.md
@@ -1,0 +1,47 @@
+# Circuit Breaker Tuning Guide
+
+This guide provides instructions on how to tune the circuit breaker parameters for different types of services in the Stellar Creator Portfolio backend.
+
+## Parameters
+
+### 1. Failure Threshold (`failure_threshold`)
+
+The `failure_threshold` defines how many **consecutive** failures must occur before the circuit breaker transitions from `Closed` to `Open`.
+
+- **Low Threshold (2-3):** Use for critical services where even a few failures indicate a major issue (e.g., primary database). This provides fast failover but can be sensitive to transient network blips.
+- **Moderate Threshold (5-10):** Use for internal services or caches where occasional failures are acceptable or expected under high load.
+- **High Threshold (10+):** Use for non-critical background tasks or services with high inherent variability.
+
+### 2. Recovery Timeout (`recovery_timeout`)
+
+The `recovery_timeout` defines how long the circuit stays in the `Open` state before transitioning to `Half-Open`.
+
+- **Short Timeout (5s - 10s):** Use for services that recover quickly, such as local caches or highly available microservices.
+- **Moderate Timeout (30s):** The default for most RPC calls. It gives the downstream service enough time to stabilize without blocking traffic for too long.
+- **Long Timeout (1m+):** Use for external third-party APIs or heavy database operations where recovery might involve manual intervention or significant startup time.
+
+## Predefined Configurations
+
+The `CircuitBreakerConfig` struct provides several factory methods for common scenarios:
+
+| Scenario | `failure_threshold` | `recovery_timeout` | Rationale |
+| :--- | :--- | :--- | :--- |
+| **Database** | 3 | 10s | DB issues are critical; fail fast and check recovery frequently. |
+| **Cache** | 5 | 5s | Caches are auxiliary; allow some failures but recover aggressively. |
+| **RPC** | 5 | 30s | External services need more time to recover; avoid "thundering herd" issues. |
+
+## Tuning Strategy
+
+1. **Observe Baseline:** Monitor the normal failure rate of the service.
+2. **Identify Impact:** Determine the cost of a failed call vs. the cost of a rejected call (circuit open).
+3. **Set Initial Values:** Start with the predefined configurations.
+4. **Iterate:**
+    - If the circuit opens too often during normal operation (false positives), increase the `failure_threshold`.
+    - If the circuit stays open too long after the service has recovered, decrease the `recovery_timeout`.
+    - If the circuit doesn't open fast enough when a service goes down, decrease the `failure_threshold`.
+
+## Best Practices
+
+- **Consecutive vs. Percentage:** Our current implementation uses **consecutive** failures. This means a single successful call will reset the failure count. Keep this in mind when dealing with flaky services.
+- **Logging:** Always monitor circuit breaker state transitions in the logs. Search for `circuit_breaker` tags in the service logs.
+- **Fallbacks:** Always consider what the application should do when the circuit is open (e.g., return cached data, show a friendly error message, or use a degraded mode).


### PR DESCRIPTION
closes #455 

Changes:
Added RustDoc comments to backend/services/common/src/circuit_breaker.rs for the CircuitBreakerConfig struct, explaining the failure_threshold and recovery_timeout parameters and their predefined settings.
Created a tuning guide at docs/circuit_breaker_tuning.md that provides detailed instructions on how to select appropriate thresholds for different service types (Database, Cache, RPC) and strategies for iterative tuning.