### PR TITLE
Create ConnectWalletButton component

### DIFF
--- a/components/connect-wallet-button.tsx
+++ b/components/connect-wallet-button.tsx
@@ -1,32 +1,5 @@
-'use client';
-
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Wallet } from 'lucide-react';
-
-export function ConnectWalletButton() {
-  const [connected, setConnected] = useState(false);
-  const [address, setAddress] = useState('');
-
-  const handleConnect = async () => {
-    if (!connected) {
-      setConnected(true);
-      // Generate a mock Stellar address
-      setAddress('G' + Array.from({length: 55}, () => Math.floor(Math.random() * 36).toString(36).toUpperCase()).join(''));
-    } else {
-      setConnected(false);
-      setAddress('');
-    }
-  };
-
-  return (
-    <Button 
-      variant={connected ? "secondary" : "default"} 
-      onClick={handleConnect}
-      className="gap-2"
-    >
-      <Wallet size={16} />
-      {connected ? `${address.slice(0, 4)}...${address.slice(-4)}` : 'Connect Wallet'}
-    </Button>
-  );
-}
+export {
+  ConnectWalletButton,
+  formatAccount,
+  type ConnectWalletButtonProps,
+} from '@/components/ui/connect-wallet-button'

--- a/components/ui/connect-wallet-button.test.tsx
+++ b/components/ui/connect-wallet-button.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  ConnectWalletButton,
+  formatAccount,
+} from '@/components/ui/connect-wallet-button'
+
+describe('ConnectWalletButton', () => {
+  it('renders idle state and calls connect handler', () => {
+    const onConnect = vi.fn()
+
+    render(<ConnectWalletButton onConnect={onConnect} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Wallet' }))
+
+    expect(onConnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders loading state as disabled', () => {
+    render(<ConnectWalletButton isLoading />)
+
+    const button = screen.getByRole('button', { name: 'Connecting' })
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('renders connected account state', () => {
+    render(<ConnectWalletButton account="GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890" />)
+
+    expect(
+      screen.getByRole('button', { name: 'GABCDE...7890' }),
+    ).toBeInTheDocument()
+  })
+
+  it('formats long and short accounts', () => {
+    expect(formatAccount('GSHORT')).toBe('GSHORT')
+    expect(formatAccount('GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')).toBe(
+      'GABCDE...7890',
+    )
+  })
+})

--- a/components/ui/connect-wallet-button.tsx
+++ b/components/ui/connect-wallet-button.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import * as React from 'react'
+import { Check, Loader2, Wallet } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+type ConnectWalletButtonProps = Omit<React.ComponentProps<typeof Button>, 'onClick'> & {
+  account?: string | null
+  isLoading?: boolean
+  onConnect?: () => void | Promise<void>
+  connectLabel?: string
+  loadingLabel?: string
+  connectedLabel?: string
+}
+
+function formatAccount(account: string) {
+  if (account.length <= 12) {
+    return account
+  }
+
+  return `${account.slice(0, 6)}...${account.slice(-4)}`
+}
+
+function ConnectWalletButton({
+  account,
+  isLoading = false,
+  onConnect,
+  connectLabel = 'Connect Wallet',
+  loadingLabel = 'Connecting',
+  connectedLabel,
+  className,
+  disabled,
+  variant,
+  type = 'button',
+  ...props
+}: ConnectWalletButtonProps) {
+  const isConnected = Boolean(account)
+  const label = isLoading
+    ? loadingLabel
+    : connectedLabel ?? (account ? formatAccount(account) : connectLabel)
+  const Icon = isLoading ? Loader2 : isConnected ? Check : Wallet
+
+  return (
+    <Button
+      type={type}
+      variant={variant ?? (isConnected ? 'secondary' : 'default')}
+      className={cn('min-w-36', className)}
+      disabled={disabled || isLoading}
+      aria-busy={isLoading}
+      aria-label={label}
+      onClick={onConnect}
+      {...props}
+    >
+      <Icon className={cn('size-4', isLoading && 'animate-spin')} aria-hidden="true" />
+      <span>{label}</span>
+    </Button>
+  )
+}
+
+export { ConnectWalletButton, formatAccount }
+export type { ConnectWalletButtonProps }


### PR DESCRIPTION
Closes #302

## Summary
- Add reusable ConnectWalletButton component
- Support idle, loading, and connected states
- Follow existing shadcn/ui styling patterns
- Add tests or exports where applicable

## Checks
- npm run lint
- npm run test -- --run
- npm run build