### PR TITLE
Fix database engine selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,11 +416,17 @@ NODE_ENV=production pnpm start
 Currently, no environment variables are required for the base installation. Future integrations may require:
 
 ```env
-DATABASE_URL=          # For database integration
+DB_ENGINE=postgresql   # Production default: postgresql. Use sqlite for local/test.
+DATABASE_URL=          # PostgreSQL URL in production; sqlite:./stellar.db for local SQLite
 NEXT_PUBLIC_API_URL=   # For API endpoints
 AUTH_SECRET=           # For authentication
 STRIPE_API_KEY=        # For payments
 ```
+
+Production deployments should provision PostgreSQL and set `DATABASE_URL` to a
+`postgres://` or `postgresql://` connection string. SQLite remains supported for
+local development and tests by setting `DB_ENGINE=sqlite` or using a
+`sqlite:` database URL.
 
 ## API Routes (Extensible)
 
@@ -532,6 +538,13 @@ docker-compose up
 # - pgAdmin: http://localhost:5050 (admin/admin)
 # - PostgreSQL: localhost:5432
 # - Redis: localhost:6379
+```
+
+PostgreSQL is the production database. For local-only API experiments or tests,
+use SQLite explicitly:
+
+```bash
+DB_ENGINE=sqlite DATABASE_URL=sqlite:./stellar.db cargo run --bin stellar-api
 ```
 
 ### Backend Development

--- a/backend/services/api/src/database.rs
+++ b/backend/services/api/src/database.rs
@@ -1,6 +1,60 @@
 #[path = "db/mod.rs"]
 pub mod db;
 
+use std::env;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DatabaseEngine {
+    PostgreSql,
+    Sqlite,
+}
+
+impl DatabaseEngine {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DatabaseEngine::PostgreSql => "postgresql",
+            DatabaseEngine::Sqlite => "sqlite",
+        }
+    }
+}
+
+pub fn select_database_engine() -> DatabaseEngine {
+    select_database_engine_from(
+        env::var("DB_ENGINE").ok().as_deref(),
+        env::var("DATABASE_URL").ok().as_deref(),
+        env::var("NODE_ENV").ok().as_deref(),
+    )
+}
+
+fn select_database_engine_from(
+    db_engine: Option<&str>,
+    database_url: Option<&str>,
+    node_env: Option<&str>,
+) -> DatabaseEngine {
+    if let Some(engine) = db_engine {
+        return match engine.trim().to_ascii_lowercase().as_str() {
+            "postgres" | "postgresql" | "pg" => DatabaseEngine::PostgreSql,
+            "sqlite" | "sqlite3" => DatabaseEngine::Sqlite,
+            other => panic!("Unsupported DB_ENGINE '{other}'. Use 'postgresql' or 'sqlite'."),
+        };
+    }
+
+    if let Some(url) = database_url {
+        let normalized = url.trim().to_ascii_lowercase();
+        if normalized.starts_with("sqlite:") || normalized.ends_with(".db") {
+            return DatabaseEngine::Sqlite;
+        }
+        if normalized.starts_with("postgres://") || normalized.starts_with("postgresql://") {
+            return DatabaseEngine::PostgreSql;
+        }
+    }
+
+    match node_env {
+        Some("test") | Some("development") | Some("local") => DatabaseEngine::Sqlite,
+        _ => DatabaseEngine::PostgreSql,
+    }
+}
+
 // Re-export all database functionality for convenient access
 pub use db::creators::{
     Creator, Project, CreatorStats,
@@ -29,3 +83,40 @@ pub use db::reviews::{
     get_mock_reviews, reviews_for_creator, aggregate_reviews, 
     recent_reviews, submit_review
 };
+
+#[cfg(test)]
+mod tests {
+    use super::{select_database_engine_from, DatabaseEngine};
+
+    #[test]
+    fn defaults_to_postgresql_for_production() {
+        assert_eq!(
+            select_database_engine_from(None, None, Some("production")),
+            DatabaseEngine::PostgreSql,
+        );
+    }
+
+    #[test]
+    fn keeps_sqlite_available_for_local_and_tests() {
+        assert_eq!(
+            select_database_engine_from(None, None, Some("development")),
+            DatabaseEngine::Sqlite,
+        );
+        assert_eq!(
+            select_database_engine_from(Some("sqlite"), None, Some("production")),
+            DatabaseEngine::Sqlite,
+        );
+    }
+
+    #[test]
+    fn database_url_selects_engine_when_db_engine_is_absent() {
+        assert_eq!(
+            select_database_engine_from(None, Some("postgres://user:pass@localhost/app"), None),
+            DatabaseEngine::PostgreSql,
+        );
+        assert_eq!(
+            select_database_engine_from(None, Some("sqlite:./stellar.db"), None),
+            DatabaseEngine::Sqlite,
+        );
+    }
+}


### PR DESCRIPTION
Closes #405

## Summary
- Add runtime database engine selection
- Default production configuration to PostgreSQL
- Preserve SQLite for local and test environments
- Update README database setup documentation

## Checks
- cargo fmt
- cargo check
- cargo test