### PR TITLE
feat: [Frontend] Implement Real-time Collaborative Markdown Editing via CRDTs

### DIFF
--- a/PR_621_COLLABORATIVE_EDITOR.md
+++ b/PR_621_COLLABORATIVE_EDITOR.md
@@ -1,0 +1,69 @@
+# [Frontend] Implement Real-time Collaborative Markdown Editing via CRDTs
+
+## Summary
+
+Adds real-time collaborative editing to bounty project scope documents using **Yjs CRDTs** and **TipTap**. Clients and creators can now co-edit the same document simultaneously without conflicts — changes merge automatically via the CRDT algorithm.
+
+## Changes
+
+### New Files
+| File | Description |
+|------|-------------|
+| `components/collaborative-editor.tsx` | Core TipTap editor with Yjs CRDT sync and multi-colored presence cursors |
+| `app/bounties/[id]/page.tsx` | Bounty detail page showing meta info + collaborative scope editor |
+| `app/bounties/[id]/bounty-scope-editor.tsx` | Client wrapper with dynamic import (SSR-safe) |
+| `server/collab.ts` | Standalone Yjs WebSocket server (runs alongside Next.js) |
+| `app/api/collab/route.ts` | Next.js API route placeholder for WebSocket upgrade |
+
+### Modified Files
+| File | Description |
+|------|-------------|
+| `package.json` | Added `yjs`, `y-websocket`, `@tiptap/extension-collaboration`, `@tiptap/extension-collaboration-cursor` |
+| `pnpm-lock.yaml` | Lockfile updated |
+
+## Implementation Details
+
+### CRDT Sync (Yjs)
+- Each bounty gets its own Yjs document room keyed by `bounty-scope-{bountyId}`
+- `WebsocketProvider` from `y-websocket` handles real-time sync and reconnection
+- Document state is a shared `Y.Doc` — all edits are conflict-free by design
+
+### Presence Cursors
+- `@tiptap/extension-collaboration-cursor` renders each user's cursor with a unique colour and name label
+- 8 distinct cursor colours assigned randomly per session
+- User identity is ephemeral (session-scoped) — no auth required for presence
+
+### WebSocket Server
+- `server/collab.ts` is a standalone Node.js WebSocket server using `y-websocket/bin/utils.js`
+- Runs on `WS_PORT` (default `1234`) alongside the Next.js dev server
+- Configure the client URL via `NEXT_PUBLIC_COLLAB_WS_URL` env var
+
+### SSR Safety
+- `CollaborativeEditor` is dynamically imported with `ssr: false` to prevent hydration issues with browser-only Yjs/WebSocket APIs
+
+## How to Run
+
+```bash
+# Terminal 1 – Next.js dev server
+pnpm dev
+
+# Terminal 2 – Yjs WebSocket collaboration server
+node --input-type=module < server/collab.ts
+# or compile first: npx tsc server/collab.ts --outDir dist && node dist/collab.js
+```
+
+Set `NEXT_PUBLIC_COLLAB_WS_URL=ws://localhost:1234` in `.env.local` (defaults to this value).
+
+## Testing
+
+1. Open `http://localhost:3000/bounties/bounty-1` in two browser tabs
+2. Type in one tab — changes appear instantly in the other
+3. Each tab shows a coloured cursor label for the other user
+
+## Screenshots
+
+> Bounty detail page with collaborative scope editor and live presence cursors.
+
+---
+
+closes #621

--- a/app/api/collab/route.ts
+++ b/app/api/collab/route.ts
@@ -1,0 +1,48 @@
+/**
+ * WebSocket endpoint for Yjs CRDT document synchronization.
+ * Uses y-websocket's setupWSConnection to handle all Yjs protocol messages.
+ */
+import { type NextRequest } from 'next/server'
+
+export const runtime = 'nodejs'
+
+// Lazy-load to avoid issues during SSR/build
+let setupWSConnection: (ws: WebSocket, req: Request, opts?: { docName?: string }) => void
+
+async function getSetup() {
+  if (!setupWSConnection) {
+    const mod = await import('y-websocket/bin/utils.js')
+    setupWSConnection = mod.setupWSConnection
+  }
+  return setupWSConnection
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const docName = searchParams.get('doc') ?? 'default'
+
+  // Next.js App Router WebSocket upgrade
+  // @ts-expect-error – Next.js exposes socket on the underlying request
+  const { socket, response } = Reflect.get(req, 'socket')
+    ? { socket: null, response: null }
+    : await (req as unknown as { socket: unknown }).socket
+
+  // Use the built-in WebSocket upgrade via Next.js
+  const upgradeHeader = req.headers.get('upgrade')
+  if (upgradeHeader !== 'websocket') {
+    return new Response('Expected WebSocket upgrade', { status: 426 })
+  }
+
+  try {
+    // @ts-expect-error – Next.js internal
+    const { socket: ws, response: wsResponse } = req[Symbol.for('NextInternalRequestContext')]?.upgradeWebSocket?.() ?? {}
+    if (!ws) {
+      return new Response('WebSocket upgrade failed', { status: 500 })
+    }
+    const setup = await getSetup()
+    setup(ws as unknown as WebSocket, req as unknown as Request, { docName })
+    return wsResponse
+  } catch {
+    return new Response('WebSocket not supported in this environment', { status: 501 })
+  }
+}

--- a/app/bounties/[id]/bounty-scope-editor.tsx
+++ b/app/bounties/[id]/bounty-scope-editor.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+/**
+ * BountyScopeEditor
+ *
+ * Client wrapper that renders the CollaborativeEditor for a specific bounty's
+ * project scope document. Each bounty gets its own Yjs document room keyed by
+ * bountyId so clients and creators can co-edit the scope in real time.
+ */
+
+import dynamic from 'next/dynamic'
+import { Users } from 'lucide-react'
+
+// Dynamically import to avoid SSR issues with browser-only Yjs/WebSocket APIs
+const CollaborativeEditor = dynamic(
+  () => import('@/components/collaborative-editor').then((m) => m.CollaborativeEditor),
+  { ssr: false, loading: () => <EditorSkeleton /> },
+)
+
+interface Props {
+  bountyId: string
+  initialDeliverables: string
+}
+
+export function BountyScopeEditor({ bountyId, initialDeliverables }: Props) {
+  return (
+    <section aria-labelledby="scope-heading">
+      <div className="flex items-center gap-2 mb-3">
+        <h2 id="scope-heading" className="text-lg font-semibold">
+          Project Scope
+        </h2>
+        <span className="flex items-center gap-1 text-xs text-muted-foreground">
+          <Users className="h-3.5 w-3.5" />
+          Live collaborative editing
+        </span>
+      </div>
+      <p className="text-sm text-muted-foreground mb-4">
+        Edit the project scope below. Changes sync in real time for all
+        collaborators — no refresh needed.
+      </p>
+      <CollaborativeEditor
+        docId={`bounty-scope-${bountyId}`}
+        initialContent={`<p>${initialDeliverables}</p>`}
+        className="min-h-[300px]"
+      />
+    </section>
+  )
+}
+
+function EditorSkeleton() {
+  return (
+    <div className="rounded-md border border-border bg-muted/30 min-h-[300px] animate-pulse" />
+  )
+}

--- a/app/bounties/[id]/page.tsx
+++ b/app/bounties/[id]/page.tsx
@@ -1,0 +1,70 @@
+import { notFound } from 'next/navigation'
+import { bounties } from '@/lib/creators-data'
+import { Header } from '@/components/header'
+import { Footer } from '@/components/footer'
+import { BountyMetaRow } from './bounty-meta-client'
+import { BountyScopeEditor } from './bounty-scope-editor'
+import { Badge } from '@/components/ui/badge'
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+export async function generateStaticParams() {
+  return bounties.map((b) => ({ id: b.id }))
+}
+
+export default async function BountyDetailPage({ params }: Props) {
+  const { id } = await params
+  const bounty = bounties.find((b) => b.id === id)
+  if (!bounty) notFound()
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background">
+      <Header />
+      <main className="flex-grow container max-w-4xl mx-auto px-4 py-10">
+        {/* Header */}
+        <div className="mb-6">
+          <div className="flex flex-wrap gap-2 mb-3">
+            <Badge variant="secondary">{bounty.category}</Badge>
+            <Badge variant="outline">{bounty.difficulty}</Badge>
+            {bounty.tags.map((tag) => (
+              <Badge key={tag} variant="outline" className="text-xs">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight mb-2">{bounty.title}</h1>
+          <p className="text-muted-foreground">{bounty.description}</p>
+        </div>
+
+        {/* Meta row: budget / deadline / status */}
+        <BountyMetaRow
+          currency={bounty.currency}
+          budget={bounty.budget}
+          deadlineMs={bounty.deadline.getTime()}
+          status={bounty.status}
+        />
+
+        {/* Required skills */}
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold mb-2">Required Skills</h2>
+          <div className="flex flex-wrap gap-2">
+            {bounty.requiredSkills.map((skill) => (
+              <Badge key={skill} variant="secondary">
+                {skill}
+              </Badge>
+            ))}
+          </div>
+        </div>
+
+        {/* Collaborative scope editor */}
+        <BountyScopeEditor
+          bountyId={bounty.id}
+          initialDeliverables={bounty.deliverables}
+        />
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/components/collaborative-editor.tsx
+++ b/components/collaborative-editor.tsx
@@ -1,0 +1,284 @@
+'use client'
+
+/**
+ * CollaborativeEditor
+ *
+ * Real-time collaborative markdown editor backed by Yjs CRDTs.
+ * - Syncs document state via y-websocket
+ * - Shows live multi-colored presence cursors for each connected user
+ * - Renders a full TipTap rich-text editor with starter-kit formatting
+ */
+
+import { useEffect, useMemo, useRef } from 'react'
+import { useEditor, EditorContent } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import Collaboration from '@tiptap/extension-collaboration'
+import CollaborationCursor from '@tiptap/extension-collaboration-cursor'
+import * as Y from 'yjs'
+import { WebsocketProvider } from 'y-websocket'
+
+// ── Presence colours ──────────────────────────────────────────────────────────
+const CURSOR_COLORS = [
+  '#f97316', '#8b5cf6', '#06b6d4', '#10b981',
+  '#f43f5e', '#eab308', '#3b82f6', '#ec4899',
+]
+
+function randomColor() {
+  return CURSOR_COLORS[Math.floor(Math.random() * CURSOR_COLORS.length)]
+}
+
+function randomName() {
+  const adjectives = ['Swift', 'Bright', 'Bold', 'Calm', 'Keen']
+  const nouns = ['Creator', 'Builder', 'Maker', 'Thinker', 'Doer']
+  return `${adjectives[Math.floor(Math.random() * adjectives.length)]} ${nouns[Math.floor(Math.random() * nouns.length)]}`
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+interface CollaborativeEditorProps {
+  /** Unique document identifier (e.g. bounty ID) */
+  docId: string
+  /** WebSocket server URL (defaults to env var or localhost:1234) */
+  wsUrl?: string
+  /** Initial content (only applied when the doc is empty) */
+  initialContent?: string
+  /** Called whenever the document content changes */
+  onChange?: (html: string) => void
+  /** Whether the editor is read-only */
+  readOnly?: boolean
+  className?: string
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+export function CollaborativeEditor({
+  docId,
+  wsUrl,
+  initialContent,
+  onChange,
+  readOnly = false,
+  className = '',
+}: CollaborativeEditorProps) {
+  const serverUrl =
+    wsUrl ??
+    process.env.NEXT_PUBLIC_COLLAB_WS_URL ??
+    'ws://localhost:1234'
+
+  // Stable user identity for this session
+  const user = useMemo(
+    () => ({ name: randomName(), color: randomColor() }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  )
+
+  // Yjs document & provider – created once per docId
+  const ydocRef = useRef<Y.Doc | null>(null)
+  const providerRef = useRef<WebsocketProvider | null>(null)
+
+  if (!ydocRef.current) {
+    ydocRef.current = new Y.Doc()
+  }
+
+  useEffect(() => {
+    const ydoc = ydocRef.current!
+    const provider = new WebsocketProvider(serverUrl, docId, ydoc)
+    providerRef.current = provider
+
+    // Broadcast our presence
+    provider.awareness.setLocalStateField('user', user)
+
+    return () => {
+      provider.destroy()
+      providerRef.current = null
+    }
+    // Re-connect only when docId or server changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [docId, serverUrl])
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        // Disable built-in history – Yjs handles undo/redo
+        history: false,
+      }),
+      Collaboration.configure({
+        document: ydocRef.current,
+      }),
+      CollaborationCursor.configure({
+        provider: providerRef.current!,
+        user,
+      }),
+    ],
+    content: initialContent ?? '',
+    editable: !readOnly,
+    onUpdate({ editor }) {
+      onChange?.(editor.getHTML())
+    },
+  })
+
+  // Keep CollaborationCursor provider in sync after mount
+  useEffect(() => {
+    if (!editor || !providerRef.current) return
+    const cursorExt = editor.extensionManager.extensions.find(
+      (e) => e.name === 'collaborationCursor',
+    )
+    if (cursorExt) {
+      cursorExt.options.provider = providerRef.current
+    }
+  }, [editor])
+
+  return (
+    <div className={`collaborative-editor ${className}`}>
+      {/* Cursor colour legend */}
+      <style>{`
+        /* Yjs collaboration cursor styles */
+        .collaboration-cursor__caret {
+          border-left: 2px solid;
+          border-right: 2px solid;
+          margin-left: -1px;
+          margin-right: -1px;
+          pointer-events: none;
+          position: relative;
+          word-break: normal;
+        }
+        .collaboration-cursor__label {
+          border-radius: 3px 3px 3px 0;
+          color: #fff;
+          font-size: 11px;
+          font-style: normal;
+          font-weight: 600;
+          left: -1px;
+          line-height: normal;
+          padding: 0.1rem 0.3rem;
+          position: absolute;
+          top: -1.4em;
+          user-select: none;
+          white-space: nowrap;
+        }
+        .collaborative-editor .ProseMirror {
+          min-height: 200px;
+          padding: 1rem;
+          outline: none;
+        }
+        .collaborative-editor .ProseMirror p.is-editor-empty:first-child::before {
+          color: #adb5bd;
+          content: attr(data-placeholder);
+          float: left;
+          height: 0;
+          pointer-events: none;
+        }
+      `}</style>
+
+      <div className="rounded-md border border-border bg-background focus-within:ring-2 focus-within:ring-ring">
+        {/* Toolbar */}
+        {!readOnly && editor && (
+          <div className="flex flex-wrap gap-1 border-b border-border p-2">
+            <ToolbarButton
+              onClick={() => editor.chain().focus().toggleBold().run()}
+              active={editor.isActive('bold')}
+              title="Bold"
+            >
+              <strong>B</strong>
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => editor.chain().focus().toggleItalic().run()}
+              active={editor.isActive('italic')}
+              title="Italic"
+            >
+              <em>I</em>
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => editor.chain().focus().toggleStrike().run()}
+              active={editor.isActive('strike')}
+              title="Strikethrough"
+            >
+              <s>S</s>
+            </ToolbarButton>
+            <div className="w-px bg-border mx-1" />
+            <ToolbarButton
+              onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+              active={editor.isActive('heading', { level: 2 })}
+              title="Heading 2"
+            >
+              H2
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+              active={editor.isActive('heading', { level: 3 })}
+              title="Heading 3"
+            >
+              H3
+            </ToolbarButton>
+            <div className="w-px bg-border mx-1" />
+            <ToolbarButton
+              onClick={() => editor.chain().focus().toggleBulletList().run()}
+              active={editor.isActive('bulletList')}
+              title="Bullet list"
+            >
+              •—
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => editor.chain().focus().toggleOrderedList().run()}
+              active={editor.isActive('orderedList')}
+              title="Ordered list"
+            >
+              1.
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+              active={editor.isActive('codeBlock')}
+              title="Code block"
+            >
+              {'</>'}
+            </ToolbarButton>
+            <div className="w-px bg-border mx-1" />
+            <ToolbarButton
+              onClick={() => editor.chain().focus().undo().run()}
+              active={false}
+              title="Undo"
+            >
+              ↩
+            </ToolbarButton>
+            <ToolbarButton
+              onClick={() => editor.chain().focus().redo().run()}
+              active={false}
+              title="Redo"
+            >
+              ↪
+            </ToolbarButton>
+          </div>
+        )}
+
+        <EditorContent editor={editor} />
+      </div>
+    </div>
+  )
+}
+
+// ── Toolbar button ─────────────────────────────────────────────────────────────
+function ToolbarButton({
+  onClick,
+  active,
+  title,
+  children,
+}: {
+  onClick: () => void
+  active: boolean
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-label={title}
+      aria-pressed={active}
+      className={`rounded px-2 py-1 text-sm font-medium transition-colors
+        ${active
+          ? 'bg-primary text-primary-foreground'
+          : 'hover:bg-muted text-foreground'
+        }`}
+    >
+      {children}
+    </button>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "@rolldown/binding-linux-x64-gnu": "^1.0.0-rc.17",
     "@supabase/supabase-js": "^2.105.1",
     "@tanstack/react-query": "^5.28.0",
+    "@tiptap/extension-collaboration": "^2.27.2",
+    "@tiptap/extension-collaboration-cursor": "^2.27.2",
     "@tiptap/extension-link": "^2.27.2",
     "@tiptap/extension-placeholder": "^2.27.2",
     "@tiptap/pm": "^2.27.2",
@@ -82,6 +84,8 @@
     "sonner": "^1.7.1",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
+    "y-websocket": "^2.1.0",
+    "yjs": "^13.6.31",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,12 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.28.0
         version: 5.100.6(react@19.2.4)
+      '@tiptap/extension-collaboration':
+        specifier: ^2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(y-prosemirror@1.3.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))
+      '@tiptap/extension-collaboration-cursor':
+        specifier: ^2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(y-prosemirror@1.3.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))
       '@tiptap/extension-link':
         specifier: ^2.27.2
         version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
@@ -182,6 +188,12 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      y-websocket:
+        specifier: ^2.1.0
+        version: 2.1.0(yjs@13.6.31)
+      yjs:
+        specifier: ^13.6.31
+        version: 13.6.31
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -1731,6 +1743,19 @@ packages:
     peerDependencies:
       '@tiptap/core': ^2.7.0
 
+  '@tiptap/extension-collaboration-cursor@2.27.2':
+    resolution: {integrity: sha512-ScgoVszsFpYs3EldKze1wLcyumNhZHgiOpAj7DpdTEdfSaFAB2gGvzenPBy1zI/PGcLPFEuC/fdLc5ntD3di4Q==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      y-prosemirror: ^1.2.11
+
+  '@tiptap/extension-collaboration@2.27.2':
+    resolution: {integrity: sha512-Y61ItHxQ1uc/Ir27mBQRI/wY9JkOui194V+awNv+1YHeaKArTjC2cdSvNzj9+h8JIh5MyfvslSf8hBa7t7PzAg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+      y-prosemirror: ^1.2.11
+
   '@tiptap/extension-document@2.27.2':
     resolution: {integrity: sha512-CFhAYsPnyYnosDC4639sCJnBUnYH4Cat9qH5NZWHVvdgtDwu8GZgZn2eSzaKSYXWH1vJ9DSlCK+7UyC3SNXIBA==}
     peerDependencies:
@@ -2153,6 +2178,16 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  abstract-leveldown@6.2.3:
+    resolution: {integrity: sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
+  abstract-leveldown@6.3.0:
+    resolution: {integrity: sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2242,6 +2277,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async-limiter@1.0.1:
+    resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
+
   autoprefixer@10.4.24:
     resolution: {integrity: sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2268,6 +2306,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -2290,6 +2331,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2463,6 +2507,11 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deferred-leveldown@5.3.0:
+    resolution: {integrity: sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -2521,6 +2570,11 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encoding-down@6.3.0:
+    resolution: {integrity: sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
   enhanced-resolve@5.19.0:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
@@ -2532,6 +2586,10 @@ packages:
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
+
+  errno@0.1.8:
+    resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
+    hasBin: true
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -2892,6 +2950,9 @@ packages:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2899,6 +2960,9 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  immediate@3.3.0:
+    resolution: {integrity: sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -2911,6 +2975,9 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   input-otp@1.4.2:
     resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
@@ -3042,6 +3109,9 @@ packages:
     resolution: {integrity: sha512-E8YkGyPY3a/U5s0WOoc8Ok+3SWL/33yn2IHCoxCFLBUUPVy9WGa++akJZFxQCcJIhI+UvYhbrbnTIFQkHKZbgA==}
     engines: {node: '>=20.19.5'}
 
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -3127,9 +3197,60 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  level-codec@9.0.2:
+    resolution: {integrity: sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by level-transcoder (https://github.com/Level/community#faq)
+
+  level-concat-iterator@2.0.1:
+    resolution: {integrity: sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
+  level-errors@2.0.1:
+    resolution: {integrity: sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
+  level-iterator-stream@4.0.2:
+    resolution: {integrity: sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==}
+    engines: {node: '>=6'}
+
+  level-js@5.0.2:
+    resolution: {integrity: sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==}
+    deprecated: Superseded by browser-level (https://github.com/Level/community#faq)
+
+  level-packager@5.1.1:
+    resolution: {integrity: sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
+  level-supports@1.0.1:
+    resolution: {integrity: sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==}
+    engines: {node: '>=6'}
+
+  level@6.0.1:
+    resolution: {integrity: sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==}
+    engines: {node: '>=8.6.0'}
+
+  leveldown@5.6.0:
+    resolution: {integrity: sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==}
+    engines: {node: '>=8.6.0'}
+    deprecated: Superseded by classic-level (https://github.com/Level/community#faq)
+
+  levelup@4.4.0:
+    resolution: {integrity: sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==}
+    engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -3289,6 +3410,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -3305,6 +3429,9 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  ltgt@2.2.1:
+    resolution: {integrity: sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==}
 
   lucide-react@0.564.0:
     resolution: {integrity: sha512-JJ8GVTQqFwuliifD48U6+h7DXEHdkhJ/E87kksGByII3qHxtPciVb8T8woQONHBQgHVOl7rSMrrip3SeVNy7Fg==}
@@ -3369,6 +3496,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-macros@2.0.0:
+    resolution: {integrity: sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==}
+
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -3407,6 +3537,10 @@ packages:
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-gyp-build@4.1.1:
+    resolution: {integrity: sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==}
+    hasBin: true
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -3595,6 +3729,9 @@ packages:
   prosemirror-view@1.41.8:
     resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
 
+  prr@1.0.1:
+    resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
+
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
@@ -3684,6 +3821,10 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
 
@@ -3740,6 +3881,9 @@ packages:
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -3853,6 +3997,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -4038,6 +4185,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   vaul@1.1.2:
     resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
     peerDependencies:
@@ -4180,6 +4330,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  ws@6.2.4:
+    resolution: {integrity: sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -4199,8 +4360,44 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  y-leveldb@0.1.2:
+    resolution: {integrity: sha512-6ulEn5AXfXJYi89rXPEg2mMHAyyw8+ZfeMMdOtBbV8FJpQ1NOrcgi6DTAcXof0dap84NjHPT2+9d0rb6cFsjEg==}
+    peerDependencies:
+      yjs: ^13.0.0
+
+  y-prosemirror@1.3.7:
+    resolution: {integrity: sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      prosemirror-model: ^1.7.1
+      prosemirror-state: ^1.2.3
+      prosemirror-view: ^1.9.10
+      y-protocols: ^1.0.1
+      yjs: ^13.5.38
+
+  y-protocols@1.0.7:
+    resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
+
+  y-websocket@2.1.0:
+    resolution: {integrity: sha512-WHYDRqomaGkkaujtowCDwL8KYk+t1zQCGIgKyvxvchhjTQlMgWXRHJK+FDEcWmHA7I7o/4fy0eniOrtmz0e4mA==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    peerDependencies:
+      yjs: ^13.5.6
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yjs@13.6.31:
+    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -5616,6 +5813,17 @@ snapshots:
     dependencies:
       '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
 
+  '@tiptap/extension-collaboration-cursor@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(y-prosemirror@1.3.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      y-prosemirror: 1.3.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
+
+  '@tiptap/extension-collaboration@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(y-prosemirror@1.3.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+      y-prosemirror: 1.3.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
+
   '@tiptap/extension-document@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
     dependencies:
       '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
@@ -6039,6 +6247,24 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abstract-leveldown@6.2.3:
+    dependencies:
+      buffer: 5.7.1
+      immediate: 3.3.0
+      level-concat-iterator: 2.0.1
+      level-supports: 1.0.1
+      xtend: 4.0.2
+    optional: true
+
+  abstract-leveldown@6.3.0:
+    dependencies:
+      buffer: 5.7.1
+      immediate: 3.3.0
+      level-concat-iterator: 2.0.1
+      level-supports: 1.0.1
+      xtend: 4.0.2
+    optional: true
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -6153,6 +6379,9 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async-limiter@1.0.1:
+    optional: true
+
   autoprefixer@10.4.24(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.1
@@ -6173,6 +6402,9 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  base64-js@1.5.1:
+    optional: true
 
   baseline-browser-mapping@2.9.19: {}
 
@@ -6200,6 +6432,12 @@ snapshots:
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    optional: true
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -6366,6 +6604,12 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deferred-leveldown@5.3.0:
+    dependencies:
+      abstract-leveldown: 6.2.3
+      inherits: 2.0.4
+    optional: true
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
@@ -6423,6 +6667,14 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encoding-down@6.3.0:
+    dependencies:
+      abstract-leveldown: 6.3.0
+      inherits: 2.0.4
+      level-codec: 9.0.2
+      level-errors: 2.0.1
+    optional: true
+
   enhanced-resolve@5.19.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -6431,6 +6683,11 @@ snapshots:
   entities@4.5.0: {}
 
   entities@8.0.0: {}
+
+  errno@0.1.8:
+    dependencies:
+      prr: 1.0.1
+    optional: true
 
   es-abstract@1.24.2:
     dependencies:
@@ -6930,9 +7187,15 @@ snapshots:
 
   iceberg-js@0.8.1: {}
 
+  ieee754@1.2.1:
+    optional: true
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  immediate@3.3.0:
+    optional: true
 
   import-fresh@3.3.1:
     dependencies:
@@ -6942,6 +7205,9 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  inherits@2.0.4:
+    optional: true
 
   input-otp@1.4.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -7083,6 +7349,8 @@ snapshots:
       - canvas
       - supports-color
 
+  isomorphic.js@0.2.5: {}
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -7199,10 +7467,76 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  level-codec@9.0.2:
+    dependencies:
+      buffer: 5.7.1
+    optional: true
+
+  level-concat-iterator@2.0.1:
+    optional: true
+
+  level-errors@2.0.1:
+    dependencies:
+      errno: 0.1.8
+    optional: true
+
+  level-iterator-stream@4.0.2:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      xtend: 4.0.2
+    optional: true
+
+  level-js@5.0.2:
+    dependencies:
+      abstract-leveldown: 6.2.3
+      buffer: 5.7.1
+      inherits: 2.0.4
+      ltgt: 2.2.1
+    optional: true
+
+  level-packager@5.1.1:
+    dependencies:
+      encoding-down: 6.3.0
+      levelup: 4.4.0
+    optional: true
+
+  level-supports@1.0.1:
+    dependencies:
+      xtend: 4.0.2
+    optional: true
+
+  level@6.0.1:
+    dependencies:
+      level-js: 5.0.2
+      level-packager: 5.1.1
+      leveldown: 5.6.0
+    optional: true
+
+  leveldown@5.6.0:
+    dependencies:
+      abstract-leveldown: 6.2.3
+      napi-macros: 2.0.0
+      node-gyp-build: 4.1.1
+    optional: true
+
+  levelup@4.4.0:
+    dependencies:
+      deferred-leveldown: 5.3.0
+      level-errors: 2.0.1
+      level-iterator-stream: 4.0.2
+      level-supports: 1.0.1
+      xtend: 4.0.2
+    optional: true
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
 
   lightningcss-android-arm64@1.31.1:
     optional: true
@@ -7312,6 +7646,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.debounce@4.0.8: {}
+
   lodash.merge@4.6.2: {}
 
   lodash@4.17.23: {}
@@ -7325,6 +7661,9 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  ltgt@2.2.1:
+    optional: true
 
   lucide-react@0.564.0(react@19.2.4):
     dependencies:
@@ -7384,6 +7723,9 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-macros@2.0.0:
+    optional: true
+
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -7424,6 +7766,9 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
+
+  node-gyp-build@4.1.1:
+    optional: true
 
   node-releases@2.0.27: {}
 
@@ -7665,6 +8010,9 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
+  prr@1.0.1:
+    optional: true
+
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
@@ -7743,6 +8091,13 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    optional: true
 
   recharts-scale@0.4.5:
     dependencies:
@@ -7837,6 +8192,9 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.2.1:
+    optional: true
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -8016,6 +8374,11 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
 
   strip-bom@3.0.0: {}
 
@@ -8212,6 +8575,9 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  util-deprecate@1.0.2:
+    optional: true
+
   vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -8349,13 +8715,59 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  ws@6.2.4:
+    dependencies:
+      async-limiter: 1.0.1
+    optional: true
+
   ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
+  xtend@4.0.2:
+    optional: true
+
+  y-leveldb@0.1.2(yjs@13.6.31):
+    dependencies:
+      level: 6.0.1
+      lib0: 0.2.117
+      yjs: 13.6.31
+    optional: true
+
+  y-prosemirror@1.3.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.8
+      y-protocols: 1.0.7(yjs@13.6.31)
+      yjs: 13.6.31
+
+  y-protocols@1.0.7(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.31
+
+  y-websocket@2.1.0(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      lodash.debounce: 4.0.8
+      y-protocols: 1.0.7(yjs@13.6.31)
+      yjs: 13.6.31
+    optionalDependencies:
+      ws: 6.2.4
+      y-leveldb: 0.1.2(yjs@13.6.31)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   yallist@3.1.1: {}
+
+  yjs@13.6.31:
+    dependencies:
+      lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
 

--- a/server/collab.ts
+++ b/server/collab.ts
@@ -1,0 +1,29 @@
+/**
+ * Standalone Yjs WebSocket collaboration server.
+ * Run with: node --loader ts-node/esm server/collab.ts
+ * Or in production: node server/collab.js
+ *
+ * Listens on WS_PORT (default 1234) and handles Yjs CRDT sync
+ * for all document rooms identified by the URL path.
+ */
+import { WebSocketServer } from 'ws'
+import { setupWSConnection } from 'y-websocket/bin/utils.js'
+
+const PORT = parseInt(process.env.WS_PORT ?? '1234', 10)
+const HOST = process.env.WS_HOST ?? 'localhost'
+
+const wss = new WebSocketServer({ host: HOST, port: PORT })
+
+wss.on('connection', (ws, req) => {
+  // Extract doc name from URL path, e.g. /bounty-123 → 'bounty-123'
+  const docName = (req.url ?? '/').replace(/^\//, '') || 'default'
+  setupWSConnection(ws, req, { docName })
+})
+
+wss.on('listening', () => {
+  console.log(`[collab] Yjs WebSocket server running on ws://${HOST}:${PORT}`)
+})
+
+wss.on('error', (err) => {
+  console.error('[collab] WebSocket server error:', err)
+})


### PR DESCRIPTION
# [Frontend] Implement Real-time Collaborative Markdown Editing via CRDTs

## Summary

Adds real-time collaborative editing to bounty project scope documents using **Yjs CRDTs** and **TipTap**. Clients and creators can now co-edit the same document simultaneously without conflicts — changes merge automatically via the CRDT algorithm.

## Changes

### New Files
| File | Description |
|------|-------------|
| `components/collaborative-editor.tsx` | Core TipTap editor with Yjs CRDT sync and multi-colored presence cursors |
| `app/bounties/[id]/page.tsx` | Bounty detail page showing meta info + collaborative scope editor |
| `app/bounties/[id]/bounty-scope-editor.tsx` | Client wrapper with dynamic import (SSR-safe) |
| `server/collab.ts` | Standalone Yjs WebSocket server (runs alongside Next.js) |
| `app/api/collab/route.ts` | Next.js API route placeholder for WebSocket upgrade |

### Modified Files
| File | Description |
|------|-------------|
| `package.json` | Added `yjs`, `y-websocket`, `@tiptap/extension-collaboration`, `@tiptap/extension-collaboration-cursor` |
| `pnpm-lock.yaml` | Lockfile updated |

## Implementation Details

### CRDT Sync (Yjs)
- Each bounty gets its own Yjs document room keyed by `bounty-scope-{bountyId}`
- `WebsocketProvider` from `y-websocket` handles real-time sync and reconnection
- Document state is a shared `Y.Doc` — all edits are conflict-free by design

### Presence Cursors
- `@tiptap/extension-collaboration-cursor` renders each user's cursor with a unique colour and name label
- 8 distinct cursor colours assigned randomly per session
- User identity is ephemeral (session-scoped) — no auth required for presence

### WebSocket Server
- `server/collab.ts` is a standalone Node.js WebSocket server using `y-websocket/bin/utils.js`
- Runs on `WS_PORT` (default `1234`) alongside the Next.js dev server
- Configure the client URL via `NEXT_PUBLIC_COLLAB_WS_URL` env var

### SSR Safety
- `CollaborativeEditor` is dynamically imported with `ssr: false` to prevent hydration issues with browser-only Yjs/WebSocket APIs

## How to Run

```bash
# Terminal 1 – Next.js dev server
pnpm dev

# Terminal 2 – Yjs WebSocket collaboration server
node --input-type=module < server/collab.ts
# or compile first: npx tsc server/collab.ts --outDir dist && node dist/collab.js
```

Set `NEXT_PUBLIC_COLLAB_WS_URL=ws://localhost:1234` in `.env.local` (defaults to this value).

## Testing

1. Open `http://localhost:3000/bounties/bounty-1` in two browser tabs
2. Type in one tab — changes appear instantly in the other
3. Each tab shows a coloured cursor label for the other user

## Screenshots

> Bounty detail page with collaborative scope editor and live presence cursors.

---

closes #621