### PR TITLE
fix/feat: on-device AI prompts, OTA updates, K8s autoscaling, WebSocket memory leaks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,17 @@ SENTRY_AUTH_TOKEN="your-sentry-auth-token"
 SENTRY_ENVIRONMENT="development"
 SENTRY_RELEASE="1.0.0"
 ENABLE_ERROR_TRACKING=true
+
+# ---------------------------------------------------------------------------
+# Yjs Collaboration WebSocket server (server/collab.ts)
+# ---------------------------------------------------------------------------
+WS_PORT=1234
+WS_HOST=localhost
+# How often the server pings each client (ms)
+WS_HEARTBEAT_INTERVAL_MS=30000
+# Seconds to wait for a pong before terminating the connection (ms)
+WS_PONG_DEADLINE_MS=10000
+# Close connections with no activity for this long (ms)
+WS_IDLE_TIMEOUT_MS=300000
+# Public URL used by the Next.js frontend to connect
+NEXT_PUBLIC_COLLAB_WS_URL=ws://localhost:1234

--- a/.github/workflows/ota-release.yml
+++ b/.github/workflows/ota-release.yml
@@ -1,0 +1,158 @@
+name: OTA Release
+
+# #603 — Build, diff, encrypt, and publish an OTA patch on every merge to main.
+# Consumers pull the manifest from OTA_MANIFEST_URL and apply the patch
+# on-device without going through App Store review.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/ota-release.yml'
+
+concurrency:
+  group: ota-release
+  cancel-in-progress: false   # never cancel a release mid-flight
+
+jobs:
+  build-and-publish:
+    name: Build → Diff → Encrypt → Publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      OTA_BUCKET: ${{ secrets.OTA_S3_BUCKET }}
+      OTA_AES_KEY: ${{ secrets.OTA_AES_KEY }}   # 64-char hex (32 bytes)
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+
+    steps:
+      # ── Checkout ────────────────────────────────────────────────────────────
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2   # need HEAD and HEAD~1 for diffing
+
+      # ── Node / pnpm ─────────────────────────────────────────────────────────
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: mobile
+
+      # ── Export JS bundle ────────────────────────────────────────────────────
+      - name: Export Expo bundle
+        run: npx expo export --platform all --output-dir dist
+        working-directory: mobile
+        env:
+          EXPO_PUBLIC_OTA_MANIFEST_URL: ${{ secrets.OTA_MANIFEST_URL }}
+          EXPO_PUBLIC_OTA_AES_KEY: ${{ secrets.OTA_AES_KEY }}
+
+      # ── Download previous bundle for diffing ────────────────────────────────
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download previous bundle
+        id: prev
+        run: |
+          aws s3 cp "s3://${OTA_BUCKET}/bundles/current.bundle" prev.bundle || echo "no-prev=true" >> "$GITHUB_OUTPUT"
+
+      # ── Generate bsdiff patch ────────────────────────────────────────────────
+      - name: Install bsdiff
+        run: sudo apt-get install -y bsdiff
+
+      - name: Generate differential patch
+        run: |
+          BUNDLE_PATH=$(find mobile/dist -name '*.bundle' | head -1)
+          echo "BUNDLE_PATH=$BUNDLE_PATH" >> "$GITHUB_ENV"
+          if [ -f prev.bundle ]; then
+            bsdiff prev.bundle "$BUNDLE_PATH" patch.bin
+          else
+            # First release: patch IS the full bundle
+            cp "$BUNDLE_PATH" patch.bin
+          fi
+
+      # ── Encrypt patch with AES-256-GCM ──────────────────────────────────────
+      - name: Encrypt patch
+        id: encrypt
+        run: |
+          IV=$(openssl rand -hex 12)
+          TAG_FILE=tag.bin
+
+          # Encrypt and capture the 16-byte auth tag
+          openssl enc -aes-256-gcm \
+            -K "$OTA_AES_KEY" \
+            -iv "$IV" \
+            -in patch.bin \
+            -out patch.enc \
+            -nosalt
+
+          # openssl writes tag to stderr with -aes-256-gcm; extract via EVP API
+          # For CI simplicity we use a Node helper to get the tag properly
+          node -e "
+            const crypto = require('crypto');
+            const fs = require('fs');
+            const key = Buffer.from(process.env.OTA_AES_KEY, 'hex');
+            const iv = Buffer.from('$IV', 'hex');
+            const plain = fs.readFileSync('patch.bin');
+            const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+            const enc = Buffer.concat([cipher.update(plain), cipher.final()]);
+            const tag = cipher.getAuthTag();
+            fs.writeFileSync('patch.enc', enc);
+            fs.writeFileSync('$TAG_FILE', tag.toString('hex'));
+          "
+
+          TAG=$(cat $TAG_FILE)
+          SHA256=$(sha256sum "$BUNDLE_PATH" | awk '{print $1}')
+          VERSION=$(node -p "require('./mobile/package.json').version")
+          PATCH_SIZE=$(wc -c < patch.enc)
+
+          echo "iv=$IV"           >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA256"   >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "patch_size=$PATCH_SIZE" >> "$GITHUB_OUTPUT"
+
+      # ── Upload patch and manifest ────────────────────────────────────────────
+      - name: Upload encrypted patch
+        run: |
+          aws s3 cp patch.enc \
+            "s3://${OTA_BUCKET}/patches/${{ steps.encrypt.outputs.version }}.enc" \
+            --content-type application/octet-stream
+
+      - name: Write and upload manifest
+        run: |
+          cat > manifest.json <<EOF
+          {
+            "version": "${{ steps.encrypt.outputs.version }}",
+            "patchUrl": "https://${OTA_BUCKET}.s3.${AWS_REGION}.amazonaws.com/patches/${{ steps.encrypt.outputs.version }}.enc",
+            "sha256": "${{ steps.encrypt.outputs.sha256 }}",
+            "iv": "${{ steps.encrypt.outputs.iv }}",
+            "tag": "${{ steps.encrypt.outputs.tag }}",
+            "patchSize": ${{ steps.encrypt.outputs.patch_size }},
+            "minBaseVersion": "1.0.0"
+          }
+          EOF
+          aws s3 cp manifest.json \
+            "s3://${OTA_BUCKET}/manifest.json" \
+            --content-type application/json \
+            --cache-control "no-cache, no-store"
+
+      # ── Promote current bundle for next diff ─────────────────────────────────
+      - name: Promote bundle to current
+        run: |
+          aws s3 cp "$BUNDLE_PATH" \
+            "s3://${OTA_BUCKET}/bundles/current.bundle"
+
+      - name: Summary
+        run: |
+          echo "### OTA Release ${{ steps.encrypt.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Patch size: ${{ steps.encrypt.outputs.patch_size }} bytes" >> "$GITHUB_STEP_SUMMARY"
+          echo "- SHA-256: \`${{ steps.encrypt.outputs.sha256 }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -47,6 +47,12 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000
 WEBHOOK_SECRET=change-me-in-production
 WS_MAX_CONNECTIONS_PER_IP=10
 WS_MAX_CONNECTIONS_GLOBAL=500
+# Heartbeat interval in seconds (how often the server pings each client)
+WS_HEARTBEAT_SECS=30
+# Seconds to wait for a pong reply before terminating the connection
+WS_PONG_DEADLINE_SECS=10
+# Seconds of inactivity before an idle connection is forcibly closed
+WS_IDLE_TIMEOUT_SECS=300
 
 # -----------------------------------------------------------------------------
 # Logging

--- a/backend/services/api/src/websocket.rs
+++ b/backend/services/api/src/websocket.rs
@@ -6,9 +6,18 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::time::{interval, timeout};
 
 const DEFAULT_WS_MAX_CONNECTIONS_PER_IP: usize = 10;
 const DEFAULT_WS_MAX_CONNECTIONS_GLOBAL: usize = 500;
+
+/// How often to send a server-initiated ping (seconds).
+const DEFAULT_WS_HEARTBEAT_SECS: u64 = 30;
+/// How long to wait for a pong reply before closing the connection (seconds).
+const DEFAULT_WS_PONG_DEADLINE_SECS: u64 = 10;
+/// Close connections that receive no message for this long (seconds).
+const DEFAULT_WS_IDLE_TIMEOUT_SECS: u64 = 300;
 
 #[derive(Clone)]
 pub struct WsConnectionLimiter {
@@ -150,23 +159,127 @@ pub async fn ws_handler(
     let (response, mut session, mut msg_stream) = actix_ws::handle(&req, stream)?;
     tracing::info!("WebSocket connected: client_ip={}", client_ip);
 
+    // Read timeout configuration from environment, falling back to defaults.
+    let heartbeat_secs = std::env::var("WS_HEARTBEAT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_WS_HEARTBEAT_SECS);
+
+    let pong_deadline_secs = std::env::var("WS_PONG_DEADLINE_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_WS_PONG_DEADLINE_SECS);
+
+    let idle_timeout_secs = std::env::var("WS_IDLE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_WS_IDLE_TIMEOUT_SECS);
+
     actix_web::rt::spawn(async move {
+        // _lease is held for the lifetime of this task; Drop releases the slot.
         let _lease = lease;
 
-        while let Some(Ok(msg)) = msg_stream.next().await {
-            match msg {
-                WsMessage::Text(text) => {
-                    let _ = session.text(text).await;
+        let mut heartbeat_tick = interval(Duration::from_secs(heartbeat_secs));
+        // Skip the immediate first tick so we don't ping before the client
+        // has had a chance to send anything.
+        heartbeat_tick.tick().await;
+
+        // Whether we are currently waiting for a pong reply.
+        let mut awaiting_pong = false;
+
+        loop {
+            tokio::select! {
+                // ── Incoming message with idle timeout ──────────────────────
+                result = timeout(
+                    Duration::from_secs(idle_timeout_secs),
+                    msg_stream.next(),
+                ) => {
+                    match result {
+                        // Idle timeout expired – no message received in time.
+                        Err(_elapsed) => {
+                            tracing::warn!(
+                                "WebSocket idle timeout ({}s): client_ip={}",
+                                idle_timeout_secs,
+                                client_ip,
+                            );
+                            let _ = session.close(None).await;
+                            break;
+                        }
+                        // Stream ended (client disconnected cleanly).
+                        Ok(None) => break,
+                        // Stream error.
+                        Ok(Some(Err(e))) => {
+                            tracing::warn!(
+                                "WebSocket stream error: client_ip={}, err={}",
+                                client_ip, e,
+                            );
+                            break;
+                        }
+                        // Normal message received.
+                        Ok(Some(Ok(msg))) => {
+                            // Any message resets the "awaiting pong" state so
+                            // that a data frame arriving before the pong does
+                            // not cause a false-positive termination.
+                            awaiting_pong = false;
+
+                            match msg {
+                                WsMessage::Text(text) => {
+                                    if session.text(text).await.is_err() {
+                                        break;
+                                    }
+                                }
+                                WsMessage::Binary(bytes) => {
+                                    if session.binary(bytes).await.is_err() {
+                                        break;
+                                    }
+                                }
+                                WsMessage::Ping(bytes) => {
+                                    if session.pong(&bytes).await.is_err() {
+                                        break;
+                                    }
+                                }
+                                // Client answered our ping – nothing extra to do;
+                                // awaiting_pong was already cleared above.
+                                WsMessage::Pong(_) => {}
+                                WsMessage::Close(_) => {
+                                    let _ = session.close(None).await;
+                                    break;
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
                 }
-                WsMessage::Ping(bytes) => {
-                    let _ = session.pong(&bytes).await;
+
+                // ── Heartbeat tick ───────────────────────────────────────────
+                _ = heartbeat_tick.tick() => {
+                    if awaiting_pong {
+                        // Previous ping was never answered – zombie connection.
+                        tracing::warn!(
+                            "WebSocket pong deadline exceeded ({}s): client_ip={}",
+                            pong_deadline_secs,
+                            client_ip,
+                        );
+                        let _ = session.close(None).await;
+                        break;
+                    }
+
+                    // Send ping; if the send itself fails the socket is gone.
+                    if session.ping(b"").await.is_err() {
+                        break;
+                    }
+                    awaiting_pong = true;
+
+                    // Arm a deadline: if the next heartbeat tick fires and
+                    // awaiting_pong is still true, we terminate above.
+                    // For a tighter deadline we shrink the next interval.
+                    heartbeat_tick.reset_after(Duration::from_secs(pong_deadline_secs));
                 }
-                WsMessage::Close(_) => break,
-                _ => {}
             }
         }
 
         tracing::info!("WebSocket disconnected: client_ip={}", client_ip);
+        // _lease drops here, decrementing the connection counter.
     });
 
     Ok(response)
@@ -202,5 +315,27 @@ mod tests {
         drop(a2);
         drop(b1);
         assert_eq!(limiter.metrics().active_connections, 0);
+    }
+
+    #[test]
+    fn limiter_releases_slot_on_drop() {
+        let limiter = WsConnectionLimiter {
+            per_ip_limit: 1,
+            global_limit: 1,
+            active_connections: Arc::new(AtomicUsize::new(0)),
+            rejected_connections: Arc::new(AtomicUsize::new(0)),
+            per_ip_connections: Arc::new(Mutex::new(HashMap::new())),
+        };
+
+        {
+            let _lease = limiter.acquire("10.0.0.1").expect("should acquire");
+            assert_eq!(limiter.metrics().active_connections, 1);
+            // lease drops here
+        }
+
+        assert_eq!(limiter.metrics().active_connections, 0);
+        // Slot is free – should be acquirable again
+        let _lease2 = limiter.acquire("10.0.0.1").expect("should re-acquire after drop");
+        assert_eq!(limiter.metrics().active_connections, 1);
     }
 }

--- a/components/collaborative-editor.tsx
+++ b/components/collaborative-editor.tsx
@@ -69,16 +69,16 @@ export function CollaborativeEditor({
     [],
   )
 
-  // Yjs document & provider – created once per docId
+  // Yjs document & provider – both scoped to docId so they are fully
+  // destroyed and recreated whenever the document changes, preventing leaks.
   const ydocRef = useRef<Y.Doc | null>(null)
   const providerRef = useRef<WebsocketProvider | null>(null)
 
-  if (!ydocRef.current) {
-    ydocRef.current = new Y.Doc()
-  }
-
   useEffect(() => {
-    const ydoc = ydocRef.current!
+    // Create a fresh Y.Doc for this docId
+    const ydoc = new Y.Doc()
+    ydocRef.current = ydoc
+
     const provider = new WebsocketProvider(serverUrl, docId, ydoc)
     providerRef.current = provider
 
@@ -86,8 +86,13 @@ export function CollaborativeEditor({
     provider.awareness.setLocalStateField('user', user)
 
     return () => {
+      // Destroy provider first (closes WS + clears awareness)
       provider.destroy()
       providerRef.current = null
+
+      // Destroy the Y.Doc to release all CRDT state and event listeners
+      ydoc.destroy()
+      ydocRef.current = null
     }
     // Re-connect only when docId or server changes
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/infrastructure/k8s/helm/api/Chart.yaml
+++ b/infrastructure/k8s/helm/api/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: stellar-api
+description: Stellar Platform – Rust API service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/infrastructure/k8s/helm/api/templates/_helpers.tpl
+++ b/infrastructure/k8s/helm/api/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{- define "stellar-api.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "stellar-api.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "stellar-api.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "stellar-api.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/infrastructure/k8s/helm/api/templates/deployment.yaml
+++ b/infrastructure/k8s/helm/api/templates/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stellar-api.fullname" . }}
+  labels: {{ include "stellar-api.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{ include "stellar-api.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "stellar-api.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          envFrom:
+            - secretRef:
+                name: {{ include "stellar-api.fullname" . }}-secrets
+          env:
+            {{- range $k, $v := .Values.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml .Values.readinessProbe | nindent 12 }}

--- a/infrastructure/k8s/helm/api/templates/hpa.yaml
+++ b/infrastructure/k8s/helm/api/templates/hpa.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stellar-api.fullname" . }}
+  labels: {{ include "stellar-api.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "stellar-api.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    # Linear CPU-based scaling
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    # Network saturation via custom metric (requires prometheus-adapter)
+    - type: Pods
+      pods:
+        metric:
+          name: network_mbps
+        target:
+          type: AverageValue
+          averageValue: {{ .Values.autoscaling.targetNetworkMbps }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 120
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+{{- end }}

--- a/infrastructure/k8s/helm/api/templates/service.yaml
+++ b/infrastructure/k8s/helm/api/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stellar-api.fullname" . }}
+  labels: {{ include "stellar-api.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector: {{ include "stellar-api.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: http

--- a/infrastructure/k8s/helm/api/values.yaml
+++ b/infrastructure/k8s/helm/api/values.yaml
@@ -1,0 +1,50 @@
+# #640 — stellar-api Helm values
+replicaCount: 2
+
+image:
+  repository: ghcr.io/dev-adetutu/stellar-api
+  pullPolicy: IfNotPresent
+  tag: ""   # overridden by CI with the image digest
+
+service:
+  type: ClusterIP
+  port: 3001
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 20
+  # Scale up when average CPU across pods exceeds 60 %
+  targetCPUUtilizationPercentage: 60
+  # Scale up when average network Rx+Tx exceeds 50 Mbps (custom metric)
+  targetNetworkMbps: 50
+
+env:
+  DATABASE_URL: ""        # injected via sealed secret
+  REDIS_URL: ""
+  RUST_LOG: "info"
+  WS_HEARTBEAT_SECS: "30"
+  WS_PONG_DEADLINE_SECS: "10"
+  WS_IDLE_TIMEOUT_SECS: "300"
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 3001
+  initialDelaySeconds: 10
+  periodSeconds: 15
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 3001
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/infrastructure/k8s/helm/collab/Chart.yaml
+++ b/infrastructure/k8s/helm/collab/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: stellar-collab
+description: Stellar Platform – Yjs WebSocket collaboration server
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/infrastructure/k8s/helm/collab/templates/_helpers.tpl
+++ b/infrastructure/k8s/helm/collab/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{- define "stellar-collab.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "stellar-collab.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "stellar-collab.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "stellar-collab.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/infrastructure/k8s/helm/collab/templates/deployment.yaml
+++ b/infrastructure/k8s/helm/collab/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stellar-collab.fullname" . }}
+  labels: {{ include "stellar-collab.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{ include "stellar-collab.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "stellar-collab.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: collab
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          env:
+            {{- range $k, $v := .Values.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 15
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stellar-collab.fullname" . }}
+  labels: {{ include "stellar-collab.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector: {{ include "stellar-collab.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: ws
+---
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stellar-collab.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "stellar-collab.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Pods
+      pods:
+        metric:
+          name: network_mbps
+        target:
+          type: AverageValue
+          averageValue: {{ .Values.autoscaling.targetNetworkMbps }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 30
+    scaleDown:
+      stabilizationWindowSeconds: 120
+{{- end }}

--- a/infrastructure/k8s/helm/collab/values.yaml
+++ b/infrastructure/k8s/helm/collab/values.yaml
@@ -1,0 +1,33 @@
+# #640 — stellar-collab Helm values
+replicaCount: 2
+
+image:
+  repository: ghcr.io/dev-adetutu/stellar-collab
+  pullPolicy: IfNotPresent
+  tag: ""
+
+service:
+  type: ClusterIP
+  port: 1234
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 60
+  targetNetworkMbps: 20
+
+env:
+  WS_PORT: "1234"
+  WS_HOST: "0.0.0.0"
+  WS_HEARTBEAT_INTERVAL_MS: "30000"
+  WS_PONG_DEADLINE_MS: "10000"
+  WS_IDLE_TIMEOUT_MS: "300000"

--- a/infrastructure/k8s/helm/postgres/Chart.yaml
+++ b/infrastructure/k8s/helm/postgres/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: stellar-postgres
+description: Stellar Platform – PostgreSQL StatefulSet
+type: application
+version: 0.1.0
+appVersion: "16.3"

--- a/infrastructure/k8s/helm/postgres/templates/statefulset.yaml
+++ b/infrastructure/k8s/helm/postgres/templates/statefulset.yaml
@@ -1,0 +1,71 @@
+# #640 — PostgreSQL StatefulSet with PVC for durable storage
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  serviceName: {{ .Release.Name }}-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: postgres
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.secretName }}
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "$(POSTGRES_USER)"]
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "$(POSTGRES_USER)"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: {{ .Values.storage.storageClassName }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.size }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  clusterIP: None   # headless – required for StatefulSet DNS
+  selector:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      name: postgres

--- a/infrastructure/k8s/helm/postgres/values.yaml
+++ b/infrastructure/k8s/helm/postgres/values.yaml
@@ -1,0 +1,24 @@
+# #640 — PostgreSQL StatefulSet values
+image:
+  repository: postgres
+  tag: "16.3-alpine"
+  pullPolicy: IfNotPresent
+
+storage:
+  storageClassName: standard
+  size: 20Gi
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 2Gi
+
+service:
+  port: 5432
+
+# Credentials injected via sealed secret named stellar-postgres-secret
+# Expected keys: POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB
+secretName: stellar-postgres-secret

--- a/infrastructure/k8s/helm/redis/Chart.yaml
+++ b/infrastructure/k8s/helm/redis/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: stellar-redis
+description: Stellar Platform – Redis StatefulSet
+type: application
+version: 0.1.0
+appVersion: "7.2"

--- a/infrastructure/k8s/helm/redis/templates/statefulset.yaml
+++ b/infrastructure/k8s/helm/redis/templates/statefulset.yaml
@@ -1,0 +1,78 @@
+# #640 — Redis StatefulSet with PVC for AOF/RDB persistence
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  serviceName: {{ .Release.Name }}-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - redis-server
+            - --appendonly yes          # enable AOF persistence
+            - --save 60 1              # RDB snapshot every 60s if ≥1 key changed
+            - --dir /data
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          {{- if .Values.secretName }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.secretName }}
+          {{- end }}
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: {{ .Values.storage.storageClassName }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.size }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  clusterIP: None   # headless
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      name: redis

--- a/infrastructure/k8s/helm/redis/values.yaml
+++ b/infrastructure/k8s/helm/redis/values.yaml
@@ -1,0 +1,23 @@
+# #640 — Redis StatefulSet values
+image:
+  repository: redis
+  tag: "7.2-alpine"
+  pullPolicy: IfNotPresent
+
+storage:
+  storageClassName: standard
+  size: 5Gi
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+service:
+  port: 6379
+
+# Optional: set to name of a secret containing REDIS_PASSWORD
+secretName: ""

--- a/mobile/src/ai/PromptSuggestionBar.tsx
+++ b/mobile/src/ai/PromptSuggestionBar.tsx
@@ -1,0 +1,82 @@
+/**
+ * #602 — PromptSuggestionBar
+ *
+ * Renders a horizontal strip of on-device AI suggestions beneath any input.
+ * Tap a chip to inject the full suggestion into the parent's onChange handler.
+ */
+
+import React from 'react'
+import {
+  View,
+  ScrollView,
+  TouchableOpacity,
+  Text,
+  ActivityIndicator,
+  StyleSheet,
+} from 'react-native'
+import { usePromptSuggestions } from './usePromptSuggestions'
+
+interface Props {
+  /** Current value of the text input being assisted */
+  value: string
+  /** Called with the full injected suggestion text */
+  onInject: (text: string) => void
+}
+
+export function PromptSuggestionBar({ value, onInject }: Props) {
+  const { suggestions, loading } = usePromptSuggestions(value)
+
+  if (!loading && suggestions.length === 0) return null
+
+  return (
+    <View style={styles.container} accessibilityRole="toolbar" accessibilityLabel="AI prompt suggestions">
+      {loading ? (
+        <ActivityIndicator size="small" color="#8b5cf6" style={styles.spinner} />
+      ) : (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          {suggestions.map((s, i) => (
+            <TouchableOpacity
+              key={i}
+              style={styles.chip}
+              onPress={() => onInject(s)}
+              accessibilityRole="button"
+              accessibilityLabel={`Suggestion: ${s}`}
+            >
+              <Text style={styles.chipText} numberOfLines={1}>
+                {s}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: 40,
+    backgroundColor: '#1e1b4b',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#4c1d95',
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+  },
+  spinner: { alignSelf: 'center' },
+  chip: {
+    backgroundColor: '#4c1d95',
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    marginRight: 8,
+    maxWidth: 220,
+  },
+  chipText: {
+    color: '#e9d5ff',
+    fontSize: 13,
+  },
+})

--- a/mobile/src/ai/prompt-suggestions.ts
+++ b/mobile/src/ai/prompt-suggestions.ts
@@ -1,0 +1,164 @@
+/**
+ * #602 — On-Device Generative AI Prompt Suggestions
+ *
+ * Runs a quantised distilled SLM (ONNX) entirely on-device via
+ * ONNX Runtime React Native. No API keys, no network calls.
+ *
+ * Model: a small GPT-2-distil / TinyLlama ONNX export bundled with the app.
+ * The model file is expected at: assets/models/prompt-slm.onnx
+ *
+ * Usage:
+ *   const engine = await PromptSuggestionEngine.getInstance()
+ *   const suggestions = await engine.suggest("I want to build a")
+ *   // → ["I want to build a mobile app", "I want to build a website", ...]
+ */
+
+import { InferenceSession, Tensor } from 'onnxruntime-react-native'
+import { Asset } from 'expo-asset'
+
+// ── Tokeniser (minimal BPE-free whitespace tokeniser for demo) ────────────────
+// In production swap this for a bundled tiktoken/sentencepiece WASM build.
+const VOCAB_SIZE = 50257 // GPT-2 vocab size
+const MAX_INPUT_TOKENS = 32
+const MAX_NEW_TOKENS = 8
+const TOP_K = 5
+
+function naiveTokenise(text: string): number[] {
+  // Deterministic char-code hash into vocab range – good enough for
+  // demonstrating the pipeline; replace with real tokeniser in production.
+  return text
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(-MAX_INPUT_TOKENS)
+    .map((word) => {
+      let h = 5381
+      for (let i = 0; i < word.length; i++) {
+        h = ((h << 5) + h) ^ word.charCodeAt(i)
+      }
+      return Math.abs(h) % VOCAB_SIZE
+    })
+}
+
+function naiveDetokenise(ids: number[]): string {
+  // Reverse mapping placeholder – replace with real vocab lookup.
+  const words = ['app', 'website', 'platform', 'tool', 'service',
+    'feature', 'system', 'dashboard', 'portfolio', 'project']
+  return ids.map((id) => words[id % words.length]).join(' ')
+}
+
+function softmax(logits: Float32Array): Float32Array {
+  const max = Math.max(...logits)
+  const exps = logits.map((v) => Math.exp(v - max))
+  const sum = exps.reduce((a, b) => a + b, 0)
+  return exps.map((v) => v / sum) as unknown as Float32Array
+}
+
+function sampleTopK(probs: Float32Array, k: number): number {
+  // Pick the top-k indices and sample proportionally.
+  const indexed = Array.from(probs).map((p, i) => ({ p, i }))
+  indexed.sort((a, b) => b.p - a.p)
+  const topK = indexed.slice(0, k)
+  const total = topK.reduce((s, x) => s + x.p, 0)
+  let r = Math.random() * total
+  for (const { p, i } of topK) {
+    r -= p
+    if (r <= 0) return i
+  }
+  return topK[0].i
+}
+
+// ── Engine ────────────────────────────────────────────────────────────────────
+export class PromptSuggestionEngine {
+  private static instance: PromptSuggestionEngine | null = null
+  private session: InferenceSession | null = null
+  private ready = false
+
+  private constructor() {}
+
+  static async getInstance(): Promise<PromptSuggestionEngine> {
+    if (!PromptSuggestionEngine.instance) {
+      PromptSuggestionEngine.instance = new PromptSuggestionEngine()
+      await PromptSuggestionEngine.instance.load()
+    }
+    return PromptSuggestionEngine.instance
+  }
+
+  private async load(): Promise<void> {
+    try {
+      // Resolve the bundled ONNX model asset
+      const [asset] = await Asset.loadAsync(
+        require('../../assets/models/prompt-slm.onnx'),
+      )
+      const modelUri = asset.localUri ?? asset.uri
+      this.session = await InferenceSession.create(modelUri, {
+        executionProviders: ['nnapi', 'cpu'], // NNAPI on Android, CPU fallback
+      })
+      this.ready = true
+    } catch (err) {
+      console.warn('[PromptSuggestionEngine] Failed to load ONNX model:', err)
+      // Graceful degradation – suggest() will return [] when not ready
+    }
+  }
+
+  /**
+   * Generate up to `count` prompt completions for the given partial text.
+   * Operates entirely on-device; returns [] if the model is not loaded.
+   */
+  async suggest(partial: string, count = 3): Promise<string[]> {
+    if (!this.ready || !this.session) return []
+
+    const inputIds = naiveTokenise(partial)
+    if (inputIds.length === 0) return []
+
+    const suggestions: string[] = []
+
+    for (let s = 0; s < count; s++) {
+      const generated: number[] = []
+      let currentIds = [...inputIds]
+
+      for (let step = 0; step < MAX_NEW_TOKENS; step++) {
+        const inputTensor = new Tensor(
+          'int64',
+          BigInt64Array.from(currentIds.map(BigInt)),
+          [1, currentIds.length],
+        )
+
+        const feeds: Record<string, Tensor> = { input_ids: inputTensor }
+        const results = await this.session.run(feeds)
+
+        // Expect logits shape [1, seq_len, vocab_size]
+        const logits = results['logits']?.data as Float32Array | undefined
+        if (!logits) break
+
+        const vocabSize = VOCAB_SIZE
+        const lastLogits = logits.slice(
+          logits.length - vocabSize,
+          logits.length,
+        )
+        const probs = softmax(lastLogits)
+        const nextToken = sampleTopK(probs, TOP_K)
+
+        generated.push(nextToken)
+        currentIds = [...currentIds, nextToken].slice(-MAX_INPUT_TOKENS)
+
+        // Stop on EOS token (50256 for GPT-2)
+        if (nextToken === 50256) break
+      }
+
+      if (generated.length > 0) {
+        suggestions.push(`${partial} ${naiveDetokenise(generated)}`.trim())
+      }
+    }
+
+    return suggestions
+  }
+
+  /** Release the ONNX session and allow GC. */
+  dispose(): void {
+    this.session?.release()
+    this.session = null
+    this.ready = false
+    PromptSuggestionEngine.instance = null
+  }
+}

--- a/mobile/src/ai/usePromptSuggestions.ts
+++ b/mobile/src/ai/usePromptSuggestions.ts
@@ -1,0 +1,47 @@
+/**
+ * #602 — usePromptSuggestions hook
+ *
+ * Provides predictive text suggestions powered by the on-device SLM.
+ * Debounces inference calls so typing doesn't saturate the CPU.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { PromptSuggestionEngine } from './prompt-suggestions'
+
+const DEBOUNCE_MS = 300
+
+export function usePromptSuggestions(partial: string, count = 3) {
+  const [suggestions, setSuggestions] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const run = useCallback(
+    async (text: string) => {
+      if (!text.trim()) {
+        setSuggestions([])
+        return
+      }
+      setLoading(true)
+      try {
+        const engine = await PromptSuggestionEngine.getInstance()
+        const results = await engine.suggest(text, count)
+        setSuggestions(results)
+      } catch {
+        setSuggestions([])
+      } finally {
+        setLoading(false)
+      }
+    },
+    [count],
+  )
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => run(partial), DEBOUNCE_MS)
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [partial, run])
+
+  return { suggestions, loading }
+}

--- a/mobile/src/ota/ota-client.ts
+++ b/mobile/src/ota/ota-client.ts
@@ -1,0 +1,274 @@
+/**
+ * #603 — OTA Client
+ *
+ * Fetches a signed OTA manifest, decrypts the AES-256-GCM payload,
+ * applies a differential binary patch, verifies the SHA-256 checksum,
+ * then swaps the bundle. Operates without App Store review.
+ *
+ * Flow:
+ *   1. Poll OTA_MANIFEST_URL for a new manifest
+ *   2. Compare manifest.version against the running bundle version
+ *   3. Download the encrypted patch blob
+ *   4. Decrypt with AES-256-GCM using the pre-shared app key
+ *   5. Apply bsdiff-compatible patch to the current bundle
+ *   6. Verify SHA-256 of the patched bundle
+ *   7. Write to the pending-bundle slot and schedule a reload
+ */
+
+import * as FileSystem from 'expo-file-system'
+import * as Crypto from 'expo-crypto'
+import Constants from 'expo-constants'
+
+// ── Config ────────────────────────────────────────────────────────────────────
+const MANIFEST_URL =
+  process.env.EXPO_PUBLIC_OTA_MANIFEST_URL ??
+  'https://ota.stellar-platform.app/manifest.json'
+
+/** AES-256-GCM key (hex-encoded 32 bytes) injected at build time. */
+const OTA_AES_KEY_HEX =
+  process.env.EXPO_PUBLIC_OTA_AES_KEY ?? ''
+
+const BUNDLE_DIR = `${FileSystem.documentDirectory}ota/`
+const PENDING_BUNDLE = `${BUNDLE_DIR}pending.bundle`
+const CURRENT_BUNDLE = `${BUNDLE_DIR}current.bundle`
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+export interface OtaManifest {
+  version: string
+  patchUrl: string
+  /** SHA-256 hex of the fully patched bundle */
+  sha256: string
+  /** AES-GCM IV (hex, 12 bytes) */
+  iv: string
+  /** AES-GCM auth tag (hex, 16 bytes) */
+  tag: string
+  /** Incremental patch size in bytes */
+  patchSize: number
+  /** Minimum app version this patch can be applied to */
+  minBaseVersion: string
+}
+
+export type OtaStatus =
+  | { type: 'up-to-date' }
+  | { type: 'update-available'; manifest: OtaManifest }
+  | { type: 'applied'; version: string }
+  | { type: 'error'; message: string }
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function hexToUint8(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+async function sha256Hex(data: Uint8Array): Promise<string> {
+  // expo-crypto digest expects a string; encode via base64 round-trip
+  const b64 = btoa(String.fromCharCode(...data))
+  return Crypto.digestStringAsync(
+    Crypto.CryptoDigestAlgorithm.SHA256,
+    b64,
+    { encoding: Crypto.CryptoEncoding.HEX },
+  )
+}
+
+/**
+ * Minimal bsdiff-compatible patch application.
+ * In production, link the native bspatch C library via a JSI module.
+ * This TypeScript implementation handles the control/diff/extra block
+ * format for small patches in CI/test environments.
+ */
+function applyBsdiffPatch(original: Uint8Array, patch: Uint8Array): Uint8Array {
+  const view = new DataView(patch.buffer, patch.byteOffset)
+  let pos = 0
+
+  function readLE64(): number {
+    const lo = view.getUint32(pos, true)
+    const hi = view.getUint32(pos + 4, true)
+    pos += 8
+    // Safe for bundle sizes < 2 GB
+    return hi * 0x100000000 + lo
+  }
+
+  // bsdiff header: magic(8) + ctrl_len(8) + diff_len(8) + new_size(8)
+  pos = 8 // skip magic
+  const ctrlLen = readLE64()
+  const diffLen = readLE64()
+  const newSize = readLE64()
+
+  const ctrlBlock = patch.slice(pos, pos + ctrlLen)
+  const diffBlock = patch.slice(pos + ctrlLen, pos + ctrlLen + diffLen)
+  const extraBlock = patch.slice(pos + ctrlLen + diffLen)
+
+  const output = new Uint8Array(newSize)
+  let oldPos = 0
+  let newPos = 0
+  let ctrlPos = 0
+  let diffPos = 0
+  let extraPos = 0
+
+  const ctrlView = new DataView(ctrlBlock.buffer, ctrlBlock.byteOffset)
+
+  while (newPos < newSize) {
+    // Read control triple: (x, y, z)
+    const x = new DataView(ctrlBlock.buffer, ctrlBlock.byteOffset + ctrlPos).getInt32(0, true); ctrlPos += 4
+    const y = new DataView(ctrlBlock.buffer, ctrlBlock.byteOffset + ctrlPos).getInt32(0, true); ctrlPos += 4
+    const z = new DataView(ctrlBlock.buffer, ctrlBlock.byteOffset + ctrlPos).getInt32(0, true); ctrlPos += 4
+    void ctrlView // suppress unused warning
+
+    // Add diff bytes to old bytes
+    for (let i = 0; i < x; i++) {
+      const oldByte = oldPos + i < original.length ? original[oldPos + i] : 0
+      output[newPos + i] = (oldByte + diffBlock[diffPos + i]) & 0xff
+    }
+    newPos += x; oldPos += x; diffPos += x
+
+    // Copy extra bytes
+    for (let i = 0; i < y; i++) {
+      output[newPos + i] = extraBlock[extraPos + i]
+    }
+    newPos += y; extraPos += y
+
+    // Adjust old position
+    oldPos += z
+  }
+
+  return output
+}
+
+// ── AES-256-GCM decryption (Web Crypto API – available in Hermes/JSC) ─────────
+async function decryptAesGcm(
+  ciphertext: Uint8Array,
+  keyHex: string,
+  ivHex: string,
+  tagHex: string,
+): Promise<Uint8Array> {
+  const keyBytes = hexToUint8(keyHex)
+  const iv = hexToUint8(ivHex)
+  const tag = hexToUint8(tagHex)
+
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    keyBytes,
+    { name: 'AES-GCM' },
+    false,
+    ['decrypt'],
+  )
+
+  // Append auth tag to ciphertext (Web Crypto expects tag appended)
+  const withTag = new Uint8Array(ciphertext.length + tag.length)
+  withTag.set(ciphertext)
+  withTag.set(tag, ciphertext.length)
+
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    cryptoKey,
+    withTag,
+  )
+
+  return new Uint8Array(plaintext)
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/** Fetch and parse the remote OTA manifest. */
+export async function fetchManifest(): Promise<OtaManifest> {
+  const res = await fetch(MANIFEST_URL, { cache: 'no-store' })
+  if (!res.ok) throw new Error(`Manifest fetch failed: ${res.status}`)
+  return res.json() as Promise<OtaManifest>
+}
+
+/** Return the currently running bundle version from Expo Constants. */
+export function currentVersion(): string {
+  return (Constants.expoConfig?.version ?? '0.0.0')
+}
+
+/**
+ * Check for an available update.
+ * Returns `up-to-date` if the manifest version matches the running version.
+ */
+export async function checkForUpdate(): Promise<OtaStatus> {
+  try {
+    const manifest = await fetchManifest()
+    if (manifest.version === currentVersion()) return { type: 'up-to-date' }
+    return { type: 'update-available', manifest }
+  } catch (err) {
+    return { type: 'error', message: String(err) }
+  }
+}
+
+/**
+ * Download, decrypt, patch, verify, and stage the update.
+ * Call `reloadAsync()` (from expo-updates) after this returns `applied`.
+ */
+export async function applyUpdate(manifest: OtaManifest): Promise<OtaStatus> {
+  try {
+    // Ensure OTA directory exists
+    await FileSystem.makeDirectoryAsync(BUNDLE_DIR, { intermediates: true })
+
+    // 1. Download encrypted patch
+    const patchPath = `${BUNDLE_DIR}patch.enc`
+    const download = await FileSystem.downloadAsync(manifest.patchUrl, patchPath)
+    if (download.status !== 200) throw new Error(`Patch download failed: ${download.status}`)
+
+    // 2. Read current bundle (or empty if first install)
+    let currentBytes = new Uint8Array(0)
+    const currentInfo = await FileSystem.getInfoAsync(CURRENT_BUNDLE)
+    if (currentInfo.exists) {
+      const b64 = await FileSystem.readAsStringAsync(CURRENT_BUNDLE, {
+        encoding: FileSystem.EncodingType.Base64,
+      })
+      currentBytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0))
+    }
+
+    // 3. Read encrypted patch
+    const encB64 = await FileSystem.readAsStringAsync(patchPath, {
+      encoding: FileSystem.EncodingType.Base64,
+    })
+    const encBytes = Uint8Array.from(atob(encB64), (c) => c.charCodeAt(0))
+
+    // 4. Decrypt
+    const patchBytes = await decryptAesGcm(
+      encBytes,
+      OTA_AES_KEY_HEX,
+      manifest.iv,
+      manifest.tag,
+    )
+
+    // 5. Apply differential patch
+    const patchedBundle = applyBsdiffPatch(currentBytes, patchBytes)
+
+    // 6. Verify SHA-256
+    const actualHash = await sha256Hex(patchedBundle)
+    if (actualHash !== manifest.sha256) {
+      throw new Error(
+        `SHA-256 mismatch: expected ${manifest.sha256}, got ${actualHash}`,
+      )
+    }
+
+    // 7. Write pending bundle
+    const patchedB64 = btoa(String.fromCharCode(...patchedBundle))
+    await FileSystem.writeAsStringAsync(PENDING_BUNDLE, patchedB64, {
+      encoding: FileSystem.EncodingType.Base64,
+    })
+
+    // Clean up temp patch file
+    await FileSystem.deleteAsync(patchPath, { idempotent: true })
+
+    return { type: 'applied', version: manifest.version }
+  } catch (err) {
+    return { type: 'error', message: String(err) }
+  }
+}
+
+/**
+ * Promote the pending bundle to current.
+ * Call this after a successful reload confirms the new bundle is stable.
+ */
+export async function promotePendingBundle(): Promise<void> {
+  const info = await FileSystem.getInfoAsync(PENDING_BUNDLE)
+  if (!info.exists) return
+  await FileSystem.moveAsync({ from: PENDING_BUNDLE, to: CURRENT_BUNDLE })
+}

--- a/mobile/src/ota/rollback.ts
+++ b/mobile/src/ota/rollback.ts
@@ -1,0 +1,107 @@
+/**
+ * #603 — OTA Rollback Manager
+ *
+ * Tracks consecutive crash counts in AsyncStorage.
+ * After MAX_CRASH_COUNT crashes the app auto-rolls back to the last
+ * known-good bundle, preventing a crash-loop from bricking the install.
+ *
+ * Integration:
+ *   Call `recordLaunch()` early in your root component (before any async work).
+ *   Call `recordStableLaunch()` once the app has been running for STABLE_MS.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import * as FileSystem from 'expo-file-system'
+
+const CRASH_COUNT_KEY = '@ota/crash_count'
+const LAST_GOOD_VERSION_KEY = '@ota/last_good_version'
+const MAX_CRASH_COUNT = 3
+/** App must run for this long without crashing to be considered stable (ms). */
+const STABLE_MS = 10_000
+
+const BUNDLE_DIR = `${FileSystem.documentDirectory}ota/`
+const CURRENT_BUNDLE = `${BUNDLE_DIR}current.bundle`
+const BACKUP_BUNDLE = `${BUNDLE_DIR}backup.bundle`
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+async function getCrashCount(): Promise<number> {
+  const raw = await AsyncStorage.getItem(CRASH_COUNT_KEY)
+  return raw ? parseInt(raw, 10) : 0
+}
+
+async function setCrashCount(n: number): Promise<void> {
+  await AsyncStorage.setItem(CRASH_COUNT_KEY, String(n))
+}
+
+async function resetCrashCount(): Promise<void> {
+  await AsyncStorage.removeItem(CRASH_COUNT_KEY)
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Call once at app startup (before any async work).
+ * Increments the crash counter and triggers rollback if the threshold is hit.
+ *
+ * Returns `true` if a rollback was performed (app should reload).
+ */
+export async function recordLaunch(): Promise<boolean> {
+  const count = await getCrashCount()
+  const next = count + 1
+  await setCrashCount(next)
+
+  if (next >= MAX_CRASH_COUNT) {
+    console.warn(
+      `[OTA Rollback] ${next} consecutive crashes detected – rolling back`,
+    )
+    await rollback()
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Call once the app has been running stably for STABLE_MS.
+ * Resets the crash counter and backs up the current bundle.
+ */
+export async function recordStableLaunch(version: string): Promise<void> {
+  await resetCrashCount()
+  await AsyncStorage.setItem(LAST_GOOD_VERSION_KEY, version)
+
+  // Back up the current bundle so rollback has something to restore
+  const info = await FileSystem.getInfoAsync(CURRENT_BUNDLE)
+  if (info.exists) {
+    await FileSystem.copyAsync({ from: CURRENT_BUNDLE, to: BACKUP_BUNDLE })
+  }
+}
+
+/**
+ * Restore the backup bundle to the current slot.
+ * The caller is responsible for triggering a reload after this returns.
+ */
+export async function rollback(): Promise<void> {
+  const backupInfo = await FileSystem.getInfoAsync(BACKUP_BUNDLE)
+  if (!backupInfo.exists) {
+    console.warn('[OTA Rollback] No backup bundle found – cannot roll back')
+    return
+  }
+
+  await FileSystem.copyAsync({ from: BACKUP_BUNDLE, to: CURRENT_BUNDLE })
+  await resetCrashCount()
+  console.log('[OTA Rollback] Rolled back to last known-good bundle')
+}
+
+/** Returns the version string of the last known-good bundle, or null. */
+export async function lastGoodVersion(): Promise<string | null> {
+  return AsyncStorage.getItem(LAST_GOOD_VERSION_KEY)
+}
+
+/** Arm the stability timer. Call at the top of your root component. */
+export function armStabilityTimer(version: string): () => void {
+  const timer = setTimeout(() => {
+    recordStableLaunch(version).catch(console.error)
+  }, STABLE_MS)
+  return () => clearTimeout(timer)
+}

--- a/server/collab.ts
+++ b/server/collab.ts
@@ -5,25 +5,209 @@
  *
  * Listens on WS_PORT (default 1234) and handles Yjs CRDT sync
  * for all document rooms identified by the URL path.
+ *
+ * Memory-leak mitigations:
+ *  - Heartbeat ping/pong with configurable interval and deadline.
+ *    Sockets that miss a pong are terminated, releasing all closures.
+ *  - Per-connection idle timeout: connections that never send a message
+ *    within IDLE_TIMEOUT_MS are forcibly closed.
+ *  - Explicit tracking map so we can audit live connections and GC them.
+ *  - SIGTERM / SIGINT handlers close the server cleanly so the process
+ *    exits without leaking open handles.
  */
-import { WebSocketServer } from 'ws'
+import { WebSocketServer, WebSocket } from 'ws'
+import { IncomingMessage } from 'http'
 import { setupWSConnection } from 'y-websocket/bin/utils.js'
 
+// ── Configuration ─────────────────────────────────────────────────────────────
 const PORT = parseInt(process.env.WS_PORT ?? '1234', 10)
 const HOST = process.env.WS_HOST ?? 'localhost'
 
+/** How often to send a ping frame (ms). */
+const HEARTBEAT_INTERVAL_MS = parseInt(
+  process.env.WS_HEARTBEAT_INTERVAL_MS ?? '30000',
+  10,
+)
+
+/** How long to wait for a pong before terminating the socket (ms). */
+const PONG_DEADLINE_MS = parseInt(
+  process.env.WS_PONG_DEADLINE_MS ?? '10000',
+  10,
+)
+
+/** Close sockets that have been idle (no message) for this long (ms). */
+const IDLE_TIMEOUT_MS = parseInt(
+  process.env.WS_IDLE_TIMEOUT_MS ?? '300000', // 5 min
+  10,
+)
+
+// ── Connection state ──────────────────────────────────────────────────────────
+interface ConnState {
+  /** True while we are waiting for a pong reply. */
+  awaitingPong: boolean
+  /** Timer that fires if pong is not received in time. */
+  pongDeadlineTimer: ReturnType<typeof setTimeout> | null
+  /** Timer that fires when the connection has been idle too long. */
+  idleTimer: ReturnType<typeof setTimeout> | null
+  /** Timestamp of the last received message (any type). */
+  lastActivity: number
+}
+
+/** Live connection registry – used for metrics and forced GC. */
+const connections = new Map<WebSocket, ConnState>()
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function clearTimers(state: ConnState): void {
+  if (state.pongDeadlineTimer !== null) {
+    clearTimeout(state.pongDeadlineTimer)
+    state.pongDeadlineTimer = null
+  }
+  if (state.idleTimer !== null) {
+    clearTimeout(state.idleTimer)
+    state.idleTimer = null
+  }
+}
+
+function resetIdleTimer(ws: WebSocket, state: ConnState): void {
+  if (state.idleTimer !== null) clearTimeout(state.idleTimer)
+  state.lastActivity = Date.now()
+  state.idleTimer = setTimeout(() => {
+    console.warn(
+      `[collab] Terminating idle connection (no activity for ${IDLE_TIMEOUT_MS}ms)`,
+    )
+    ws.terminate()
+  }, IDLE_TIMEOUT_MS)
+}
+
+function terminateAndCleanup(ws: WebSocket): void {
+  const state = connections.get(ws)
+  if (state) {
+    clearTimers(state)
+    connections.delete(ws)
+  }
+  // terminate() is safe to call even if already closed
+  ws.terminate()
+}
+
+// ── Server ────────────────────────────────────────────────────────────────────
 const wss = new WebSocketServer({ host: HOST, port: PORT })
 
-wss.on('connection', (ws, req) => {
-  // Extract doc name from URL path, e.g. /bounty-123 → 'bounty-123'
+wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
   const docName = (req.url ?? '/').replace(/^\//, '') || 'default'
+
+  // Initialise per-connection state
+  const state: ConnState = {
+    awaitingPong: false,
+    pongDeadlineTimer: null,
+    idleTimer: null,
+    lastActivity: Date.now(),
+  }
+  connections.set(ws, state)
+
+  // Start idle timer immediately
+  resetIdleTimer(ws, state)
+
+  // ── Pong handler ────────────────────────────────────────────────────────────
+  ws.on('pong', () => {
+    const s = connections.get(ws)
+    if (!s) return
+    s.awaitingPong = false
+    if (s.pongDeadlineTimer !== null) {
+      clearTimeout(s.pongDeadlineTimer)
+      s.pongDeadlineTimer = null
+    }
+    resetIdleTimer(ws, s)
+  })
+
+  // ── Message handler – reset idle timer on any data ──────────────────────────
+  ws.on('message', () => {
+    const s = connections.get(ws)
+    if (s) resetIdleTimer(ws, s)
+  })
+
+  // ── Cleanup on close / error ─────────────────────────────────────────────────
+  ws.on('close', () => {
+    const s = connections.get(ws)
+    if (s) {
+      clearTimers(s)
+      connections.delete(ws)
+    }
+  })
+
+  ws.on('error', (err: Error) => {
+    console.error('[collab] Socket error:', err.message)
+    terminateAndCleanup(ws)
+  })
+
+  // Delegate CRDT sync to y-websocket
   setupWSConnection(ws, req, { docName })
 })
 
+// ── Heartbeat loop ────────────────────────────────────────────────────────────
+const heartbeatInterval = setInterval(() => {
+  for (const [ws, state] of connections) {
+    if (ws.readyState !== WebSocket.OPEN) {
+      terminateAndCleanup(ws)
+      continue
+    }
+
+    if (state.awaitingPong) {
+      // Previous ping was never answered – zombie connection
+      console.warn('[collab] Terminating zombie connection (missed pong)')
+      terminateAndCleanup(ws)
+      continue
+    }
+
+    // Send ping and arm the deadline timer
+    state.awaitingPong = true
+    state.pongDeadlineTimer = setTimeout(() => {
+      console.warn(
+        `[collab] Pong deadline exceeded (${PONG_DEADLINE_MS}ms) – terminating`,
+      )
+      terminateAndCleanup(ws)
+    }, PONG_DEADLINE_MS)
+
+    ws.ping()
+  }
+}, HEARTBEAT_INTERVAL_MS)
+
+// Prevent the interval from keeping the process alive after server close
+heartbeatInterval.unref()
+
 wss.on('listening', () => {
-  console.log(`[collab] Yjs WebSocket server running on ws://${HOST}:${PORT}`)
+  console.log(
+    `[collab] Yjs WebSocket server running on ws://${HOST}:${PORT}` +
+      ` | heartbeat=${HEARTBEAT_INTERVAL_MS}ms` +
+      ` | pong_deadline=${PONG_DEADLINE_MS}ms` +
+      ` | idle_timeout=${IDLE_TIMEOUT_MS}ms`,
+  )
 })
 
-wss.on('error', (err) => {
+wss.on('error', (err: Error) => {
   console.error('[collab] WebSocket server error:', err)
 })
+
+// ── Graceful shutdown ─────────────────────────────────────────────────────────
+function shutdown(signal: string): void {
+  console.log(`[collab] Received ${signal} – shutting down gracefully`)
+  clearInterval(heartbeatInterval)
+
+  // Terminate all open connections so their closures are released
+  for (const [ws, state] of connections) {
+    clearTimers(state)
+    ws.terminate()
+  }
+  connections.clear()
+
+  wss.close(() => {
+    console.log('[collab] Server closed')
+    process.exit(0)
+  })
+
+  // Force-exit if close takes too long
+  setTimeout(() => process.exit(1), 5000).unref()
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'))
+process.on('SIGINT', () => shutdown('SIGINT'))


### PR DESCRIPTION
## Summary

Closes #602
Closes #603
Closes #640
Closes #642

---

### #602 — On-Device Generative AI Prompt Suggestions

Deploys a small distilled SLM natively via ONNX Runtime React Native. No API keys, no network calls — inference runs entirely on-device through WebNN/NNAPI with CPU fallback.

- `mobile/src/ai/prompt-suggestions.ts` — `PromptSuggestionEngine` singleton loads a quantised ONNX model from the app bundle, runs top-k sampled autoregressive generation
- `mobile/src/ai/usePromptSuggestions.ts` — debounced React hook for predictive text injection (300ms debounce to avoid saturating the CPU while typing)
- `mobile/src/ai/PromptSuggestionBar.tsx` — horizontal chip strip rendered beneath any input; tapping a chip injects the full suggestion

---

### #603 — CI Mobile Over-The-Air (OTA) Updates

Custom OTA pipeline with AES-256-GCM encrypted differential patching and automatic crash-loop rollback — no App Store review required.

- `mobile/src/ota/ota-client.ts` — fetches signed manifest, decrypts payload, applies bsdiff binary patch, verifies SHA-256 checksum before writing to the pending bundle slot
- `mobile/src/ota/rollback.ts` — tracks consecutive crash count in AsyncStorage; after 3 crashes auto-restores the last known-good bundle; `armStabilityTimer` promotes the bundle after a stable 10s run
- `.github/workflows/ota-release.yml` — CI pipeline that exports the Expo bundle, generates a bsdiff patch against the previous release, encrypts with AES-256-GCM, uploads to S3, and publishes the manifest on every merge to `main`

---

### #640 — Kubernetes Native Auto-Scaling Infrastructure

Helm charts for all services with CPU + network-based HPA and StatefulSet persistence for databases.

- `infrastructure/k8s/helm/api/` — Rust API service; HPA scales linearly from 2→20 pods at CPU ≥ 60% or network ≥ 50 Mbps
- `infrastructure/k8s/helm/collab/` — Node Yjs collab server; HPA scales 2→10 pods at CPU ≥ 60% or network ≥ 20 Mbps
- `infrastructure/k8s/helm/postgres/` — StatefulSet with 20 Gi PVC, headless Service, liveness via `pg_isready`
- `infrastructure/k8s/helm/redis/` — StatefulSet with 5 Gi PVC, AOF + RDB persistence enabled, headless Service

---

### #642 — Memory Leaks in WebSocket Signaling Server

Three leak vectors patched across the full stack.

- `server/collab.ts` — heartbeat ping/pong (30s interval, 10s pong deadline), per-connection idle timeout (5 min), explicit connection registry; `SIGTERM`/`SIGINT` handlers terminate all sockets and call `wss.close()` before exit
- `components/collaborative-editor.tsx` — `Y.Doc` moved inside `useEffect` with `ydoc.destroy()` in cleanup; stale docs fully released on `docId` change instead of leaking CRDT state
- `backend/services/api/src/websocket.rs` — `tokio::select!` loop with idle timeout + heartbeat tick replaces bare message loop; missed pong or idle expiry closes the session and drops `WsConnectionLease`, decrementing the connection counter
- `.env.example` files updated with `WS_HEARTBEAT_*`, `WS_PONG_DEADLINE_*`, `WS_IDLE_TIMEOUT_*` vars
