### PR TITLE
feat(mobile): implement AR native object placement for creators

### DIFF
--- a/mobile/__tests__/ar/ARObjectPlacementService.test.ts
+++ b/mobile/__tests__/ar/ARObjectPlacementService.test.ts
@@ -1,0 +1,395 @@
+import {
+  vec3Add,
+  vec3Scale,
+  vec3Dot,
+  vec3Length,
+  vec3Normalize,
+  vec3Cross,
+  mat4Identity,
+  planeArea,
+  isPlaneViable,
+  makeGltfModel,
+  computeSunLight,
+  deriveEnvironmentLight,
+  computeShadowParams,
+  StubARProvider,
+  ARSceneManager,
+  ARObjectPlacementService,
+  MIN_PLANE_AREA_M2,
+  MAX_TRACKED_PLANES,
+  SHADOW_AMBIENT,
+  DEFAULT_METALNESS,
+  DEFAULT_ROUGHNESS,
+  ARPlane,
+  Vec3,
+  Mat4,
+} from '../../src/services/ARObjectPlacementService';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const PLANE_ID = 'plane-1';
+
+function makePlane(overrides: Partial<ARPlane> = {}): ARPlane {
+  return {
+    id: PLANE_ID,
+    alignment: 'horizontal',
+    center: { x: 0, y: 0, z: 0 },
+    extent: { width: 1.0, height: 1.0 },
+    transform: mat4Identity(),
+    confidence: 0.9,
+    ...overrides,
+  };
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+describe('constants', () => {
+  it('MIN_PLANE_AREA_M2 is 0.09', () => expect(MIN_PLANE_AREA_M2).toBe(0.09));
+  it('MAX_TRACKED_PLANES is 20', () => expect(MAX_TRACKED_PLANES).toBe(20));
+  it('SHADOW_AMBIENT is between 0 and 1', () => {
+    expect(SHADOW_AMBIENT).toBeGreaterThan(0);
+    expect(SHADOW_AMBIENT).toBeLessThan(1);
+  });
+  it('DEFAULT_METALNESS is 0', () => expect(DEFAULT_METALNESS).toBe(0.0));
+  it('DEFAULT_ROUGHNESS is 0.5', () => expect(DEFAULT_ROUGHNESS).toBe(0.5));
+});
+
+// ─── Vec3 helpers ─────────────────────────────────────────────────────────────
+
+describe('vec3 helpers', () => {
+  const A: Vec3 = { x: 1, y: 2, z: 3 };
+  const B: Vec3 = { x: 4, y: 5, z: 6 };
+
+  it('vec3Add sums components', () => {
+    expect(vec3Add(A, B)).toEqual({ x: 5, y: 7, z: 9 });
+  });
+
+  it('vec3Scale multiplies by scalar', () => {
+    expect(vec3Scale(A, 2)).toEqual({ x: 2, y: 4, z: 6 });
+  });
+
+  it('vec3Dot computes dot product', () => {
+    expect(vec3Dot(A, B)).toBe(32); // 4+10+18
+  });
+
+  it('vec3Length returns Euclidean length', () => {
+    expect(vec3Length({ x: 3, y: 4, z: 0 })).toBeCloseTo(5);
+  });
+
+  it('vec3Normalize returns unit vector', () => {
+    const n = vec3Normalize({ x: 3, y: 0, z: 0 });
+    expect(n.x).toBeCloseTo(1);
+    expect(n.y).toBeCloseTo(0);
+  });
+
+  it('vec3Normalize handles zero vector gracefully', () => {
+    const n = vec3Normalize({ x: 0, y: 0, z: 0 });
+    expect(n).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it('vec3Cross computes cross product', () => {
+    const x = vec3Cross({ x: 1, y: 0, z: 0 }, { x: 0, y: 1, z: 0 });
+    expect(x).toEqual({ x: 0, y: 0, z: 1 });
+  });
+});
+
+// ─── mat4Identity ─────────────────────────────────────────────────────────────
+
+describe('mat4Identity', () => {
+  it('returns 16-element array', () => {
+    expect(mat4Identity()).toHaveLength(16);
+  });
+
+  it('has 1s on the main diagonal', () => {
+    const m: Mat4 = mat4Identity();
+    // Diagonal indices: 0, 5, 10, 15
+    expect(m[0]).toBe(1);
+    expect(m[5]).toBe(1);
+    expect(m[10]).toBe(1);
+    expect(m[15]).toBe(1);
+  });
+
+  it('has 0s off the diagonal', () => {
+    const m: Mat4 = mat4Identity();
+    expect(m[1]).toBe(0);
+    expect(m[4]).toBe(0);
+  });
+});
+
+// ─── planeArea / isPlaneViable ─────────────────────────────────────────────────
+
+describe('planeArea', () => {
+  it('returns width × height', () => {
+    const plane = makePlane({ extent: { width: 2, height: 3 } });
+    expect(planeArea(plane)).toBe(6);
+  });
+});
+
+describe('isPlaneViable', () => {
+  it('returns true for large, confident plane', () => {
+    expect(isPlaneViable(makePlane())).toBe(true);
+  });
+
+  it('returns false when area is below MIN_PLANE_AREA_M2', () => {
+    expect(isPlaneViable(makePlane({ extent: { width: 0.1, height: 0.1 } }))).toBe(false);
+  });
+
+  it('returns false when confidence is below 0.5', () => {
+    expect(isPlaneViable(makePlane({ confidence: 0.3 }))).toBe(false);
+  });
+});
+
+// ─── makeGltfModel ────────────────────────────────────────────────────────────
+
+describe('makeGltfModel', () => {
+  it('applies defaults', () => {
+    const m = makeGltfModel({ id: 'chair', uri: 'models/chair.glb' });
+    expect(m.metalness).toBe(DEFAULT_METALNESS);
+    expect(m.roughness).toBe(DEFAULT_ROUGHNESS);
+    expect(m.scale).toEqual({ x: 1, y: 1, z: 1 });
+    expect(m.castsShadow).toBe(true);
+  });
+
+  it('accepts overrides', () => {
+    const m = makeGltfModel({ id: 'mirror', uri: 'models/mirror.glb', metalness: 0.9, roughness: 0.1 });
+    expect(m.metalness).toBe(0.9);
+    expect(m.roughness).toBe(0.1);
+  });
+});
+
+// ─── computeSunLight ──────────────────────────────────────────────────────────
+
+describe('computeSunLight', () => {
+  it('returns a unit direction vector', () => {
+    const light = computeSunLight(45, 180);
+    const len = vec3Length(light.direction);
+    expect(len).toBeCloseTo(1, 5);
+  });
+
+  it('sun at zenith (elevation 90) points straight down', () => {
+    const light = computeSunLight(90, 0);
+    expect(light.direction.y).toBeCloseTo(-1, 1);
+  });
+
+  it('accepts custom intensity', () => {
+    const light = computeSunLight(45, 90, 50000);
+    expect(light.intensity).toBe(50000);
+  });
+
+  it('colour R component is always 1.0', () => {
+    const light = computeSunLight(10, 90);
+    expect(light.color.x).toBe(1.0);
+  });
+});
+
+// ─── deriveEnvironmentLight ───────────────────────────────────────────────────
+
+describe('deriveEnvironmentLight', () => {
+  it('returns both ambient and directional components', () => {
+    const env = deriveEnvironmentLight(45, 180);
+    expect(env.ambient).toBeDefined();
+    expect(env.directional).toBeDefined();
+  });
+
+  it('ambient components are positive', () => {
+    const env = deriveEnvironmentLight(45, 180);
+    expect(env.ambient.x).toBeGreaterThan(0);
+    expect(env.ambient.y).toBeGreaterThan(0);
+    expect(env.ambient.z).toBeGreaterThan(0);
+  });
+});
+
+// ─── computeShadowParams ──────────────────────────────────────────────────────
+
+describe('computeShadowParams', () => {
+  it('returns shadow params with matrix, opacity, blurRadius', () => {
+    const light = computeSunLight(45, 180);
+    const shadow = computeShadowParams({ x: 0, y: 0.5, z: 0 }, light);
+    expect(shadow).toHaveProperty('matrix');
+    expect(shadow).toHaveProperty('opacity');
+    expect(shadow).toHaveProperty('blurRadius');
+  });
+
+  it('opacity is between 0 and 1', () => {
+    const light = computeSunLight(45, 180);
+    const shadow = computeShadowParams({ x: 0, y: 1, z: 0 }, light);
+    expect(shadow.opacity).toBeGreaterThanOrEqual(0);
+    expect(shadow.opacity).toBeLessThanOrEqual(1);
+  });
+
+  it('blurRadius is non-negative', () => {
+    const light = computeSunLight(45, 180);
+    const shadow = computeShadowParams({ x: 0, y: 0.5, z: 0 }, light);
+    expect(shadow.blurRadius).toBeGreaterThanOrEqual(0);
+  });
+
+  it('shadow matrix is a 16-element array', () => {
+    const light = computeSunLight(45, 180);
+    const shadow = computeShadowParams({ x: 0, y: 0, z: 0 }, light);
+    expect(shadow.matrix).toHaveLength(16);
+  });
+
+  it('higher sun elevation reduces shadow opacity', () => {
+    const lightHigh = computeSunLight(80, 180);
+    const lightLow = computeSunLight(10, 180);
+    const pos: Vec3 = { x: 0, y: 1, z: 0 };
+    const shadowHigh = computeShadowParams(pos, lightHigh);
+    const shadowLow = computeShadowParams(pos, lightLow);
+    expect(shadowHigh.opacity).toBeLessThanOrEqual(shadowLow.opacity);
+  });
+});
+
+// ─── StubARProvider ───────────────────────────────────────────────────────────
+
+describe('StubARProvider', () => {
+  it('returns empty planes by default', () => {
+    const p = new StubARProvider();
+    expect(p.getTrackedPlanes()).toHaveLength(0);
+  });
+
+  it('returns provided planes', () => {
+    const p = new StubARProvider([makePlane()]);
+    expect(p.getTrackedPlanes()).toHaveLength(1);
+  });
+
+  it('hitTest returns null when no planes', () => {
+    const p = new StubARProvider();
+    expect(p.hitTest(0, 0)).toBeNull();
+  });
+
+  it('hitTest returns a Vec3 when planes exist', () => {
+    const p = new StubARProvider([makePlane()]);
+    const hit = p.hitTest(100, 200);
+    expect(hit).not.toBeNull();
+    expect(typeof hit!.x).toBe('number');
+  });
+});
+
+// ─── ARSceneManager ───────────────────────────────────────────────────────────
+
+describe('ARSceneManager', () => {
+  let provider: StubARProvider;
+  let scene: ARSceneManager;
+
+  beforeEach(() => {
+    provider = new StubARProvider([makePlane()]);
+    scene = new ARSceneManager(provider);
+  });
+
+  it('starts inactive', () => expect(scene.isActive).toBe(false));
+
+  it('becomes active after start()', () => {
+    scene.start();
+    expect(scene.isActive).toBe(true);
+  });
+
+  it('becomes inactive after stop()', () => {
+    scene.start();
+    scene.stop();
+    expect(scene.isActive).toBe(false);
+  });
+
+  it('registers and retrieves a model', () => {
+    const model = makeGltfModel({ id: 'chair', uri: 'models/chair.glb' });
+    scene.registerModel(model);
+    expect(scene.getModel('chair')).toBe(model);
+  });
+
+  it('unregisterModel removes the model', () => {
+    const model = makeGltfModel({ id: 'table', uri: 'models/table.glb' });
+    scene.registerModel(model);
+    scene.unregisterModel('table');
+    expect(scene.getModel('table')).toBeUndefined();
+  });
+
+  it('getViablePlanes filters by plane viability', () => {
+    const tiny = makePlane({ id: 'small', extent: { width: 0.05, height: 0.05 } });
+    const stub = new StubARProvider([makePlane(), tiny]);
+    const mgr = new ARSceneManager(stub);
+    expect(mgr.getViablePlanes()).toHaveLength(1);
+  });
+
+  it('placeObject returns an instance ID', () => {
+    scene.registerModel(makeGltfModel({ id: 'm1', uri: 'x.glb' }));
+    const id = scene.placeObject('m1', PLANE_ID, { x: 0, y: 0, z: 0 });
+    expect(typeof id).toBe('string');
+    expect(id).not.toBeNull();
+  });
+
+  it('placeObject returns null for unknown model', () => {
+    expect(scene.placeObject('no-model', PLANE_ID, { x: 0, y: 0, z: 0 })).toBeNull();
+  });
+
+  it('placeObject returns null for unknown plane', () => {
+    scene.registerModel(makeGltfModel({ id: 'm2', uri: 'x.glb' }));
+    expect(scene.placeObject('m2', 'no-plane', { x: 0, y: 0, z: 0 })).toBeNull();
+  });
+
+  it('objectCount increments on placement', () => {
+    scene.registerModel(makeGltfModel({ id: 'm3', uri: 'x.glb' }));
+    scene.placeObject('m3', PLANE_ID, { x: 0, y: 0, z: 0 });
+    expect(scene.objectCount).toBe(1);
+  });
+
+  it('removeObject deletes the object', () => {
+    scene.registerModel(makeGltfModel({ id: 'm4', uri: 'x.glb' }));
+    const id = scene.placeObject('m4', PLANE_ID, { x: 0, y: 0, z: 0 })!;
+    scene.removeObject(id);
+    expect(scene.getObject(id)).toBeUndefined();
+    expect(scene.objectCount).toBe(0);
+  });
+
+  it('listObjects returns all placed objects', () => {
+    scene.registerModel(makeGltfModel({ id: 'm5', uri: 'x.glb' }));
+    scene.placeObject('m5', PLANE_ID, { x: 0, y: 0, z: 0 });
+    scene.placeObject('m5', PLANE_ID, { x: 1, y: 0, z: 1 });
+    expect(scene.listObjects()).toHaveLength(2);
+  });
+
+  it('moveObject updates the position', () => {
+    scene.registerModel(makeGltfModel({ id: 'm6', uri: 'x.glb' }));
+    const id = scene.placeObject('m6', PLANE_ID, { x: 0, y: 0, z: 0 })!;
+    const moved = scene.moveObject(id, { x: 2, y: 0, z: 3 });
+    expect(moved).toBe(true);
+    expect(scene.getObject(id)?.position).toEqual({ x: 2, y: 0, z: 3 });
+  });
+
+  it('moveObject returns false for unknown id', () => {
+    expect(scene.moveObject('bad-id', { x: 0, y: 0, z: 0 })).toBe(false);
+  });
+
+  it('updateLighting changes the environment light', () => {
+    const before = scene.getEnvironmentLight().directional.intensity;
+    scene.updateLighting(10, 90, );
+    // Direction should have changed
+    const after = scene.getEnvironmentLight().directional;
+    expect(after).toBeDefined();
+    // Intensity remains the same (default 100000) — just verify it's a number
+    expect(typeof before).toBe('number');
+  });
+
+  it('placed object stores shadow parameters', () => {
+    scene.registerModel(makeGltfModel({ id: 'm7', uri: 'x.glb' }));
+    const id = scene.placeObject('m7', PLANE_ID, { x: 0, y: 0.5, z: 0 })!;
+    const obj = scene.getObject(id);
+    expect(obj?.shadow.matrix).toHaveLength(16);
+    expect(obj?.shadow.opacity).toBeGreaterThan(0);
+  });
+});
+
+// ─── ARObjectPlacementService ─────────────────────────────────────────────────
+
+describe('ARObjectPlacementService', () => {
+  it('exposes getScene()', () => {
+    const svc = new ARObjectPlacementService(new StubARProvider());
+    expect(svc.getScene()).toBeInstanceOf(ARSceneManager);
+  });
+
+  it('start/stop delegate to scene', () => {
+    const svc = new ARObjectPlacementService(new StubARProvider());
+    svc.start();
+    expect(svc.getScene().isActive).toBe(true);
+    svc.stop();
+    expect(svc.getScene().isActive).toBe(false);
+  });
+});

--- a/mobile/src/services/ARObjectPlacementService.ts
+++ b/mobile/src/services/ARObjectPlacementService.ts
@@ -1,0 +1,495 @@
+/**
+ * ARObjectPlacementService — Issue #594
+ * "[Mobile] Implement AR Native Object Placement for Creators"
+ *
+ * Features:
+ *  - ARKit (iOS) / ARCore (Android) surface-plane detection abstraction
+ *  - glTF 2.0 model registry with dynamic lighting parameter calculation
+ *  - Physically-based 3D shadow computation (sun position → shadow matrix)
+ *  - Scene manager for placing, transforming, and removing objects
+ *  - Platform-agnostic interface — concrete implementations swap at runtime
+ */
+
+// ─── Constants ─────────────────────────────────────────────────────────────────
+
+/** Minimum plane area (m²) required before it is considered valid for placement. */
+export const MIN_PLANE_AREA_M2 = 0.09; // 30 cm × 30 cm
+
+/** Maximum number of planes tracked simultaneously. */
+export const MAX_TRACKED_PLANES = 20;
+
+/** Shadow ambient coefficient (0–1): prevents fully black shadows. */
+export const SHADOW_AMBIENT = 0.15;
+
+/** Default PBR metalness for newly placed objects. */
+export const DEFAULT_METALNESS = 0.0;
+
+/** Default PBR roughness for newly placed objects. */
+export const DEFAULT_ROUGHNESS = 0.5;
+
+// ─── Math Primitives ──────────────────────────────────────────────────────────
+
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface Vec4 {
+  x: number;
+  y: number;
+  z: number;
+  w: number;
+}
+
+/** Column-major 4×4 transformation matrix stored as a flat 16-element array. */
+export type Mat4 = [
+  number, number, number, number,
+  number, number, number, number,
+  number, number, number, number,
+  number, number, number, number,
+];
+
+export function vec3Add(a: Vec3, b: Vec3): Vec3 {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+export function vec3Scale(v: Vec3, s: number): Vec3 {
+  return { x: v.x * s, y: v.y * s, z: v.z * s };
+}
+
+export function vec3Dot(a: Vec3, b: Vec3): number {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+export function vec3Length(v: Vec3): number {
+  return Math.sqrt(vec3Dot(v, v));
+}
+
+export function vec3Normalize(v: Vec3): Vec3 {
+  const len = vec3Length(v);
+  if (len === 0) return { x: 0, y: 0, z: 0 };
+  return vec3Scale(v, 1 / len);
+}
+
+export function vec3Cross(a: Vec3, b: Vec3): Vec3 {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+/** Returns the identity Mat4. */
+export function mat4Identity(): Mat4 {
+  return [
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1,
+  ];
+}
+
+// ─── Surface Plane ─────────────────────────────────────────────────────────────
+
+export type PlaneAlignment = 'horizontal' | 'vertical' | 'arbitrary';
+
+export interface ARPlane {
+  id: string;
+  alignment: PlaneAlignment;
+  center: Vec3;
+  /** Width and height in metres. */
+  extent: { width: number; height: number };
+  transform: Mat4;
+  confidence: number; // 0–1
+}
+
+/** Computed area of a plane in square metres. */
+export function planeArea(plane: ARPlane): number {
+  return plane.extent.width * plane.extent.height;
+}
+
+/** Returns true when a plane is large and confident enough for object placement. */
+export function isPlaneViable(plane: ARPlane): boolean {
+  return planeArea(plane) >= MIN_PLANE_AREA_M2 && plane.confidence >= 0.5;
+}
+
+// ─── glTF Model Registry ───────────────────────────────────────────────────────
+
+export interface GltfModel {
+  id: string;
+  uri: string;            // Local path or remote URL
+  scale: Vec3;
+  metalness: number;      // PBR: 0 (dielectric) → 1 (metal)
+  roughness: number;      // PBR: 0 (smooth) → 1 (rough)
+  castsShadow: boolean;
+  receivesShadow: boolean;
+}
+
+export function makeGltfModel(partial: Pick<GltfModel, 'id' | 'uri'> & Partial<GltfModel>): GltfModel {
+  return {
+    scale: { x: 1, y: 1, z: 1 },
+    metalness: DEFAULT_METALNESS,
+    roughness: DEFAULT_ROUGHNESS,
+    castsShadow: true,
+    receivesShadow: true,
+    ...partial,
+  };
+}
+
+// ─── Lighting ─────────────────────────────────────────────────────────────────
+
+export interface DirectionalLight {
+  direction: Vec3;    // Unit vector pointing FROM light source
+  color: Vec3;        // Linear RGB, each component 0–1
+  intensity: number;  // Lux equivalent
+}
+
+export interface EnvironmentLight {
+  ambient: Vec3;      // Base ambient colour
+  directional: DirectionalLight;
+}
+
+/**
+ * Computes a simple sun-based directional light from elevation and azimuth angles.
+ *
+ * @param elevationDeg  Angle above the horizon in degrees (0 = horizon, 90 = zenith).
+ * @param azimuthDeg    Clockwise angle from north in degrees.
+ * @param intensity     Light intensity in lux.
+ */
+export function computeSunLight(
+  elevationDeg: number,
+  azimuthDeg: number,
+  intensity: number = 100_000,
+): DirectionalLight {
+  const elRad = (elevationDeg * Math.PI) / 180;
+  const azRad = (azimuthDeg * Math.PI) / 180;
+
+  // Convert spherical → Cartesian, then negate (direction points from object to sun)
+  const sunX = Math.cos(elRad) * Math.sin(azRad);
+  const sunY = Math.sin(elRad);
+  const sunZ = Math.cos(elRad) * Math.cos(azRad);
+
+  const direction = vec3Normalize({ x: -sunX, y: -sunY, z: -sunZ });
+
+  // Colour temperature: warm at low elevation, white at zenith
+  const warmth = Math.max(0, 1 - elevationDeg / 90);
+  const color: Vec3 = {
+    x: 1.0,
+    y: 1.0 - warmth * 0.15,
+    z: 1.0 - warmth * 0.35,
+  };
+
+  return { direction, color, intensity };
+}
+
+/**
+ * Derives an EnvironmentLight combining a directional sun and computed ambient.
+ */
+export function deriveEnvironmentLight(
+  elevationDeg: number,
+  azimuthDeg: number,
+  intensity: number = 100_000,
+): EnvironmentLight {
+  const directional = computeSunLight(elevationDeg, azimuthDeg, intensity);
+
+  // Ambient is a fraction of the sky colour, brighter when sun is higher
+  const skyFactor = Math.max(SHADOW_AMBIENT, elevationDeg / 90);
+  const ambient: Vec3 = {
+    x: skyFactor * 0.5,
+    y: skyFactor * 0.6,
+    z: skyFactor * 0.8,
+  };
+
+  return { ambient, directional };
+}
+
+// ─── Shadow Calculation ────────────────────────────────────────────────────────
+
+export interface ShadowParams {
+  /** Shadow projection matrix for rendering. */
+  matrix: Mat4;
+  /** 0 (fully transparent) → 1 (fully opaque). */
+  opacity: number;
+  /** Shadow softness radius in world units. */
+  blurRadius: number;
+}
+
+/**
+ * Computes shadow parameters for an object placed at `objectPosition` on a plane.
+ *
+ * Uses a simple orthographic shadow projection oriented along the light direction.
+ * The shadow matrix translates the object position along the light direction
+ * onto the plane's Y=0 surface.
+ *
+ * @param objectPosition  World-space position of the object.
+ * @param light           Directional light driving the shadow.
+ * @param planeNormal     Upward normal of the receiving surface (default: world up).
+ */
+export function computeShadowParams(
+  objectPosition: Vec3,
+  light: DirectionalLight,
+  planeNormal: Vec3 = { x: 0, y: 1, z: 0 },
+): ShadowParams {
+  const lightDir = vec3Normalize(light.direction);
+  const dotNL = vec3Dot(planeNormal, lightDir);
+
+  // Shadow opacity scales with elevation: higher sun → shorter, less opaque shadow
+  const elevation = Math.asin(Math.max(-1, Math.min(1, -lightDir.y)));
+  const opacity = Math.max(0.1, 1.0 - elevation / (Math.PI / 2));
+
+  // Blur radius is proportional to the object height above the plane
+  // (approximated by the Y component of the object position)
+  const height = Math.max(0, objectPosition.y);
+  const blurRadius = height * 0.15 * (1 - opacity);
+
+  // Build a simple shadow matrix: project along light onto Y=0 plane.
+  // shadow_pos = position - (dot(planeNormal, position) / dot(planeNormal, lightDir)) * lightDir
+  const denominator = dotNL === 0 ? 0.0001 : dotNL;
+  const scale = -vec3Dot(planeNormal, objectPosition) / denominator;
+
+  const shadowOffset = vec3Scale(lightDir, scale);
+  const shadowPos = vec3Add(objectPosition, shadowOffset);
+
+  // Embed shadow translation into column-major Mat4
+  const matrix = mat4Identity();
+  matrix[12] = shadowPos.x;
+  matrix[13] = 0; // Shadow is projected onto Y=0
+  matrix[14] = shadowPos.z;
+
+  return { matrix, opacity, blurRadius };
+}
+
+// ─── Placed Object ────────────────────────────────────────────────────────────
+
+export interface PlacedObject {
+  instanceId: string;
+  modelId: string;
+  planeId: string;
+  position: Vec3;
+  rotation: Vec4;    // Quaternion
+  scale: Vec3;
+  shadow: ShadowParams;
+  placedAt: number;
+}
+
+// ─── AR Platform Provider Interface ───────────────────────────────────────────
+
+/**
+ * Pluggable interface for ARKit (iOS) and ARCore (Android).
+ * Production implementations call into native modules via JSI / expo-modules.
+ */
+export interface ARPlatformProvider {
+  startSession(): void;
+  stopSession(): void;
+  getTrackedPlanes(): ARPlane[];
+  hitTest(screenX: number, screenY: number): Vec3 | null;
+}
+
+/**
+ * Stub provider for unit tests — returns a single pre-defined plane.
+ */
+export class StubARProvider implements ARPlatformProvider {
+  private planes: ARPlane[];
+
+  constructor(planes: ARPlane[] = []) {
+    this.planes = planes;
+  }
+
+  startSession(): void { /* no-op */ }
+  stopSession(): void { /* no-op */ }
+
+  getTrackedPlanes(): ARPlane[] {
+    return this.planes;
+  }
+
+  hitTest(screenX: number, screenY: number): Vec3 | null {
+    if (this.planes.length === 0) return null;
+    // Return center of first plane, offset by screen position as a stub
+    const p = this.planes[0];
+    return { x: p.center.x + screenX * 0.001, y: p.center.y, z: p.center.z + screenY * 0.001 };
+  }
+}
+
+// ─── AR Scene Manager ─────────────────────────────────────────────────────────
+
+/**
+ * Manages the AR scene: model registry, plane tracking, object placement,
+ * lighting, and shadow calculation.
+ */
+export class ARSceneManager {
+  private provider: ARPlatformProvider;
+  private models: Map<string, GltfModel> = new Map();
+  private objects: Map<string, PlacedObject> = new Map();
+  private environment: EnvironmentLight;
+  private instanceCounter = 0;
+  private active = false;
+
+  constructor(
+    provider: ARPlatformProvider,
+    initialElevation = 45,
+    initialAzimuth = 180,
+  ) {
+    this.provider = provider;
+    this.environment = deriveEnvironmentLight(initialElevation, initialAzimuth);
+  }
+
+  // ── Session ──────────────────────────────────────────────────────────────
+
+  start(): void {
+    this.active = true;
+    this.provider.startSession();
+  }
+
+  stop(): void {
+    this.active = false;
+    this.provider.stopSession();
+  }
+
+  get isActive(): boolean {
+    return this.active;
+  }
+
+  // ── Model Registry ────────────────────────────────────────────────────────
+
+  registerModel(model: GltfModel): void {
+    this.models.set(model.id, model);
+  }
+
+  unregisterModel(modelId: string): boolean {
+    return this.models.delete(modelId);
+  }
+
+  getModel(modelId: string): GltfModel | undefined {
+    return this.models.get(modelId);
+  }
+
+  // ── Plane Queries ─────────────────────────────────────────────────────────
+
+  getTrackedPlanes(): ARPlane[] {
+    return this.provider.getTrackedPlanes();
+  }
+
+  getViablePlanes(): ARPlane[] {
+    return this.getTrackedPlanes().filter(isPlaneViable);
+  }
+
+  // ── Object Placement ──────────────────────────────────────────────────────
+
+  /**
+   * Place a registered model onto a given plane at a world-space position.
+   * Returns the instance ID or null when the model or plane is not found.
+   */
+  placeObject(
+    modelId: string,
+    planeId: string,
+    position: Vec3,
+    rotation: Vec4 = { x: 0, y: 0, z: 0, w: 1 },
+  ): string | null {
+    const model = this.models.get(modelId);
+    if (!model) return null;
+
+    const planes = this.provider.getTrackedPlanes();
+    const plane = planes.find((p) => p.id === planeId);
+    if (!plane) return null;
+
+    const shadow = computeShadowParams(position, this.environment.directional);
+    const instanceId = `obj-${++this.instanceCounter}-${Date.now()}`;
+
+    const placed: PlacedObject = {
+      instanceId,
+      modelId,
+      planeId,
+      position,
+      rotation,
+      scale: { ...model.scale },
+      shadow,
+      placedAt: Date.now(),
+    };
+
+    this.objects.set(instanceId, placed);
+    return instanceId;
+  }
+
+  /**
+   * Remove a placed object from the scene.
+   */
+  removeObject(instanceId: string): boolean {
+    return this.objects.delete(instanceId);
+  }
+
+  /**
+   * Retrieve a placed object by its instance ID.
+   */
+  getObject(instanceId: string): PlacedObject | undefined {
+    return this.objects.get(instanceId);
+  }
+
+  /**
+   * List all currently placed objects.
+   */
+  listObjects(): PlacedObject[] {
+    return Array.from(this.objects.values());
+  }
+
+  /**
+   * Move a placed object to a new position, recomputing its shadow.
+   */
+  moveObject(instanceId: string, newPosition: Vec3): boolean {
+    const obj = this.objects.get(instanceId);
+    if (!obj) return false;
+
+    obj.position = newPosition;
+    obj.shadow = computeShadowParams(newPosition, this.environment.directional);
+    return true;
+  }
+
+  // ── Lighting ─────────────────────────────────────────────────────────────
+
+  /**
+   * Update the scene lighting based on new sun angles.
+   * Also recomputes shadows for all existing objects.
+   */
+  updateLighting(elevationDeg: number, azimuthDeg: number): void {
+    this.environment = deriveEnvironmentLight(elevationDeg, azimuthDeg);
+
+    // Recompute shadows for all placed objects
+    for (const obj of this.objects.values()) {
+      obj.shadow = computeShadowParams(obj.position, this.environment.directional);
+    }
+  }
+
+  getEnvironmentLight(): EnvironmentLight {
+    return this.environment;
+  }
+
+  /** Total number of objects currently in the scene. */
+  get objectCount(): number {
+    return this.objects.size;
+  }
+}
+
+// ─── ARObjectPlacementService ─────────────────────────────────────────────────
+
+/**
+ * Top-level service facade — creates and owns the ARSceneManager.
+ */
+export class ARObjectPlacementService {
+  private scene: ARSceneManager;
+
+  constructor(provider: ARPlatformProvider, elevationDeg = 45, azimuthDeg = 180) {
+    this.scene = new ARSceneManager(provider, elevationDeg, azimuthDeg);
+  }
+
+  getScene(): ARSceneManager {
+    return this.scene;
+  }
+
+  start(): void {
+    this.scene.start();
+  }
+
+  stop(): void {
+    this.scene.stop();
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #594

- **Math primitives**: `Vec3`/`Mat4` helpers (add, scale, dot, cross, normalise, identity mat4) used throughout the AR pipeline.
- **Surface plane detection**: `ARPlane` model with `planeArea` and `isPlaneViable` (min 0.09 m², confidence ≥ 0.5). `ARSceneManager.getViablePlanes()` filters the live plane list.
- **glTF model registry**: `GltfModel` with PBR fields (metalness, roughness, shadow casting/receiving). `makeGltfModel` applies sensible defaults.
- **Dynamic lighting**: `computeSunLight` derives a `DirectionalLight` from solar elevation and azimuth angles with warm-to-white colour temperature. `deriveEnvironmentLight` adds computed ambient.
- **Realistic 3D shadows**: `computeShadowParams` computes shadow opacity (higher sun → less opaque), blur radius (object height proportional), and a projection matrix that places the shadow on the receiving plane.
- **`ARPlatformProvider` interface**: clean swap point for ARKit (iOS) vs ARCore (Android) native modules.
- **`ARSceneManager`**: full scene lifecycle — start/stop, model CRUD, `placeObject`, `removeObject`, `moveObject` (recomputes shadow), `updateLighting` (recomputes all shadows).
- **`StubARProvider`**: deterministic test double.

## Test plan

- [x] Constants — correct values
- [x] Vec3 helpers — all operations including zero-vector normalise
- [x] `mat4Identity` — diagonal, off-diagonal, length
- [x] `planeArea` / `isPlaneViable` — area, confidence gating
- [x] `makeGltfModel` — defaults and overrides
- [x] `computeSunLight` — unit direction, zenith case, intensity, colour
- [x] `deriveEnvironmentLight` — ambient/directional presence, positive components
- [x] `computeShadowParams` — matrix, opacity range, blur ≥ 0, elevation comparison
- [x] `StubARProvider` — empty/filled planes, hitTest
- [x] `ARSceneManager` — full lifecycle, model CRUD, placement, move, remove, lighting update, shadow stored on object
- [x] `ARObjectPlacementService` — getScene(), start/stop delegation

54 tests — all passing.