### PR TITLE
This PR adds a post-verification onboarding wizard for new Creator and Client users

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,41 @@
+name: Helm Chart Validation
+
+on:
+  pull_request:
+    paths:
+      - 'helm/**'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'helm/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Lint subcharts
+        run: |
+          for chart in helm/charts/*/; do
+            echo "Linting $chart"
+            helm lint "$chart"
+          done
+
+      - name: Build dependencies
+        run: helm dependency build helm/
+
+      - name: Lint umbrella chart
+        run: helm lint helm/
+
+      - name: Template render (dry-run)
+        run: helm template stellar helm/ --debug > /dev/null
+
+      - name: Validate rendered manifests
+        run: |
+          helm template stellar helm/ | kubectl apply --dry-run=client -f -

--- a/__tests__/api-keys.test.ts
+++ b/__tests__/api-keys.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { generateApiKey, hashApiKey, parseScopes } from '@/lib/api-keys';
+
+describe('API key utilities', () => {
+  it('generates keys with sk_ prefix', () => {
+    const { rawKey, keyHash } = generateApiKey();
+    expect(rawKey).toMatch(/^sk_[a-f0-9]{48}$/);
+    expect(keyHash).toHaveLength(64);
+  });
+
+  it('hashes keys consistently', () => {
+    const key = 'sk_test123';
+    expect(hashApiKey(key)).toBe(hashApiKey(key));
+  });
+
+  it('parses valid scopes', () => {
+    expect(parseScopes(['read-only', 'read-write', 'invalid'])).toEqual([
+      'read-only',
+      'read-write',
+    ]);
+  });
+
+  it('rejects empty scope list after parsing', () => {
+    expect(parseScopes(['admin'])).toEqual([]);
+  });
+});

--- a/__tests__/onboarding.test.ts
+++ b/__tests__/onboarding.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import * as z from 'zod';
+
+const roleSchema = z.object({
+  role: z.enum(['CREATOR', 'CLIENT']),
+});
+
+const creatorSchema = z.object({
+  displayName: z.string().min(2).max(30),
+  discipline: z.string().min(1),
+  skills: z.array(z.string()).min(1).max(5),
+});
+
+describe('Onboarding wizard validation', () => {
+  it('accepts valid role selection', () => {
+    expect(roleSchema.parse({ role: 'CREATOR' }).role).toBe('CREATOR');
+    expect(roleSchema.parse({ role: 'CLIENT' }).role).toBe('CLIENT');
+  });
+
+  it('requires creator profile fields on step 2', () => {
+    const result = creatorSchema.safeParse({
+      displayName: 'Ada',
+      discipline: 'Development',
+      skills: ['react', 'typescript', 'rust'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects creator with fewer than 3 skills when max is 5', () => {
+    const result = creatorSchema.safeParse({
+      displayName: 'Ada',
+      discipline: 'Development',
+      skills: ['react'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty display name', () => {
+    const result = creatorSchema.safeParse({
+      displayName: 'A',
+      discipline: 'Development',
+      skills: ['react'],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('Onboarding step progression', () => {
+  it('tracks three visible steps', () => {
+    const TOTAL_STEPS = 3;
+    expect(TOTAL_STEPS).toBe(3);
+    expect((2 / TOTAL_STEPS) * 100).toBeCloseTo(66.67, 1);
+  });
+});

--- a/__tests__/profile-completion.test.ts
+++ b/__tests__/profile-completion.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { computeProfileCompletion } from '@/lib/profile-completion';
+
+describe('computeProfileCompletion', () => {
+  it('returns 0% for empty profile', () => {
+    const result = computeProfileCompletion({});
+    expect(result.percentage).toBe(0);
+    expect(result.missing.length).toBe(7);
+  });
+
+  it('returns 100% for fully complete profile', () => {
+    const result = computeProfileCompletion({
+      displayName: 'Ada Lovelace',
+      avatar: 'https://example.com/avatar.png',
+      bio: 'Full-stack developer',
+      skills: ['react', 'typescript', 'rust'],
+      portfolio: { items: [{ title: 'Project' }] },
+      githubUrl: 'https://github.com/ada',
+      verified: true,
+    });
+    expect(result.percentage).toBe(100);
+    expect(result.missing).toHaveLength(0);
+  });
+
+  it('counts display name as 10%', () => {
+    const result = computeProfileCompletion({ displayName: 'Ada' });
+    expect(result.percentage).toBe(10);
+  });
+
+  it('requires 3+ skills for skills field', () => {
+    const twoSkills = computeProfileCompletion({ skills: ['a', 'b'] });
+    const threeSkills = computeProfileCompletion({ skills: ['a', 'b', 'c'] });
+    expect(twoSkills.percentage).toBe(0);
+    expect(threeSkills.percentage).toBe(15);
+  });
+
+  it('accepts github or linkedin for social field', () => {
+    const github = computeProfileCompletion({ linkedinUrl: 'https://linkedin.com/in/ada' });
+    expect(github.percentage).toBe(10);
+  });
+});

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from 'next-auth';
+import { authOptions } from '@/lib/auth/config';
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/app/api/auth/verify-email/route.ts
+++ b/app/api/auth/verify-email/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * GET /api/auth/verify-email?token=...
+ * Marks email as verified and redirects to onboarding.
+ */
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get('token');
+  if (!token) {
+    return NextResponse.redirect(new URL('/auth/login?error=missing_token', req.url));
+  }
+
+  const record = await prisma.verificationToken.findUnique({
+    where: { token },
+    include: { user: true },
+  });
+
+  if (!record || record.expires < new Date()) {
+    return NextResponse.redirect(new URL('/auth/login?error=invalid_token', req.url));
+  }
+
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id: record.userId },
+      data: { emailVerified: new Date() },
+    }),
+    prisma.verificationToken.delete({ where: { id: record.id } }),
+  ]);
+
+  const onboardingUrl = new URL('/onboarding', req.url);
+  onboardingUrl.searchParams.set('verified', '1');
+  return NextResponse.redirect(onboardingUrl);
+}

--- a/app/api/developer/keys/[id]/route.ts
+++ b/app/api/developer/keys/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/auth/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const key = await prisma.apiKey.findFirst({
+    where: { id, userId: session.user.id, revokedAt: null },
+  });
+
+  if (!key) {
+    return NextResponse.json({ error: 'Key not found' }, { status: 404 });
+  }
+
+  await prisma.apiKey.update({
+    where: { id },
+    data: { revokedAt: new Date() },
+  });
+
+  return NextResponse.json({ revoked: true });
+}

--- a/app/api/developer/keys/route.ts
+++ b/app/api/developer/keys/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/auth/auth';
+import { prisma } from '@/lib/prisma';
+import { generateApiKey, parseScopes } from '@/lib/api-keys';
+
+export async function GET() {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const keys = await prisma.apiKey.findMany({
+    where: { userId: session.user.id, revokedAt: null },
+    select: {
+      id: true,
+      name: true,
+      scopes: true,
+      lastUsedAt: true,
+      expiresAt: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return NextResponse.json({ keys });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { name, scopes, expiresAt } = body as {
+    name: string;
+    scopes: string[];
+    expiresAt?: string;
+  };
+
+  if (!name?.trim()) {
+    return NextResponse.json({ error: 'Name is required' }, { status: 400 });
+  }
+
+  const parsedScopes = parseScopes(scopes ?? []);
+  if (parsedScopes.length === 0) {
+    return NextResponse.json({ error: 'At least one valid scope is required' }, { status: 400 });
+  }
+
+  const { rawKey, keyHash } = generateApiKey();
+
+  const key = await prisma.apiKey.create({
+    data: {
+      userId: session.user.id,
+      keyHash,
+      name: name.trim(),
+      scopes: parsedScopes,
+      expiresAt: expiresAt ? new Date(expiresAt) : null,
+    },
+    select: { id: true, name: true, scopes: true, expiresAt: true, createdAt: true },
+  });
+
+  return NextResponse.json({ key, rawKey }, { status: 201 });
+}

--- a/app/api/onboarding/route.ts
+++ b/app/api/onboarding/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/auth/auth';
+import { prisma } from '@/lib/prisma';
+import { Role } from '@prisma/client';
+
+export async function GET() {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: {
+      onboardingStep: true,
+      onboardingCompletedAt: true,
+      onboardingData: true,
+      role: true,
+      emailVerified: true,
+    },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(user);
+}
+
+export async function PATCH(req: NextRequest) {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { step, data, role } = body as {
+    step?: number;
+    data?: Record<string, unknown>;
+    role?: 'CREATOR' | 'CLIENT';
+  };
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+  });
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  const mergedData = {
+    ...((user.onboardingData as Record<string, unknown> | null) ?? {}),
+    ...(data ?? {}),
+  };
+
+  const updated = await prisma.user.update({
+    where: { id: session.user.id },
+    data: {
+      onboardingStep: step ?? user.onboardingStep,
+      onboardingData: mergedData,
+      ...(role ? { role: role as Role } : {}),
+    },
+    select: {
+      onboardingStep: true,
+      onboardingCompletedAt: true,
+      onboardingData: true,
+      role: true,
+    },
+  });
+
+  return NextResponse.json(updated);
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { role, profile } = body as {
+    role: 'CREATOR' | 'CLIENT';
+    profile: Record<string, unknown>;
+  };
+
+  const userId = session.user.id;
+
+  await prisma.$transaction(async (tx) => {
+    if (role === 'CREATOR') {
+      await tx.creatorProfile.upsert({
+        where: { userId },
+        create: {
+          userId,
+          displayName: (profile.displayName as string) || 'Creator',
+          bio: (profile.bio as string) || null,
+          avatar: (profile.avatar as string) || null,
+          discipline: (profile.discipline as string) || null,
+          skills: (profile.skills as string[]) || [],
+        },
+        update: {
+          displayName: (profile.displayName as string) || undefined,
+          bio: (profile.bio as string) || null,
+          avatar: (profile.avatar as string) || null,
+          discipline: (profile.discipline as string) || null,
+          skills: (profile.skills as string[]) || undefined,
+        },
+      });
+    } else {
+      await tx.clientProfile.upsert({
+        where: { userId },
+        create: {
+          userId,
+          companyName: (profile.companyName as string) || null,
+          projectType: (profile.projectType as string) || null,
+          budgetRange: (profile.budgetRange as string) || null,
+        },
+        update: {
+          companyName: (profile.companyName as string) || null,
+          projectType: (profile.projectType as string) || null,
+          budgetRange: (profile.budgetRange as string) || null,
+        },
+      });
+    }
+
+    await tx.user.update({
+      where: { id: userId },
+      data: {
+        role: role as Role,
+        onboardingCompletedAt: new Date(),
+        onboardingStep: 3,
+      },
+    });
+  });
+
+  return NextResponse.json({ completed: true });
+}

--- a/app/api/profile/completion/route.ts
+++ b/app/api/profile/completion/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/auth/auth';
+import { prisma } from '@/lib/prisma';
+import { computeProfileCompletion } from '@/lib/profile-completion';
+
+export async function GET() {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const profile = await prisma.creatorProfile.findUnique({
+    where: { userId: session.user.id },
+    select: {
+      displayName: true,
+      avatar: true,
+      bio: true,
+      skills: true,
+      portfolio: true,
+      githubUrl: true,
+      linkedinUrl: true,
+      verified: true,
+    },
+  });
+
+  if (!profile) {
+    return NextResponse.json(computeProfileCompletion({}));
+  }
+
+  return NextResponse.json(computeProfileCompletion(profile));
+}

--- a/app/dashboard/api-keys/page.tsx
+++ b/app/dashboard/api-keys/page.tsx
@@ -1,0 +1,20 @@
+import { ApiKeysManager } from "@/components/dashboard/api-keys-manager";
+
+export const metadata = {
+  title: "API Keys | Stellar Creators",
+  description: "Manage developer API keys for third-party integrations",
+};
+
+export default function ApiKeysPage() {
+  return (
+    <div className="container max-w-3xl py-10 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">API Keys</h1>
+        <p className="text-muted-foreground mt-1">
+          Generate and manage API keys for programmatic access to the GraphQL API.
+        </p>
+      </div>
+      <ApiKeysManager />
+    </div>
+  );
+}

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ status: 'healthy', service: 'next-app' });
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,10 @@
+import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard";
+
+export const metadata = {
+  title: "Onboarding | Stellar Creators",
+  description: "Complete your profile setup",
+};
+
+export default function OnboardingPage() {
+  return <OnboardingWizard />;
+}

--- a/app/ready/route.ts
+++ b/app/ready/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ status: 'ready', service: 'next-app' });
+}

--- a/backend/services/api/src/main.rs
+++ b/backend/services/api/src/main.rs
@@ -399,6 +399,17 @@ async fn health(
         }))
 }
 
+/// Readiness probe — returns 200 when the database is reachable.
+async fn ready(pool: web::Data<PgPool>) -> HttpResponse {
+    match pool.acquire().await {
+        Ok(_) => HttpResponse::Ok().json(serde_json::json!({ "status": "ready" })),
+        Err(e) => {
+            tracing::error!("Readiness check failed: {}", e);
+            HttpResponse::ServiceUnavailable().json(serde_json::json!({ "status": "not_ready" }))
+        }
+    }
+}
+
 /// Create a new bounty
 async fn create_bounty(body: web::Json<database::BountyRequest>) -> HttpResponse {
     tracing::info!("Creating bounty: {:?}", body.title);
@@ -1346,6 +1357,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(middleware::NormalizePath::trim())
             .wrap(ApiVersionHeader)
             .route("/health", web::get().to(health))
+            .route("/ready", web::get().to(ready))
             .route("/api/versions", web::get().to(api_versions))
             .route("/ws", web::get().to(websocket::ws_handler))
             .route("/api/v1/ws/metrics", web::get().to(websocket::websocket_metrics))

--- a/components/dashboard/api-keys-manager.tsx
+++ b/components/dashboard/api-keys-manager.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { trackEvent } from "@/lib/analytics/analytics";
+
+interface ApiKeyRecord {
+  id: string;
+  name: string;
+  scopes: string[];
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+export function ApiKeysManager() {
+  const [keys, setKeys] = useState<ApiKeyRecord[]>([]);
+  const [name, setName] = useState("");
+  const [scopes, setScopes] = useState<string[]>(["read-only"]);
+  const [expiryDays, setExpiryDays] = useState("90");
+  const [newKey, setNewKey] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadKeys = useCallback(async () => {
+    const res = await fetch("/api/developer/keys");
+    if (res.ok) {
+      const data = await res.json();
+      setKeys(data.keys);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadKeys();
+  }, [loadKeys]);
+
+  const toggleScope = (scope: string) => {
+    setScopes((prev) =>
+      prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope],
+    );
+  };
+
+  const createKey = async () => {
+    const expiresAt =
+      expiryDays === "never"
+        ? undefined
+        : new Date(Date.now() + Number(expiryDays) * 86400000).toISOString();
+
+    const res = await fetch("/api/developer/keys", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, scopes, expiresAt }),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      setNewKey(data.rawKey);
+      setName("");
+      trackEvent("api_key_created", { scopes: scopes.join(",") });
+      await loadKeys();
+    }
+  };
+
+  const revokeKey = async (id: string) => {
+    await fetch(`/api/developer/keys/${id}`, { method: "DELETE" });
+    trackEvent("api_key_revoked", { id });
+    await loadKeys();
+  };
+
+  if (loading) {
+    return <p className="text-muted-foreground">Loading API keys…</p>;
+  }
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-lg border p-6 space-y-4">
+        <h2 className="text-lg font-semibold">Create API key</h2>
+        <div className="space-y-2">
+          <Label htmlFor="key-name">Name</Label>
+          <Input
+            id="key-name"
+            placeholder="My integration"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Permission scopes</Label>
+          <div className="flex gap-4">
+            {(["read-only", "read-write"] as const).map((scope) => (
+              <label key={scope} className="flex items-center gap-2 text-sm">
+                <Checkbox
+                  checked={scopes.includes(scope)}
+                  onCheckedChange={() => toggleScope(scope)}
+                />
+                {scope}
+              </label>
+            ))}
+          </div>
+        </div>
+        <div className="space-y-2">
+          <Label>Expiry</Label>
+          <Select value={expiryDays} onValueChange={setExpiryDays}>
+            <SelectTrigger className="w-48">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="30">30 days</SelectItem>
+              <SelectItem value="90">90 days</SelectItem>
+              <SelectItem value="365">1 year</SelectItem>
+              <SelectItem value="never">Never</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <Button onClick={createKey} disabled={!name.trim() || scopes.length === 0}>
+          Generate key
+        </Button>
+        {newKey && (
+          <div className="rounded-md bg-muted p-4 space-y-2">
+            <p className="text-sm font-medium text-destructive">
+              Copy this key now — it will not be shown again.
+            </p>
+            <code className="block break-all text-sm">{newKey}</code>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Your API keys</h2>
+        {keys.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No API keys yet.</p>
+        ) : (
+          <ul className="divide-y rounded-lg border">
+            {keys.map((key) => (
+              <li key={key.id} className="flex items-center justify-between p-4 gap-4">
+                <div>
+                  <p className="font-medium">{key.name}</p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Scopes: {key.scopes.join(", ")} · Created{" "}
+                    {new Date(key.createdAt).toLocaleDateString()}
+                    {key.lastUsedAt &&
+                      ` · Last used ${new Date(key.lastUsedAt).toLocaleDateString()}`}
+                  </p>
+                  <div className="mt-2 h-8 w-48 rounded bg-muted/60 flex items-center justify-center text-xs text-muted-foreground">
+                    Usage graph (requests/day)
+                  </div>
+                </div>
+                <Button variant="destructive" size="sm" onClick={() => revokeKey(key.id)}>
+                  Revoke
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/components/forms/profile-form.tsx
+++ b/components/forms/profile-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useForm } from "react-hook-form";
+import { useEffect } from "react";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { Button } from "@/components/ui/button";
@@ -15,6 +16,10 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { SkillCombobox } from "@/components/ui/skill-combobox";
+import { ProfileCompletionIndicator } from "@/components/profile/profile-completion-indicator";
+import { trackEvent } from "@/lib/analytics/analytics";
+import { computeProfileCompletion } from "@/lib/profile-completion";
 
 const profileFormSchema = z.object({
     displayName: z.string().min(2, {
@@ -22,7 +27,10 @@ const profileFormSchema = z.object({
     }).max(30, {
         message: "Display name must not be longer than 30 characters.",
     }),
-    bio: z.string().max(160).optional(),
+    bio: z.string().max(500).optional(),
+    avatar: z.string().url({ message: "Please enter a valid URL." }).optional().or(z.literal("")),
+    skills: z.array(z.string()).default([]),
+    portfolioUrl: z.string().url().optional().or(z.literal("")),
     githubUrl: z.string().url({ message: "Please enter a valid URL." }).optional().or(z.literal("")),
     figmaUrl: z.string().url({ message: "Please enter a valid URL." }).optional().or(z.literal("")),
     linkedinUrl: z.string().url({ message: "Please enter a valid URL." }).optional().or(z.literal("")),
@@ -31,9 +39,12 @@ const profileFormSchema = z.object({
 
 type ProfileFormValues = z.infer<typeof profileFormSchema>;
 
-const defaultValues: Partial<ProfileFormValues> = {
+const defaultValues: ProfileFormValues = {
     displayName: "",
     bio: "",
+    avatar: "",
+    skills: [],
+    portfolioUrl: "",
     githubUrl: "",
     figmaUrl: "",
     linkedinUrl: "",
@@ -47,116 +58,167 @@ export function ProfileForm() {
         mode: "onChange",
     });
 
+    const watched = useWatch({ control: form.control });
+    const completion = computeProfileCompletion({
+        displayName: watched.displayName,
+        avatar: watched.avatar || null,
+        bio: watched.bio,
+        skills: watched.skills,
+        portfolio: watched.portfolioUrl ? { items: [{ url: watched.portfolioUrl }] } : null,
+        githubUrl: watched.githubUrl,
+        linkedinUrl: watched.linkedinUrl,
+    });
+
+    useEffect(() => {
+        trackEvent("profile_completion_rate", { percentage: completion.percentage });
+    }, [completion.percentage]);
+
     function onSubmit(data: ProfileFormValues) {
-        // We will implement server action here
         console.log(data);
+        trackEvent("profile_updated", { completion: completion.percentage });
     }
 
     return (
-        <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-                <FormField
-                    control={form.control}
-                    name="displayName"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>Display Name</FormLabel>
-                            <FormControl>
-                                <Input placeholder="Your Name" {...field} />
-                            </FormControl>
-                            <FormDescription>
-                                This is your public display name.
-                            </FormDescription>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    control={form.control}
-                    name="bio"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>Bio</FormLabel>
-                            <FormControl>
-                                <Textarea
-                                    placeholder="Tell us a little bit about yourself"
-                                    className="resize-none"
-                                    {...field}
-                                />
-                            </FormControl>
-                            <FormDescription>
-                                You can write up to 160 characters.
-                            </FormDescription>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    control={form.control}
-                    name="githubUrl"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>GitHub URL</FormLabel>
-                            <FormControl>
-                                <Input placeholder="https://github.com/..." {...field} />
-                            </FormControl>
-                            <FormDescription>
-                                Link your GitHub profile.
-                            </FormDescription>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    control={form.control}
-                    name="figmaUrl"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>Figma URL</FormLabel>
-                            <FormControl>
-                                <Input placeholder="https://figma.com/..." {...field} />
-                            </FormControl>
-                            <FormDescription>
-                                Link your Figma profile.
-                            </FormDescription>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    control={form.control}
-                    name="linkedinUrl"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>LinkedIn URL</FormLabel>
-                            <FormControl>
-                                <Input placeholder="https://linkedin.com/in/..." {...field} />
-                            </FormControl>
-                            <FormDescription>
-                                Link your LinkedIn profile.
-                            </FormDescription>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    control={form.control}
-                    name="websiteUrl"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>Website / Portfolio URL</FormLabel>
-                            <FormControl>
-                                <Input placeholder="https://yourportfolio.com" {...field} />
-                            </FormControl>
-                            <FormDescription>
-                                Link your personal website or portfolio.
-                            </FormDescription>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <Button type="submit">Update profile</Button>
-            </form>
-        </Form>
+        <div className="space-y-8">
+            <ProfileCompletionIndicator profile={{
+                displayName: watched.displayName,
+                avatar: watched.avatar || null,
+                bio: watched.bio,
+                skills: watched.skills,
+                portfolio: watched.portfolioUrl ? { items: [{ url: watched.portfolioUrl }] } : null,
+                githubUrl: watched.githubUrl,
+                linkedinUrl: watched.linkedinUrl,
+            }} />
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+                    <FormField
+                        control={form.control}
+                        name="displayName"
+                        render={({ field }) => (
+                            <FormItem id="displayName">
+                                <FormLabel>Display Name</FormLabel>
+                                <FormControl>
+                                    <Input placeholder="Your Name" {...field} />
+                                </FormControl>
+                                <FormDescription>
+                                    This is your public display name.
+                                </FormDescription>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <FormField
+                        control={form.control}
+                        name="avatar"
+                        render={({ field }) => (
+                            <FormItem id="avatar">
+                                <FormLabel>Avatar URL</FormLabel>
+                                <FormControl>
+                                    <Input placeholder="https://…" {...field} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <FormField
+                        control={form.control}
+                        name="bio"
+                        render={({ field }) => (
+                            <FormItem id="bio">
+                                <FormLabel>Bio</FormLabel>
+                                <FormControl>
+                                    <Textarea
+                                        placeholder="Tell us a little bit about yourself"
+                                        className="resize-none"
+                                        {...field}
+                                    />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <FormField
+                        control={form.control}
+                        name="skills"
+                        render={({ field }) => (
+                            <FormItem id="skills">
+                                <FormLabel>Skills</FormLabel>
+                                <FormControl>
+                                    <SkillCombobox value={field.value} onChange={field.onChange} maxItems={10} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <FormField
+                        control={form.control}
+                        name="portfolioUrl"
+                        render={({ field }) => (
+                            <FormItem id="portfolio">
+                                <FormLabel>Portfolio sample URL</FormLabel>
+                                <FormControl>
+                                    <Input placeholder="https://yourportfolio.com/project" {...field} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <FormField
+                        control={form.control}
+                        name="githubUrl"
+                        render={({ field }) => (
+                            <FormItem id="social">
+                                <FormLabel>GitHub URL</FormLabel>
+                                <FormControl>
+                                    <Input placeholder="https://github.com/..." {...field} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <FormField
+                        control={form.control}
+                        name="linkedinUrl"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>LinkedIn URL</FormLabel>
+                                <FormControl>
+                                    <Input placeholder="https://linkedin.com/in/..." {...field} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <FormField
+                        control={form.control}
+                        name="figmaUrl"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>Figma URL</FormLabel>
+                                <FormControl>
+                                    <Input placeholder="https://figma.com/..." {...field} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <FormField
+                        control={form.control}
+                        name="websiteUrl"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>Website / Portfolio URL</FormLabel>
+                                <FormControl>
+                                    <Input placeholder="https://yourportfolio.com" {...field} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <Button type="submit">Update profile</Button>
+                </form>
+            </Form>
+        </div>
     );
 }

--- a/components/onboarding/onboarding-wizard.tsx
+++ b/components/onboarding/onboarding-wizard.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SkillCombobox } from "@/components/ui/skill-combobox";
+import { CreatorCard } from "@/components/creator-card";
+import { creators, bounties } from "@/lib/creators-data";
+import { trackEvent, trackConversion } from "@/lib/analytics/analytics";
+
+const TOTAL_STEPS = 3;
+
+const roleSchema = z.object({
+  role: z.enum(["CREATOR", "CLIENT"]),
+});
+
+const creatorSchema = z.object({
+  displayName: z.string().min(2).max(30),
+  discipline: z.string().min(1, "Select a discipline"),
+  skills: z.array(z.string()).min(1, "Add at least one skill").max(5),
+  avatar: z.string().url().optional().or(z.literal("")),
+});
+
+const clientSchema = z.object({
+  companyName: z.string().min(2).max(80),
+  projectType: z.string().min(1),
+  budgetRange: z.string().min(1),
+});
+
+const DISCIPLINES = ["Design", "Development", "Writing", "Marketing", "Video"];
+const PROJECT_TYPES = ["Web App", "Mobile App", "Brand Design", "Content", "Other"];
+const BUDGET_RANGES = ["<$1k", "$1k–$5k", "$5k–$20k", "$20k+"];
+
+export function OnboardingWizard() {
+  const router = useRouter();
+  const [step, setStep] = useState(1);
+  const [role, setRole] = useState<"CREATOR" | "CLIENT" | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const roleForm = useForm<z.infer<typeof roleSchema>>({
+    resolver: zodResolver(roleSchema),
+    defaultValues: { role: "CREATOR" },
+  });
+
+  const creatorForm = useForm<z.infer<typeof creatorSchema>>({
+    resolver: zodResolver(creatorSchema),
+    defaultValues: { displayName: "", discipline: "", skills: [], avatar: "" },
+  });
+
+  const clientForm = useForm<z.infer<typeof clientSchema>>({
+    resolver: zodResolver(clientSchema),
+    defaultValues: { companyName: "", projectType: "", budgetRange: "" },
+  });
+
+  const persistStep = useCallback(async (nextStep: number, extra?: Record<string, unknown>) => {
+    await fetch("/api/onboarding", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ step: nextStep, data: extra, role: role ?? undefined }),
+    });
+  }, [role]);
+
+  useEffect(() => {
+    fetch("/api/onboarding")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.onboardingCompletedAt) {
+          router.replace("/dashboard");
+          return;
+        }
+        if (data?.onboardingStep) setStep(Math.min(data.onboardingStep, TOTAL_STEPS));
+        if (data?.role === "CREATOR" || data?.role === "CLIENT") setRole(data.role);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [router]);
+
+  const goToStep = async (next: number) => {
+    setStep(next);
+    await persistStep(next);
+    trackEvent("onboarding_step", { step: next, role: role ?? "unset" });
+  };
+
+  const onRoleSubmit = async (values: z.infer<typeof roleSchema>) => {
+    setRole(values.role);
+    await fetch("/api/onboarding", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ step: 2, role: values.role }),
+    });
+    trackEvent("onboarding_step_complete", { step: 1, role: values.role });
+    setStep(2);
+  };
+
+  const onProfileSubmit = async (profile: Record<string, unknown>) => {
+    if (!role) return;
+    await fetch("/api/onboarding", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ step: 3, data: profile, role }),
+    });
+    trackEvent("onboarding_step_complete", { step: 2, role });
+    setStep(3);
+  };
+
+  const completeOnboarding = async (skipFeatured = false) => {
+    const profile =
+      role === "CREATOR"
+        ? creatorForm.getValues()
+        : clientForm.getValues();
+
+    await fetch("/api/onboarding", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role, profile }),
+    });
+
+    trackConversion("signup", { role, skippedFeatured: skipFeatured });
+    trackEvent("onboarding_complete", { role });
+    router.push(role === "CREATOR" ? "/bounties" : "/creators");
+  };
+
+  if (loading) {
+    return <div className="container max-w-2xl py-16 text-center text-muted-foreground">Loading…</div>;
+  }
+
+  const progressValue = (step / TOTAL_STEPS) * 100;
+
+  return (
+    <div className="container max-w-2xl py-10 space-y-8">
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm text-muted-foreground">
+          <span>Step {step} of {TOTAL_STEPS}</span>
+          <Link href="/" className="hover:underline" onClick={() => trackEvent("onboarding_skip", { step })}>
+            Skip for now
+          </Link>
+        </div>
+        <Progress value={progressValue} className="h-2" />
+      </div>
+
+      {step === 1 && (
+        <Form {...roleForm}>
+          <form onSubmit={roleForm.handleSubmit(onRoleSubmit)} className="space-y-6">
+            <div>
+              <h1 className="text-2xl font-bold">Welcome! Choose your path</h1>
+              <p className="text-muted-foreground mt-1">
+                Are you here to offer services or hire creators?
+              </p>
+            </div>
+            <FormField
+              control={roleForm.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    {(["CREATOR", "CLIENT"] as const).map((r) => (
+                      <button
+                        key={r}
+                        type="button"
+                        onClick={() => field.onChange(r)}
+                        className={`rounded-lg border p-6 text-left transition-colors ${
+                          field.value === r ? "border-primary bg-primary/5" : "hover:border-muted-foreground/40"
+                        }`}
+                      >
+                        <p className="font-semibold">{r === "CREATOR" ? "Creator" : "Client"}</p>
+                        <p className="text-sm text-muted-foreground mt-1">
+                          {r === "CREATOR"
+                            ? "I offer services and apply to bounties"
+                            : "I hire creators and post bounties"}
+                        </p>
+                      </button>
+                    ))}
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button type="submit">Continue</Button>
+          </form>
+        </Form>
+      )}
+
+      {step === 2 && role === "CREATOR" && (
+        <Form {...creatorForm}>
+          <form
+            onSubmit={creatorForm.handleSubmit((v) => onProfileSubmit(v))}
+            className="space-y-6"
+          >
+            <div>
+              <h1 className="text-2xl font-bold">Set up your creator profile</h1>
+              <p className="text-muted-foreground mt-1">Tell clients who you are and what you do.</p>
+            </div>
+            <FormField
+              control={creatorForm.control}
+              name="displayName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Display name</FormLabel>
+                  <FormControl><Input placeholder="Your name" {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={creatorForm.control}
+              name="discipline"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Discipline</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger><SelectValue placeholder="Select discipline" /></SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {DISCIPLINES.map((d) => (
+                        <SelectItem key={d} value={d}>{d}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={creatorForm.control}
+              name="skills"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Top skills (up to 5)</FormLabel>
+                  <FormControl>
+                    <SkillCombobox value={field.value} onChange={field.onChange} maxItems={5} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={creatorForm.control}
+              name="avatar"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Avatar URL (optional)</FormLabel>
+                  <FormControl><Input placeholder="https://…" {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="flex gap-3">
+              <Button type="button" variant="outline" onClick={() => goToStep(1)}>Back</Button>
+              <Button type="submit">Continue</Button>
+            </div>
+          </form>
+        </Form>
+      )}
+
+      {step === 2 && role === "CLIENT" && (
+        <Form {...clientForm}>
+          <form
+            onSubmit={clientForm.handleSubmit((v) => onProfileSubmit(v))}
+            className="space-y-6"
+          >
+            <div>
+              <h1 className="text-2xl font-bold">Tell us about your company</h1>
+              <p className="text-muted-foreground mt-1">Help us match you with the right creators.</p>
+            </div>
+            <FormField
+              control={clientForm.control}
+              name="companyName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Company name</FormLabel>
+                  <FormControl><Input placeholder="Acme Inc." {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={clientForm.control}
+              name="projectType"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Project type</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger><SelectValue placeholder="Select type" /></SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {PROJECT_TYPES.map((t) => (
+                        <SelectItem key={t} value={t}>{t}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={clientForm.control}
+              name="budgetRange"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Budget range</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger><SelectValue placeholder="Select budget" /></SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {BUDGET_RANGES.map((b) => (
+                        <SelectItem key={b} value={b}>{b}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="flex gap-3">
+              <Button type="button" variant="outline" onClick={() => goToStep(1)}>Back</Button>
+              <Button type="submit">Continue</Button>
+            </div>
+          </form>
+        </Form>
+      )}
+
+      {step === 3 && (
+        <div className="space-y-6">
+          <div>
+            <h1 className="text-2xl font-bold">
+              {role === "CREATOR" ? "Featured bounties" : "Top creators"}
+            </h1>
+            <p className="text-muted-foreground mt-1">
+              {role === "CREATOR"
+                ? "Browse open bounties and apply to get started."
+                : "Explore top-rated creators ready for your next project."}
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-1">
+            {role === "CREATOR"
+              ? bounties.slice(0, 3).map((b) => (
+                  <Link
+                    key={b.id}
+                    href={`/bounties/${b.id}`}
+                    className="block rounded-lg border p-4 hover:border-primary transition-colors"
+                  >
+                    <p className="font-semibold">{b.title}</p>
+                    <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{b.description}</p>
+                    <p className="text-sm font-medium mt-2">${b.budget.toLocaleString()}</p>
+                  </Link>
+                ))
+              : creators.slice(0, 3).map((c) => (
+                  <CreatorCard key={c.id} creator={c} />
+                ))}
+          </div>
+          <div className="flex gap-3">
+            <Button type="button" variant="outline" onClick={() => goToStep(2)}>Back</Button>
+            <Button onClick={() => completeOnboarding(false)}>Get started</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/profile/profile-completion-indicator.tsx
+++ b/components/profile/profile-completion-indicator.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import Link from 'next/link';
+import { computeProfileCompletion, type CreatorProfileFields } from '@/lib/profile-completion';
+import { cn } from '@/lib/utils';
+
+interface ProfileCompletionIndicatorProps {
+  profile: CreatorProfileFields;
+  className?: string;
+}
+
+export function ProfileCompletionIndicator({
+  profile,
+  className,
+}: ProfileCompletionIndicatorProps) {
+  const { percentage, missing } = computeProfileCompletion(profile);
+
+  const radius = 40;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (percentage / 100) * circumference;
+
+  return (
+    <div className={cn('rounded-lg border p-6 space-y-4', className)}>
+      <div className="flex items-center gap-6">
+        <div className="relative h-24 w-24 shrink-0">
+          <svg className="h-24 w-24 -rotate-90" viewBox="0 0 100 100">
+            <circle
+              cx="50"
+              cy="50"
+              r={radius}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="8"
+              className="text-muted"
+            />
+            <circle
+              cx="50"
+              cy="50"
+              r={radius}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="8"
+              strokeDasharray={circumference}
+              strokeDashoffset={offset}
+              strokeLinecap="round"
+              className="text-primary transition-all duration-300"
+            />
+          </svg>
+          <span className="absolute inset-0 flex items-center justify-center text-lg font-bold">
+            {percentage}%
+          </span>
+        </div>
+        <div>
+          <h3 className="font-semibold">Profile completion</h3>
+          <p className="text-sm text-muted-foreground mt-1">
+            Profiles with &gt;80% completion get 3× more inquiries.
+          </p>
+        </div>
+      </div>
+
+      {missing.length > 0 && (
+        <ul className="space-y-2">
+          {missing.map((field) => (
+            <li key={field.key} className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">{field.label}</span>
+              <Link href={field.href} className="text-primary hover:underline font-medium">
+                Complete
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: stellar
+description: Stellar Creator Portfolio — production umbrella chart
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+dependencies:
+  - name: api
+    version: 0.1.0
+    repository: "file://charts/api"
+  - name: auth
+    version: 0.1.0
+    repository: "file://charts/auth"
+  - name: notifications
+    version: 0.1.0
+    repository: "file://charts/notifications"
+  - name: indexer
+    version: 0.1.0
+    repository: "file://charts/indexer"
+  - name: next-app
+    version: 0.1.0
+    repository: "file://charts/next-app"

--- a/helm/charts/api/Chart.yaml
+++ b/helm/charts/api/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: api
+description: Stellar Platform – Rust API service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/charts/api/templates/_helpers.tpl
+++ b/helm/charts/api/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{- define "stellar-microservice.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "stellar-microservice.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "stellar-microservice.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "stellar-microservice.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/charts/api/templates/deployment.yaml
+++ b/helm/charts/api/templates/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}-config
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.config }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{ include "stellar-microservice.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels: {{ include "stellar-microservice.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "stellar-microservice.fullname" . }}-config
+            - secretRef:
+                name: {{ include "stellar-microservice.fullname" . }}-secrets
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml .Values.readinessProbe | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector: {{ include "stellar-microservice.selectorLabels" . | nindent 4 }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels: {{ include "stellar-microservice.selectorLabels" . | nindent 6 }}
+---
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "stellar-microservice.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}-external
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "stellar-microservice.fullname" . }}-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: {{ .Values.secrets.awsSecretName }}

--- a/helm/charts/api/values.yaml
+++ b/helm/charts/api/values.yaml
@@ -1,0 +1,49 @@
+# #804 — stellar-api production values
+replicaCount: 3
+
+image:
+  repository: ghcr.io/tukura11/stellar-api
+  pullPolicy: IfNotPresent
+  tag: ""
+
+service:
+  type: ClusterIP
+  port: 3001
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+config:
+  RUST_LOG: "info"
+  API_PORT: "3001"
+
+secrets:
+  awsSecretName: stellar/api
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 3001
+  initialDelaySeconds: 10
+  periodSeconds: 15
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 3001
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+pdb:
+  minAvailable: 1

--- a/helm/charts/auth/Chart.yaml
+++ b/helm/charts/auth/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: auth
+description: Stellar Platform – Auth service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/charts/auth/templates/_helpers.tpl
+++ b/helm/charts/auth/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{- define "stellar-microservice.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "stellar-microservice.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "stellar-microservice.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "stellar-microservice.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/charts/auth/templates/deployment.yaml
+++ b/helm/charts/auth/templates/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}-config
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.config }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{ include "stellar-microservice.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels: {{ include "stellar-microservice.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "stellar-microservice.fullname" . }}-config
+            - secretRef:
+                name: {{ include "stellar-microservice.fullname" . }}-secrets
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml .Values.readinessProbe | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector: {{ include "stellar-microservice.selectorLabels" . | nindent 4 }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels: {{ include "stellar-microservice.selectorLabels" . | nindent 6 }}
+---
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "stellar-microservice.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}-external
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "stellar-microservice.fullname" . }}-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: {{ .Values.secrets.awsSecretName }}

--- a/helm/charts/auth/values.yaml
+++ b/helm/charts/auth/values.yaml
@@ -1,0 +1,48 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/tukura11/stellar-auth
+  pullPolicy: IfNotPresent
+  tag: ""
+
+service:
+  type: ClusterIP
+  port: 3002
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+config:
+  RUST_LOG: "info"
+  AUTH_PORT: "3002"
+
+secrets:
+  awsSecretName: stellar/auth
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 3002
+  initialDelaySeconds: 10
+  periodSeconds: 15
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 3002
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+pdb:
+  minAvailable: 1

--- a/helm/charts/indexer/Chart.yaml
+++ b/helm/charts/indexer/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: indexer
+description: Stellar Platform – Soroban indexer
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/charts/indexer/templates/_helpers.tpl
+++ b/helm/charts/indexer/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{- define "stellar-microservice.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "stellar-microservice.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "stellar-microservice.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "stellar-microservice.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/charts/indexer/templates/deployment.yaml
+++ b/helm/charts/indexer/templates/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}-config
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.config }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{ include "stellar-microservice.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels: {{ include "stellar-microservice.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "stellar-microservice.fullname" . }}-config
+            - secretRef:
+                name: {{ include "stellar-microservice.fullname" . }}-secrets
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml .Values.readinessProbe | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector: {{ include "stellar-microservice.selectorLabels" . | nindent 4 }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels: {{ include "stellar-microservice.selectorLabels" . | nindent 6 }}
+---
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "stellar-microservice.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}-external
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "stellar-microservice.fullname" . }}-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: {{ .Values.secrets.awsSecretName }}

--- a/helm/charts/indexer/values.yaml
+++ b/helm/charts/indexer/values.yaml
@@ -1,0 +1,45 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/tukura11/stellar-indexer
+  pullPolicy: IfNotPresent
+  tag: ""
+
+service:
+  type: ClusterIP
+  port: 3004
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: false
+
+config:
+  RUST_LOG: "info"
+  STELLAR_NETWORK: "mainnet"
+
+secrets:
+  awsSecretName: stellar/indexer
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 3004
+  initialDelaySeconds: 15
+  periodSeconds: 30
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 3004
+  initialDelaySeconds: 10
+  periodSeconds: 15
+
+pdb:
+  minAvailable: 1

--- a/helm/charts/next-app/Chart.yaml
+++ b/helm/charts/next-app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: next-app
+description: Stellar Platform – Next.js frontend
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/charts/next-app/templates/_helpers.tpl
+++ b/helm/charts/next-app/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{- define "stellar-microservice.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "stellar-microservice.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "stellar-microservice.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "stellar-microservice.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/charts/next-app/templates/deployment.yaml
+++ b/helm/charts/next-app/templates/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}-config
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.config }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{ include "stellar-microservice.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels: {{ include "stellar-microservice.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "stellar-microservice.fullname" . }}-config
+            - secretRef:
+                name: {{ include "stellar-microservice.fullname" . }}-secrets
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml .Values.readinessProbe | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector: {{ include "stellar-microservice.selectorLabels" . | nindent 4 }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels: {{ include "stellar-microservice.selectorLabels" . | nindent 6 }}
+---
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "stellar-microservice.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}-external
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "stellar-microservice.fullname" . }}-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: {{ .Values.secrets.awsSecretName }}

--- a/helm/charts/next-app/values.yaml
+++ b/helm/charts/next-app/values.yaml
@@ -1,0 +1,48 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/tukura11/stellar-next-app
+  pullPolicy: IfNotPresent
+  tag: ""
+
+service:
+  type: ClusterIP
+  port: 3000
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+config:
+  NODE_ENV: "production"
+  PORT: "3000"
+
+secrets:
+  awsSecretName: stellar/next-app
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 3000
+  initialDelaySeconds: 10
+  periodSeconds: 15
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 3000
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+pdb:
+  minAvailable: 1

--- a/helm/charts/notifications/Chart.yaml
+++ b/helm/charts/notifications/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: notifications
+description: Stellar Platform – Notification service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/charts/notifications/templates/_helpers.tpl
+++ b/helm/charts/notifications/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{- define "stellar-microservice.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "stellar-microservice.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "stellar-microservice.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "stellar-microservice.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/charts/notifications/templates/deployment.yaml
+++ b/helm/charts/notifications/templates/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}-config
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.config }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{ include "stellar-microservice.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels: {{ include "stellar-microservice.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "stellar-microservice.fullname" . }}-config
+            - secretRef:
+                name: {{ include "stellar-microservice.fullname" . }}-secrets
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml .Values.readinessProbe | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector: {{ include "stellar-microservice.selectorLabels" . | nindent 4 }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels: {{ include "stellar-microservice.selectorLabels" . | nindent 6 }}
+---
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "stellar-microservice.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "stellar-microservice.fullname" . }}-external
+  labels: {{ include "stellar-microservice.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "stellar-microservice.fullname" . }}-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: {{ .Values.secrets.awsSecretName }}

--- a/helm/charts/notifications/values.yaml
+++ b/helm/charts/notifications/values.yaml
@@ -1,0 +1,48 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/tukura11/stellar-notifications
+  pullPolicy: IfNotPresent
+  tag: ""
+
+service:
+  type: ClusterIP
+  port: 3003
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+config:
+  RUST_LOG: "info"
+  NOTIFICATIONS_PORT: "3003"
+
+secrets:
+  awsSecretName: stellar/notifications
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 3003
+  initialDelaySeconds: 10
+  periodSeconds: 15
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 3003
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+pdb:
+  minAvailable: 1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,11 @@
+# Umbrella values — override per subchart
+api:
+  enabled: true
+auth:
+  enabled: true
+notifications:
+  enabled: true
+indexer:
+  enabled: true
+next-app:
+  enabled: true

--- a/lib/api-keys.ts
+++ b/lib/api-keys.ts
@@ -1,0 +1,19 @@
+import { createHash, randomBytes } from 'crypto';
+
+export const API_KEY_PREFIX = 'sk_';
+
+export function generateApiKey(): { rawKey: string; keyHash: string } {
+  const rawKey = `${API_KEY_PREFIX}${randomBytes(24).toString('hex')}`;
+  const keyHash = hashApiKey(rawKey);
+  return { rawKey, keyHash };
+}
+
+export function hashApiKey(rawKey: string): string {
+  return createHash('sha256').update(rawKey).digest('hex');
+}
+
+export type ApiKeyScope = 'read-only' | 'read-write';
+
+export function parseScopes(scopes: string[]): ApiKeyScope[] {
+  return scopes.filter((s): s is ApiKeyScope => s === 'read-only' || s === 'read-write');
+}

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -1,0 +1,6 @@
+import { getServerSession as nextAuthGetServerSession } from 'next-auth';
+import { authOptions } from './config';
+
+export function getServerSession() {
+  return nextAuthGetServerSession(authOptions);
+}

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -1,0 +1,83 @@
+import type { NextAuthOptions } from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import { createHash, scryptSync, timingSafeEqual } from 'crypto';
+import { prisma } from '@/lib/prisma';
+
+function hashPassword(password: string): string {
+  const salt = createHash('sha256').update('stellar-salt').digest();
+  const hash = scryptSync(password, salt, 64);
+  return hash.toString('hex');
+}
+
+function verifyPassword(password: string, stored: string): boolean {
+  const salt = createHash('sha256').update('stellar-salt').digest();
+  const hash = scryptSync(password, salt, 64);
+  const storedBuf = Buffer.from(stored, 'hex');
+  if (hash.length !== storedBuf.length) return false;
+  return timingSafeEqual(hash, storedBuf);
+}
+
+export const authOptions: NextAuthOptions = {
+  session: { strategy: 'jwt' },
+  pages: {
+    signIn: '/auth/login',
+  },
+  providers: [
+    CredentialsProvider({
+      name: 'credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials?.password) return null;
+
+        const user = await prisma.user.findUnique({
+          where: { email: credentials.email },
+        });
+        if (!user?.password || !user.emailVerified) return null;
+        if (!verifyPassword(credentials.password, user.password)) return null;
+
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+          emailVerified: user.emailVerified?.toISOString() ?? null,
+          onboardingCompleted: !!user.onboardingCompletedAt,
+        };
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user, trigger }) {
+      if (user) {
+        token.id = user.id;
+        token.role = user.role;
+        token.emailVerified = (user as { emailVerified?: string | null }).emailVerified ?? null;
+        token.onboardingCompleted = (user as { onboardingCompleted?: boolean }).onboardingCompleted ?? false;
+      }
+      if (trigger === 'update' && token.id) {
+        const dbUser = await prisma.user.findUnique({
+          where: { id: token.id as string },
+          select: { onboardingCompletedAt: true, emailVerified: true, role: true },
+        });
+        if (dbUser) {
+          token.onboardingCompleted = !!dbUser.onboardingCompletedAt;
+          token.emailVerified = dbUser.emailVerified?.toISOString() ?? null;
+          token.role = dbUser.role;
+        }
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.id = token.id as string;
+        session.user.role = (token.role as string) ?? 'USER';
+      }
+      return session;
+    },
+  },
+};
+
+export { hashPassword };

--- a/lib/profile-completion.ts
+++ b/lib/profile-completion.ts
@@ -1,0 +1,101 @@
+export interface CreatorProfileFields {
+  displayName?: string | null;
+  avatar?: string | null;
+  bio?: string | null;
+  skills?: string[];
+  portfolio?: unknown;
+  githubUrl?: string | null;
+  linkedinUrl?: string | null;
+  verified?: boolean;
+}
+
+export interface ProfileCompletionField {
+  key: string;
+  label: string;
+  weight: number;
+  complete: boolean;
+  href: string;
+}
+
+export interface ProfileCompletionResult {
+  percentage: number;
+  fields: ProfileCompletionField[];
+  missing: ProfileCompletionField[];
+}
+
+function hasPortfolioItem(portfolio: unknown): boolean {
+  if (!portfolio) return false;
+  if (Array.isArray(portfolio)) return portfolio.length > 0;
+  if (typeof portfolio === 'object' && portfolio !== null) {
+    const obj = portfolio as Record<string, unknown>;
+    if (Array.isArray(obj.items)) return obj.items.length > 0;
+    if (Array.isArray(obj.sections)) return obj.sections.length > 0;
+    return Object.keys(obj).length > 0;
+  }
+  return false;
+}
+
+export function computeProfileCompletion(
+  profile: CreatorProfileFields,
+): ProfileCompletionResult {
+  const checks: ProfileCompletionField[] = [
+    {
+      key: 'displayName',
+      label: 'Display name',
+      weight: 10,
+      complete: !!profile.displayName && profile.displayName.length >= 2,
+      href: '/profile/edit#displayName',
+    },
+    {
+      key: 'avatar',
+      label: 'Profile photo',
+      weight: 15,
+      complete: !!profile.avatar,
+      href: '/profile/edit#avatar',
+    },
+    {
+      key: 'bio',
+      label: 'Bio',
+      weight: 20,
+      complete: !!profile.bio && profile.bio.trim().length > 0,
+      href: '/profile/edit#bio',
+    },
+    {
+      key: 'skills',
+      label: '3+ skills',
+      weight: 15,
+      complete: (profile.skills?.length ?? 0) >= 3,
+      href: '/profile/edit#skills',
+    },
+    {
+      key: 'portfolio',
+      label: 'Portfolio sample',
+      weight: 25,
+      complete: hasPortfolioItem(profile.portfolio),
+      href: '/profile/edit#portfolio',
+    },
+    {
+      key: 'social',
+      label: 'GitHub or LinkedIn',
+      weight: 10,
+      complete: !!(profile.githubUrl || profile.linkedinUrl),
+      href: '/profile/edit#social',
+    },
+    {
+      key: 'verified',
+      label: 'Verified account',
+      weight: 5,
+      complete: !!profile.verified,
+      href: '/profile/edit#verification',
+    },
+  ];
+
+  const percentage = checks.reduce(
+    (sum, field) => sum + (field.complete ? field.weight : 0),
+    0,
+  );
+
+  const missing = checks.filter((f) => !f.complete);
+
+  return { percentage, fields: checks, missing };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,21 +1,45 @@
-/**
- * Next.js middleware
- */
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
 
-// Middleware function
-export function middleware() {
-  // Currently no middleware needed
+const ONBOARDING_PATH = '/onboarding';
+const PROTECTED_PREFIXES = ['/dashboard', '/profile', '/onboarding'];
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  const token = await getToken({
+    req,
+    secret: process.env.NEXTAUTH_SECRET,
+  });
+
+  const isProtected = PROTECTED_PREFIXES.some((p) => pathname.startsWith(p));
+
+  if (!token && isProtected) {
+    const login = new URL('/auth/login', req.url);
+    login.searchParams.set('callbackUrl', pathname);
+    return NextResponse.redirect(login);
+  }
+
+  if (token && pathname.startsWith('/onboarding')) {
+    return NextResponse.next();
+  }
+
+  if (
+    token &&
+    token.emailVerified &&
+    !token.onboardingCompleted &&
+    !pathname.startsWith(ONBOARDING_PATH) &&
+    !pathname.startsWith('/api') &&
+    isProtected
+  ) {
+    return NextResponse.redirect(new URL(ONBOARDING_PATH, req.url));
+  }
+
+  return NextResponse.next();
 }
 
 export const config = {
   matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - api (API routes)
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     */
     '/((?!api|_next/static|_next/image|favicon.ico).*)',
   ],
-}
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,7 @@ model User {
   onboardingStep        Int       @default(0)
   onboardingCompletedAt DateTime?
   onboardingData        Json?
+  apiKeys               ApiKey[]
   matchFeedback       MatchFeedback[]
   matchNotifications  MatchNotification[]
   auditLogs           AuditLog[]
@@ -170,6 +171,23 @@ model ClientProfile {
   updatedAt   DateTime @updatedAt
 
   @@index([userId])
+}
+
+model ApiKey {
+  id         String    @id @default(cuid())
+  userId     String
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  keyHash    String    @unique
+  name       String
+  scopes     String[]
+  lastUsedAt DateTime?
+  expiresAt  DateTime?
+  revokedAt  DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+
+  @@index([userId])
+  @@index([keyHash])
 }
 
 model Bounty {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,9 @@ model User {
   inAppNotifications     InAppNotification[]
   emailDeliveryLogs      EmailDeliveryLog[]
   emailUnsubscribeToken  String? @unique
+  onboardingStep        Int       @default(0)
+  onboardingCompletedAt DateTime?
+  onboardingData        Json?
   matchFeedback       MatchFeedback[]
   matchNotifications  MatchNotification[]
   auditLogs           AuditLog[]
@@ -154,6 +157,8 @@ model ClientProfile {
   userId      String   @unique
   user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   companyName String?
+  projectType String?
+  budgetRange String?
   bio         String?
   avatar      String?
   verified    Boolean  @default(false)

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -17,5 +17,7 @@ declare module "next-auth/jwt" {
   interface JWT {
     id?: string
     role?: string
+    emailVerified?: string | null
+    onboardingCompleted?: boolean
   }
 }


### PR DESCRIPTION
Summary
This PR adds a post-verification onboarding wizard for new Creator and Client users, a profile completion score with real-time nudges on the edit page, production Kubernetes Helm charts for all microservices, and a developer API key management dashboard with hashed key storage.

Changes
#798 — Onboarding wizard
Added onboardingStep, onboardingCompletedAt, and onboardingData to the Prisma User model
Created /onboarding 3-step wizard (role → profile → featured content) with react-hook-form, progress bar, and skip link
Added NextAuth credentials config, email verification redirect (/api/auth/verify-email), and /api/onboarding for server-side state persistence
Middleware redirects verified users without completed onboarding to /onboarding
Plausible analytics events for step completion and onboarding completion
#797 — Profile completion percentage
Added lib/profile-completion.ts with weighted scoring (display name 10%, avatar 15%, bio 20%, 3+ skills 15%, portfolio 25%, social 10%, verified 5%)
Added ProfileCompletionIndicator with progress ring, missing-field prompts, and “>80% completion” banner
Extended ProfileForm with avatar, skills, and portfolio fields; updates percentage in real time via useWatch
Added GET /api/profile/completion and unit tests
#804 — Kubernetes Helm charts
Added umbrella chart at helm/ with subcharts: api (3 replicas, HPA 3–10), auth (2), notifications (2), indexer (1, no HPA), next-app (2)
Each chart includes Deployment, Service, ConfigMap, ExternalSecret, PodDisruptionBudget, and HPA (CPU > 70%)
Added /ready endpoint to Rust API; added /health and /ready routes for Next.js
Added .github/workflows/helm.yml for lint/template validation on every PR
#800 — API key management
Added ApiKey Prisma model with hashed keys (keyHash), scopes, expiry, and revocation
Added POST/GET /api/developer/keys and DELETE /api/developer/keys/:id
Added /dashboard/api-keys page with create (key shown once), revoke, and usage graph placeholder
Added lib/api-keys.ts helpers and unit tests
Notes
Onboarding builds on new NextAuth credentials config (lib/auth/config.ts) since no prior web auth routes existed; email verification redirects to /onboarding instead of /dashboard.
Profile completion weights match the issue spec; portfolio is inferred from a portfolio URL field or JSON items array.
Helm charts follow the existing infrastructure/k8s/helm/api pattern but live under helm/charts/ per issue #804; ExternalSecrets assume AWS Secrets Manager via external-secrets.io.
API keys are SHA-256 hashed in PostgreSQL; raw key is returned only on creation. Rate limiting per key is not wired yet (existing backend/limit service is separate).
Closes #798, Closes #797, Closes #804, Closes #800