### PR TITLE
feat(search): Postgres FTS fallback for creator discovery

### DIFF
--- a/backend/services/search.ts
+++ b/backend/services/search.ts
@@ -22,6 +22,8 @@
 
 import { Client as ElasticClient } from '@elastic/elasticsearch';
 import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
 // ── Configuration ────────────────────────────────────────────────────────────
 
@@ -432,10 +434,23 @@ export async function hybridSearch(
 
   // ── 3. Run both queries in parallel ──────────────────────────────────────
 
-  const [lexicalResult, semanticResult] = await Promise.all([
-    lexicalPromise,
-    semanticPromise,
-  ]);
+  let lexicalResult: Awaited<typeof lexicalPromise>;
+  let semanticResult: Awaited<typeof semanticPromise>;
+  try {
+    [lexicalResult, semanticResult] = await Promise.all([
+      lexicalPromise,
+      semanticPromise,
+    ]);
+  } catch (err) {
+    // Elasticsearch unreachable — serve relevant results from Postgres FTS
+    // instead of failing the request.
+    if (isConnectionError(err)) {
+      // Swallow the unhandled rejection from whichever promise didn't settle.
+      void Promise.allSettled([lexicalPromise, semanticPromise]);
+      return postgresFtsSearch(options);
+    }
+    throw err;
+  }
 
   // ── 4. Reciprocal Rank Fusion ─────────────────────────────────────────────
 
@@ -521,6 +536,95 @@ export async function hybridSearch(
   });
 
   return merged.slice(0, limit);
+}
+
+// ── Postgres full-text fallback ────────────────────────────────────────────────
+
+/** True if the error looks like Elasticsearch being unreachable. */
+function isConnectionError(err: unknown): boolean {
+  const message =
+    err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+  const name = (err as { name?: string })?.name ?? '';
+  return (
+    name === 'ConnectionError' ||
+    message.includes('ECONNREFUSED') ||
+    message.includes('ENOTFOUND') ||
+    message.includes('ETIMEDOUT') ||
+    message.includes('connect')
+  );
+}
+
+/** Build a prefix tsquery: "rust dev" → "rust:* & dev:*" for autocomplete. */
+function toPrefixTsQuery(query: string): string {
+  return query
+    .trim()
+    .split(/\s+/)
+    .map((term) => term.replace(/[^\p{L}\p{N}]/gu, ''))
+    .filter(Boolean)
+    .map((term) => `${term}:*`)
+    .join(' & ');
+}
+
+interface CreatorFtsRow {
+  id: string;
+  displayName: string;
+  discipline: string | null;
+  skills: string[];
+  verified: boolean;
+  rating: number;
+  completedProjects: number;
+  rank: number;
+}
+
+/**
+ * Postgres full-text search over CreatorProfile.fts (GIN-indexed tsvector) with
+ * prefix matching for autocomplete and pg_trgm similarity for typo tolerance.
+ * Case-insensitive. Used as the fallback when Elasticsearch is unreachable.
+ */
+export async function postgresFtsSearch(
+  options: HybridSearchOptions,
+): Promise<SearchResult[]> {
+  const { query, limit = 10, discipline, skills, verifiedOnly = false } = options;
+  if (!query.trim()) return [];
+
+  const tsquery = toPrefixTsQuery(query);
+  if (!tsquery) return [];
+
+  const filters: Prisma.Sql[] = [];
+  if (discipline) filters.push(Prisma.sql`"discipline" = ${discipline}`);
+  if (skills?.length) filters.push(Prisma.sql`"skills" @> ${skills}`);
+  if (verifiedOnly) filters.push(Prisma.sql`"verified" = true`);
+  const whereExtra = filters.length
+    ? Prisma.sql`AND ${Prisma.join(filters, ' AND ')}`
+    : Prisma.empty;
+
+  const rows = await prisma.$queryRaw<CreatorFtsRow[]>`
+    SELECT "id", "displayName", "discipline", "skills", "verified", "rating",
+           "completedProjects",
+           ts_rank("fts", to_tsquery('english', ${tsquery})) AS rank
+    FROM "CreatorProfile"
+    WHERE ("fts" @@ to_tsquery('english', ${tsquery})
+           OR similarity("displayName", ${query}) > 0.3)
+      ${whereExtra}
+    ORDER BY rank DESC, "verified" DESC, "rating" DESC
+    LIMIT ${limit}
+  `;
+
+  return rows.map((row) => ({
+    id: row.id,
+    displayName: row.displayName,
+    discipline: row.discipline,
+    skills: row.skills ?? [],
+    verified: row.verified,
+    rating: Number(row.rating),
+    completedProjects: row.completedProjects,
+    score: Number(row.rank),
+    scoreBreakdown: {
+      lexical: Number(row.rank),
+      semantic: 0,
+      rrf: Number(row.rank),
+    },
+  }));
 }
 
 // ── Cluster health ────────────────────────────────────────────────────────────

--- a/prisma/migrations/20260626010000_add_creator_fts/migration.sql
+++ b/prisma/migrations/20260626010000_add_creator_fts/migration.sql
@@ -1,0 +1,26 @@
+-- Postgres full-text search for creator discovery.
+-- Issue #776: Add full-text search indexes for creators in Postgres so the
+-- hybrid search endpoint can serve relevant, typo-tolerant results without
+-- Elasticsearch.
+
+-- pg_trgm powers similarity()/fuzzy matching for typo tolerance.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Generated tsvector column keeps the search document in sync automatically on
+-- every INSERT/UPDATE. English stemming handles plurals and stop-words.
+-- Weights: name + discipline (A), bio + skills (B).
+ALTER TABLE "CreatorProfile"
+  ADD COLUMN IF NOT EXISTS "fts" tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('english', coalesce("displayName", '')), 'A') ||
+    setweight(to_tsvector('english', coalesce("discipline", '')), 'A') ||
+    setweight(to_tsvector('english', coalesce("bio", '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(array_to_string("skills", ' '), '')), 'B')
+  ) STORED;
+
+CREATE INDEX IF NOT EXISTS "CreatorProfile_fts_idx"
+  ON "CreatorProfile" USING GIN ("fts");
+
+-- Trigram index for typo-tolerant prefix matching on display names.
+CREATE INDEX IF NOT EXISTS "CreatorProfile_displayName_trgm_idx"
+  ON "CreatorProfile" USING GIN ("displayName" gin_trgm_ops);


### PR DESCRIPTION
## Summary
Wires Postgres full-text search into the hybrid search path so creator discovery returns relevant, typo-tolerant results without depending on Elasticsearch.

- Migration adds a generated `fts` tsvector column (name + discipline weighted A, bio + skills weighted B) with a GIN index on `CreatorProfile`, plus the `pg_trgm` extension and a trigram GIN index on `displayName` for typo tolerance
- New `postgresFtsSearch()` uses prefix `to_tsquery` matching (autocomplete) and `similarity()` for fuzzy name matches; case-insensitive; honours discipline/skills/verified filters
- `hybridSearch()` falls back to Postgres FTS when Elasticsearch is unreachable instead of failing the request

Closes #776

## Validation
- Type/flow reviewed against existing `SearchResult`/`HybridSearchOptions` contracts; uses `Prisma.sql` for safe parameterised filters
- Repo toolchain (eslint/tsc) and DB migration could not be executed locally (dependencies not installed, no database in this environment)