### PR TITLE
feat(portfolio): token-gated premium content via NFT ownership

### DIFF
--- a/components/portfolio/token-gate.tsx
+++ b/components/portfolio/token-gate.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { Lock } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useStellarWallet } from '@/hooks/useStellarWallet';
+import { hasTokenBalance } from '@/lib/stellar/token-gate';
+
+type GateState = 'idle' | 'checking' | 'locked' | 'unlocked';
+
+interface TokenGateProps {
+  /** Soroban token contract address (the Stellar asset) required to view. */
+  tokenContractId: string;
+  /** Unlock price the creator set. */
+  price: number;
+  /** Currency the price is denominated in. */
+  priceAsset?: 'XLM' | 'USDC';
+  /**
+   * Mints/purchases the gating token via the escrow contract. Resolves once the
+   * holder owns the token; the gate then re-checks and reveals the content.
+   */
+  onUnlock?: () => Promise<void>;
+  /** Premium content shown only to token holders. */
+  children: ReactNode;
+}
+
+/**
+ * Gates premium portfolio content behind on-chain token ownership.
+ *
+ * Holders see the content; non-holders see a blurred preview with a lock
+ * overlay and an "Unlock" button. The ownership check runs entirely
+ * client-side against the public Soroban RPC — no server secret required.
+ */
+export function TokenGate({
+  tokenContractId,
+  price,
+  priceAsset = 'XLM',
+  onUnlock,
+  children,
+}: TokenGateProps) {
+  const { publicKey, isConnected, connect } = useStellarWallet();
+  const [state, setState] = useState<GateState>('idle');
+  const [unlocking, setUnlocking] = useState(false);
+
+  const check = useCallback(async () => {
+    if (!publicKey) {
+      setState('idle');
+      return;
+    }
+    setState('checking');
+    try {
+      const owns = await hasTokenBalance(tokenContractId, publicKey);
+      setState(owns ? 'unlocked' : 'locked');
+    } catch {
+      setState('locked');
+    }
+  }, [publicKey, tokenContractId]);
+
+  useEffect(() => {
+    void check();
+  }, [check]);
+
+  const handleUnlock = useCallback(async () => {
+    if (!isConnected) {
+      await connect();
+      return;
+    }
+    setUnlocking(true);
+    try {
+      await onUnlock?.();
+      await check();
+    } finally {
+      setUnlocking(false);
+    }
+  }, [isConnected, connect, onUnlock, check]);
+
+  if (state === 'unlocked') {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="relative overflow-hidden rounded-lg">
+      <div className="pointer-events-none select-none blur-md" aria-hidden="true">
+        {children}
+      </div>
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background/60 p-6 text-center backdrop-blur-sm">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <Lock size={22} />
+        </div>
+        <p className="text-sm font-medium text-foreground">Premium content</p>
+        <Button onClick={handleUnlock} disabled={state === 'checking' || unlocking}>
+          {state === 'checking'
+            ? 'Checking access…'
+            : unlocking
+              ? 'Unlocking…'
+              : isConnected
+                ? `Unlock for ${price} ${priceAsset}`
+                : 'Connect wallet to unlock'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/lib/stellar/token-gate.ts
+++ b/lib/stellar/token-gate.ts
@@ -1,0 +1,76 @@
+/**
+ * Client-side NFT / token ownership checks for gated portfolio content.
+ *
+ * The balance is read by simulating the token contract's `balance(address)`
+ * view method against the public Soroban RPC. Simulation is read-only and
+ * requires no signing and no admin/server secret — safe to run in the browser.
+ */
+
+import {
+  Account,
+  Address,
+  Contract,
+  Networks,
+  TransactionBuilder,
+  nativeToScVal,
+  scValToNative,
+  rpc,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+const RPC_URL =
+  process.env.NEXT_PUBLIC_STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const NETWORK_PASSPHRASE =
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
+
+/**
+ * Read a holder's balance of a Soroban token contract. Returns the raw token
+ * amount as a bigint (0 when the holder has no trustline / balance).
+ */
+export async function getTokenBalance(
+  tokenContractId: string,
+  holderPublicKey: string,
+): Promise<bigint> {
+  const server = new rpc.Server(RPC_URL);
+  const contract = new Contract(tokenContractId);
+
+  // A throwaway source account is fine — simulation never touches the ledger.
+  const source = new Account(holderPublicKey, '0');
+
+  const tx = new TransactionBuilder(source, {
+    fee: '100',
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      contract.call(
+        'balance',
+        nativeToScVal(Address.fromString(holderPublicKey), { type: 'address' }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(sim) || !sim.result?.retval) {
+    return 0n;
+  }
+
+  try {
+    return BigInt(scValToNative(sim.result.retval as xdr.ScVal));
+  } catch {
+    return 0n;
+  }
+}
+
+/**
+ * Whether a holder owns at least `minAmount` (default 1) of the token — i.e.
+ * passes the ownership gate.
+ */
+export async function hasTokenBalance(
+  tokenContractId: string,
+  holderPublicKey: string,
+  minAmount: bigint = 1n,
+): Promise<boolean> {
+  const balance = await getTokenBalance(tokenContractId, holderPublicKey);
+  return balance >= minAmount;
+}


### PR DESCRIPTION
## Summary
Lets creators gate premium portfolio content behind on-chain token ownership.

- `lib/stellar/token-gate.ts` — reads a holder's balance of a Soroban token by simulating the contract's `balance(address)` view method against the public RPC. Read-only, no signing, no server/admin secret (runs client-side)
- `components/portfolio/token-gate.tsx` — `TokenGate` wraps premium content: holders see it, non-holders see a blurred preview with a lock overlay and an "Unlock for X XLM/USDC" button. On unlock it mints via the supplied escrow callback, re-checks ownership, and reveals immediately

Closes #779

## Acceptance criteria
- [x] Gated content shows blur/lock overlay to non-holders
- [x] Purchase mints a token and unlocks content immediately (re-check after `onUnlock`)
- [x] Token balance check happens client-side (public RPC simulation, no server secret)
- [x] Creator sets price in XLM or USDC (`price` / `priceAsset` props)

## Validation
- Imports verified against the existing `@stellar/stellar-sdk` usage in `services/api/stellar` and the `useStellarWallet` hook
- Repo toolchain (eslint/tsc) not runnable locally (dependencies not installed in this environment)