### PR TITLE
feat: issues #762, #763, #764, #765 — geofencing, form validation, idempotency keys, reputation decay

### DIFF
--- a/__tests__/bounty-application-validation.test.ts
+++ b/__tests__/bounty-application-validation.test.ts
@@ -1,34 +1,64 @@
 import { describe, expect, it } from 'vitest'
-import { applicationSubmitSchema } from '@/lib/validators'
+import { bountyApplicationSchema } from '@/lib/validations/bounty-application'
 
-describe('applicationSubmitSchema', () => {
+describe('bountyApplicationSchema', () => {
   it('accepts valid proposal', () => {
-    const r = applicationSubmitSchema.safeParse({
+    const r = bountyApplicationSchema.safeParse({
       bounty_id: 'bounty-1',
       proposed_budget: 2500,
       timeline: 14,
-      proposal: 'a'.repeat(50),
+      proposal: 'a'.repeat(100),
     })
     expect(r.success).toBe(true)
   })
 
-  it('rejects short proposal', () => {
-    const r = applicationSubmitSchema.safeParse({
+  it('rejects short proposal (under 100 chars)', () => {
+    const r = bountyApplicationSchema.safeParse({
       bounty_id: 'bounty-1',
       proposed_budget: 100,
       timeline: 7,
-      proposal: 'short',
+      proposal: 'a'.repeat(99),
     })
     expect(r.success).toBe(false)
   })
 
   it('rejects negative budget', () => {
-    const r = applicationSubmitSchema.safeParse({
+    const r = bountyApplicationSchema.safeParse({
       bounty_id: 'bounty-1',
       proposed_budget: -1,
       timeline: 7,
-      proposal: 'a'.repeat(50),
+      proposal: 'a'.repeat(100),
     })
     expect(r.success).toBe(false)
+  })
+
+  it('rejects budget exceeding 1,000,000', () => {
+    const r = bountyApplicationSchema.safeParse({
+      bounty_id: 'bounty-1',
+      proposed_budget: 1_000_001,
+      timeline: 14,
+      proposal: 'a'.repeat(100),
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects timeline exceeding 365 days', () => {
+    const r = bountyApplicationSchema.safeParse({
+      bounty_id: 'bounty-1',
+      proposed_budget: 500,
+      timeline: 366,
+      proposal: 'a'.repeat(100),
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('accepts boundary values', () => {
+    const r = bountyApplicationSchema.safeParse({
+      bounty_id: 'bounty-1',
+      proposed_budget: 1_000_000,
+      timeline: 365,
+      proposal: 'a'.repeat(100),
+    })
+    expect(r.success).toBe(true)
   })
 })

--- a/app/api/payments/route.ts
+++ b/app/api/payments/route.ts
@@ -1,0 +1,232 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { getStripe, isStripeConfigured } from '@/lib/stripe'
+import {
+  createEscrow,
+  attachPaymentIntent,
+  getEscrow,
+  listEscrowsForUser,
+  markReleased,
+  markRefunded,
+} from '@/lib/payments/escrow-service'
+import { paymentPostBodySchema } from '@/lib/payments/payment-validators'
+import { validateRequest, formatZodErrors } from '@/lib/utils/validators'
+import { getCachedResponse, cacheResponse } from '@/lib/payments/idempotency'
+
+export const runtime = 'nodejs'
+
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const escrows = listEscrowsForUser(session.user.id)
+  return NextResponse.json({
+    escrows,
+    stripeConfigured: isStripeConfigured(),
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const idempotencyKey = request.headers.get('Idempotency-Key')
+  if (!idempotencyKey) {
+    return NextResponse.json(
+      { error: 'Missing Idempotency-Key header' },
+      { status: 400 },
+    )
+  }
+
+  const cached = getCachedResponse(idempotencyKey)
+  if (cached) {
+    return NextResponse.json(cached.body, { status: cached.status })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const parsed = validateRequest(paymentPostBodySchema, body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: formatZodErrors(parsed.errors) },
+      { status: 400 },
+    )
+  }
+
+  const data = parsed.data
+
+  if (data.type === 'bounty_escrow') {
+    if (session.user.role !== 'CLIENT' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Only clients can fund bounties' }, { status: 403 })
+    }
+
+    if (!isStripeConfigured()) {
+      return NextResponse.json(
+        { error: 'Payments are not configured (missing STRIPE_SECRET_KEY)' },
+        { status: 503 },
+      )
+    }
+
+    const escrow = createEscrow({
+      bountyId: data.bountyId,
+      clientUserId: session.user.id,
+      amountCents: data.amountCents,
+      currency: data.currency,
+    })
+
+    const stripe = getStripe()
+    const pi = await stripe.paymentIntents.create({
+      amount: data.amountCents,
+      currency: data.currency,
+      capture_method: 'manual',
+      automatic_payment_methods: { enabled: true },
+      metadata: {
+        escrowId: escrow.id,
+        bountyId: data.bountyId,
+        clientUserId: session.user.id,
+        kind: 'bounty_escrow',
+      },
+    })
+
+    attachPaymentIntent(escrow.id, pi.id)
+
+    const responseBody = {
+      escrowId: escrow.id,
+      clientSecret: pi.client_secret,
+      publishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? null,
+      amountCents: data.amountCents,
+      currency: data.currency,
+    }
+    cacheResponse(idempotencyKey, 200, responseBody)
+    return NextResponse.json(responseBody)
+  }
+
+  if (data.type === 'subscription') {
+    if (!isStripeConfigured()) {
+      return NextResponse.json({ error: 'Payments are not configured' }, { status: 503 })
+    }
+
+    const base = process.env.NEXTAUTH_URL ?? request.nextUrl.origin
+    const successUrl = data.successUrl ?? `${base}/dashboard/payments?session_id={CHECKOUT_SESSION_ID}`
+    const cancelUrl = data.cancelUrl ?? `${base}/dashboard/payments?canceled=1`
+
+    const stripe = getStripe()
+    const sessionCheckout = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      line_items: [{ price: data.priceId, quantity: 1 }],
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      customer_email: session.user.email ?? undefined,
+      metadata: { userId: session.user.id },
+    })
+
+    const responseBody = { url: sessionCheckout.url }
+    cacheResponse(idempotencyKey, 200, responseBody)
+    return NextResponse.json(responseBody)
+  }
+
+  if (data.type === 'escrow_release') {
+    if (session.user.role !== 'CLIENT' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const escrow = getEscrow(data.escrowId)
+    if (!escrow) {
+      return NextResponse.json({ error: 'Escrow not found' }, { status: 404 })
+    }
+    if (escrow.clientUserId !== session.user.id && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    if (escrow.status !== 'funded_authorized') {
+      return NextResponse.json({ error: 'Escrow is not in a releasable state' }, { status: 400 })
+    }
+    if (!escrow.paymentIntentId) {
+      return NextResponse.json({ error: 'Missing payment intent' }, { status: 400 })
+    }
+
+    if (!isStripeConfigured()) {
+      markReleased(escrow.id)
+      const responseBody = { ok: true, escrow: getEscrow(escrow.id), mode: 'simulated' }
+      cacheResponse(idempotencyKey, 200, responseBody)
+      return NextResponse.json(responseBody)
+    }
+
+    const stripe = getStripe()
+    const captured = await stripe.paymentIntents.capture(escrow.paymentIntentId, {
+      expand: ['latest_charge'],
+    })
+    const charge = captured.latest_charge
+    const receiptUrl =
+      typeof charge === 'object' && charge && !charge.deleted && 'receipt_url' in charge
+        ? (charge.receipt_url as string | null) ?? undefined
+        : undefined
+    markReleased(escrow.id, receiptUrl)
+
+    const responseBody = { ok: true, escrow: getEscrow(escrow.id), receiptUrl }
+    cacheResponse(idempotencyKey, 200, responseBody)
+    return NextResponse.json(responseBody)
+  }
+
+  if (data.type === 'escrow_refund') {
+    if (escrowRefundAllowed(session.user.role, session.user.id, data.escrowId) === false) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const escrow = getEscrow(data.escrowId)
+    if (!escrow) {
+      return NextResponse.json({ error: 'Escrow not found' }, { status: 404 })
+    }
+    if (escrow.status !== 'funded_authorized' && escrow.status !== 'pending_funding') {
+      return NextResponse.json({ error: 'Escrow cannot be refunded in this state' }, { status: 400 })
+    }
+
+    if (!isStripeConfigured()) {
+      markRefunded(escrow.id)
+      const responseBody = { ok: true, escrow: getEscrow(escrow.id), mode: 'simulated' }
+      cacheResponse(idempotencyKey, 200, responseBody)
+      return NextResponse.json(responseBody)
+    }
+
+    if (!escrow.paymentIntentId) {
+      markRefunded(escrow.id)
+      const responseBody = { ok: true, escrow: getEscrow(escrow.id) }
+      cacheResponse(idempotencyKey, 200, responseBody)
+      return NextResponse.json(responseBody)
+    }
+
+    const stripe = getStripe()
+    const pi = await stripe.paymentIntents.retrieve(escrow.paymentIntentId)
+    if (pi.status === 'requires_capture') {
+      await stripe.paymentIntents.cancel(escrow.paymentIntentId)
+    } else if (pi.status === 'succeeded') {
+      const chargeId = pi.latest_charge
+      if (typeof chargeId === 'string') {
+        await stripe.refunds.create({ charge: chargeId })
+      }
+    }
+
+    markRefunded(escrow.id)
+    const responseBody = { ok: true, escrow: getEscrow(escrow.id) }
+    cacheResponse(idempotencyKey, 200, responseBody)
+    return NextResponse.json(responseBody)
+  }
+
+  return NextResponse.json({ error: 'Unsupported' }, { status: 400 })
+}
+
+function escrowRefundAllowed(role: string, userId: string, escrowId: string): boolean {
+  const escrow = getEscrow(escrowId)
+  if (!escrow) return false
+  if (role === 'ADMIN') return true
+  return escrow.clientUserId === userId
+}

--- a/backend/contracts/stellar_insights/src/lib.rs
+++ b/backend/contracts/stellar_insights/src/lib.rs
@@ -8,6 +8,11 @@ use soroban_sdk::{
 /// Challenge deposit in stroops (10 XLM).
 pub const CHALLENGE_DEPOSIT: i128 = 100_000_000;
 
+const SECONDS_PER_MONTH: u64 = 30 * 86400;
+const GRACE_PERIOD_MONTHS: u64 = 3;
+const DECAY_SCALE: i64 = 10_000;
+const DEFAULT_DECAY_RATE: i64 = 500; // 5% per month
+
 #[contracttype]
 pub struct EpochData {
     pub epoch: u64,
@@ -51,6 +56,15 @@ pub struct ReviewChallenge {
 }
 
 #[contracttype]
+#[derive(Clone, Debug)]
+pub struct CreatorReputation {
+    pub creator: Address,
+    pub score: i64,
+    pub last_activity: u64,
+    pub bounties_completed: u64,
+}
+
+#[contracttype]
 pub enum DataKey {
     Epoch(Symbol, u64),
     Review(u64),
@@ -59,6 +73,8 @@ pub enum DataKey {
     ChallengeCounter,
     Admin,
     PlatformToken,
+    Reputation(Address),
+    DecayRate,
 }
 
 #[contracttype]
@@ -306,6 +322,137 @@ impl StellarInsights {
             .get(&DataKey::Challenge(challenge_id))
             .expect("Challenge not found")
     }
+
+    // ── Reputation decay (#765) ──────────────────────────────────────────────
+
+    fn exp_decay(decay_rate: i64, months: u64) -> i64 {
+        let x = decay_rate * (months as i64);
+        let t1 = DECAY_SCALE * DECAY_SCALE;
+        let t2 = x * DECAY_SCALE;
+        let t3 = (x * x) / 2;
+        let t4 = (x * x * x) / (6 * DECAY_SCALE);
+        let t5 = (x * x * x * x) / (24 * DECAY_SCALE * DECAY_SCALE);
+        let result = (t1 - t2 + t3 - t4 + t5) / DECAY_SCALE;
+        if result < 0 { 0 } else { result }
+    }
+
+    pub fn set_reputation(env: Env, admin: Address, creator: Address, score: i64) -> bool {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        assert!(score >= 0, "Score must be non-negative");
+
+        let rep = CreatorReputation {
+            creator: creator.clone(),
+            score,
+            last_activity: env.ledger().timestamp(),
+            bounties_completed: 0,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Reputation(creator.clone()), &rep);
+
+        env.events().publish(
+            (symbol_short!("rep_set"), creator),
+            score,
+        );
+        true
+    }
+
+    pub fn record_bounty_completion(env: Env, creator: Address, bonus: i64) -> bool {
+        creator.require_auth();
+        assert!(bonus >= 0, "Bonus must be non-negative");
+
+        let mut rep: CreatorReputation = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Reputation(creator.clone()))
+            .expect("Creator reputation not found");
+
+        rep.score += bonus;
+        rep.last_activity = env.ledger().timestamp();
+        rep.bounties_completed += 1;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Reputation(creator.clone()), &rep);
+
+        env.events().publish(
+            (symbol_short!("bty_done"), creator),
+            (rep.score, rep.bounties_completed),
+        );
+        true
+    }
+
+    pub fn get_effective_reputation(env: Env, creator: Address) -> i64 {
+        let rep: CreatorReputation = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Reputation(creator))
+            .expect("Creator reputation not found");
+
+        let now = env.ledger().timestamp();
+        if now <= rep.last_activity {
+            return rep.score;
+        }
+
+        let months_inactive = (now - rep.last_activity) / SECONDS_PER_MONTH;
+        if months_inactive <= GRACE_PERIOD_MONTHS {
+            return rep.score;
+        }
+
+        let decay_months = months_inactive - GRACE_PERIOD_MONTHS;
+        let decay_rate: i64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DecayRate)
+            .unwrap_or(DEFAULT_DECAY_RATE);
+
+        let factor = Self::exp_decay(decay_rate, decay_months);
+        (rep.score * factor) / DECAY_SCALE
+    }
+
+    pub fn is_decaying(env: Env, creator: Address) -> bool {
+        let rep: Option<CreatorReputation> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Reputation(creator));
+
+        match rep {
+            None => false,
+            Some(r) => {
+                let now = env.ledger().timestamp();
+                if now <= r.last_activity {
+                    return false;
+                }
+                (now - r.last_activity) / SECONDS_PER_MONTH > GRACE_PERIOD_MONTHS
+            }
+        }
+    }
+
+    pub fn set_decay_rate(env: Env, admin: Address, new_rate: i64) -> bool {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        assert!(new_rate > 0 && new_rate <= DECAY_SCALE, "Rate must be between 1 and 10000");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::DecayRate, &new_rate);
+        true
+    }
+
+    pub fn get_decay_rate(env: Env) -> i64 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::DecayRate)
+            .unwrap_or(DEFAULT_DECAY_RATE)
+    }
+
+    pub fn get_reputation(env: Env, creator: Address) -> CreatorReputation {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Reputation(creator))
+            .expect("Creator reputation not found")
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -416,5 +563,78 @@ mod tests {
 
         assert_eq!(contract.get_review(&review_id).status, ReviewStatus::Active);
         assert_eq!(contract.get_challenge(&0).status, ChallengeStatus::Rejected);
+    }
+
+    // ── Reputation decay tests (#765) ────────────────────────────────────────
+
+    #[test]
+    fn test_no_decay_within_grace_period() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, token, _, _) = setup(&env);
+        let contract_id = env.register_contract(None, StellarInsights);
+        let contract = StellarInsightsClient::new(&env, &contract_id);
+
+        contract.initialize(&admin, &token);
+        let creator = Address::generate(&env);
+        contract.set_reputation(&admin, &creator, &1000);
+
+        env.ledger().set_timestamp(2 * SECONDS_PER_MONTH);
+        assert_eq!(contract.get_effective_reputation(&creator), 1000);
+        assert!(!contract.is_decaying(&creator));
+    }
+
+    #[test]
+    fn test_decay_after_grace_period() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, token, _, _) = setup(&env);
+        let contract_id = env.register_contract(None, StellarInsights);
+        let contract = StellarInsightsClient::new(&env, &contract_id);
+
+        contract.initialize(&admin, &token);
+        let creator = Address::generate(&env);
+        contract.set_reputation(&admin, &creator, &10000);
+
+        env.ledger().set_timestamp(6 * SECONDS_PER_MONTH);
+        let effective = contract.get_effective_reputation(&creator);
+        assert!(effective < 10000);
+        assert!(effective > 8000);
+        assert!(contract.is_decaying(&creator));
+    }
+
+    #[test]
+    fn test_bounty_completion_refreshes_activity() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, token, _, _) = setup(&env);
+        let contract_id = env.register_contract(None, StellarInsights);
+        let contract = StellarInsightsClient::new(&env, &contract_id);
+
+        contract.initialize(&admin, &token);
+        let creator = Address::generate(&env);
+        contract.set_reputation(&admin, &creator, &1000);
+
+        env.ledger().set_timestamp(6 * SECONDS_PER_MONTH);
+        assert!(contract.is_decaying(&creator));
+
+        contract.record_bounty_completion(&creator, &100);
+        assert!(!contract.is_decaying(&creator));
+        assert_eq!(contract.get_effective_reputation(&creator), 1100);
+    }
+
+    #[test]
+    fn test_governance_adjusts_decay_rate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, token, _, _) = setup(&env);
+        let contract_id = env.register_contract(None, StellarInsights);
+        let contract = StellarInsightsClient::new(&env, &contract_id);
+
+        contract.initialize(&admin, &token);
+        assert_eq!(contract.get_decay_rate(), DEFAULT_DECAY_RATE);
+
+        contract.set_decay_rate(&admin, &1000);
+        assert_eq!(contract.get_decay_rate(), 1000);
     }
 }

--- a/components/forms/bounty-application-form.tsx
+++ b/components/forms/bounty-application-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { applicationSubmitSchema } from '@/lib/validators'
+import { bountyApplicationSchema } from '@/lib/validations/bounty-application'
 import type { z } from 'zod'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
@@ -12,7 +12,7 @@ import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Loader2 } from 'lucide-react'
 
-const schema = applicationSubmitSchema
+const schema = bountyApplicationSchema
 type FormValues = z.infer<typeof schema>
 
 export function BountyApplicationForm({
@@ -30,6 +30,7 @@ export function BountyApplicationForm({
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
+    mode: 'onChange',
     defaultValues: {
       bounty_id: bountyId,
       proposed_budget: suggestedBudget,
@@ -63,6 +64,7 @@ export function BountyApplicationForm({
           id="proposed_budget"
           type="number"
           min={1}
+          max={1_000_000}
           step={1}
           {...form.register('proposed_budget', { valueAsNumber: true })}
         />
@@ -79,7 +81,7 @@ export function BountyApplicationForm({
           id="timeline"
           type="number"
           min={1}
-          max={3650}
+          max={365}
           {...form.register('timeline', { valueAsNumber: true })}
         />
         {form.formState.errors.timeline && (
@@ -88,7 +90,7 @@ export function BountyApplicationForm({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="proposal">Proposal (min. 50 characters)</Label>
+        <Label htmlFor="proposal">Proposal (min. 100 characters)</Label>
         <Textarea
           id="proposal"
           rows={10}
@@ -107,7 +109,7 @@ export function BountyApplicationForm({
         </Alert>
       )}
 
-      <Button type="submit" disabled={form.formState.isSubmitting} className="w-full sm:w-auto">
+      <Button type="submit" disabled={!form.formState.isValid || form.formState.isSubmitting} className="w-full sm:w-auto">
         {form.formState.isSubmitting ? (
           <>
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/lib/payments/idempotency.ts
+++ b/lib/payments/idempotency.ts
@@ -1,0 +1,47 @@
+const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+interface CachedResponse {
+  status: number;
+  body: unknown;
+  createdAt: number;
+}
+
+type Store = Map<string, CachedResponse>;
+
+function getStore(): Store {
+  const g = globalThis as unknown as { __idempotencyStore?: Store };
+  if (!g.__idempotencyStore) {
+    g.__idempotencyStore = new Map();
+  }
+  return g.__idempotencyStore;
+}
+
+function pruneExpired(): void {
+  const now = Date.now();
+  const store = getStore();
+  for (const [key, entry] of store) {
+    if (now - entry.createdAt > TTL_MS) {
+      store.delete(key);
+    }
+  }
+}
+
+export function getCachedResponse(key: string): { status: number; body: unknown } | null {
+  pruneExpired();
+  const entry = getStore().get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.createdAt > TTL_MS) {
+    getStore().delete(key);
+    return null;
+  }
+  return { status: entry.status, body: entry.body };
+}
+
+export function cacheResponse(key: string, status: number, body: unknown): void {
+  getStore().set(key, { status, body, createdAt: Date.now() });
+}
+
+export function __resetIdempotencyStoreForTests(): void {
+  const g = globalThis as unknown as { __idempotencyStore?: Store };
+  g.__idempotencyStore = new Map();
+}

--- a/lib/utils/validators.ts
+++ b/lib/utils/validators.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { bountyApplicationSchema } from '@/lib/validations/bounty-application'
 
 export const paginationSchema = z.object({
   page: z.coerce.number().int().positive().optional().default(1),
@@ -90,12 +91,7 @@ export const applicationSchema = z.object({
 })
 
 /** Client-submitted body (applicant comes from session). */
-export const applicationSubmitSchema = z.object({
-  bounty_id: z.string().min(1).max(128),
-  proposed_budget: z.number().positive(),
-  timeline: z.number().int().positive().max(3650),
-  proposal: z.string().min(50).max(5000),
-})
+export const applicationSubmitSchema = bountyApplicationSchema
 
 export const applicationStatusBodySchema = z.object({
   status: z.enum(['accepted', 'rejected']),

--- a/lib/validations/bounty-application.ts
+++ b/lib/validations/bounty-application.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const bountyApplicationSchema = z.object({
+  bounty_id: z.string().min(1).max(128),
+  proposed_budget: z.number().positive().max(1_000_000),
+  timeline: z.number().int().min(1).max(365),
+  proposal: z.string().min(100, 'Proposal must be at least 100 characters').max(5000),
+})
+
+export type BountyApplicationInput = z.infer<typeof bountyApplicationSchema>

--- a/mobile/src/screens/CreatorDirectoryScreen.tsx
+++ b/mobile/src/screens/CreatorDirectoryScreen.tsx
@@ -9,8 +9,9 @@
  *  - Pull-to-refresh
  */
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  ActivityIndicator,
   Pressable,
   SafeAreaView,
   ScrollView,
@@ -24,6 +25,12 @@ import * as Haptics from "expo-haptics";
 import { useTheme } from "../theme/ThemeProvider";
 import { VirtualizedScrollList } from "../components/VirtualizedScrollList";
 import { FontSize, FontWeight, Radius, Spacing } from "../theme/tokens";
+import {
+  type NearbyCreator,
+  fetchNearbyCreators,
+  getCurrentPosition,
+  requestGeofencingPermissions,
+} from "../services/GeofencingService";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -265,6 +272,34 @@ export function CreatorDirectoryScreen({
   const { colors, isDark } = useTheme();
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedDiscipline, setSelectedDiscipline] = useState("All");
+  const [nearbyCreators, setNearbyCreators] = useState<NearbyCreator[]>([]);
+  const [nearbyLoading, setNearbyLoading] = useState(false);
+
+  const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3000";
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const perms = await requestGeofencingPermissions();
+      if (!perms.foreground || cancelled) return;
+      setNearbyLoading(true);
+      try {
+        const pos = await getCurrentPosition();
+        const creators = await fetchNearbyCreators(
+          pos.coords.latitude,
+          pos.coords.longitude,
+          10,
+          API_BASE,
+        );
+        if (!cancelled) setNearbyCreators(creators);
+      } catch {
+        // silently degrade — nearby section just won't show
+      } finally {
+        if (!cancelled) setNearbyLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [API_BASE]);
 
   const fetchCreators = useCallback(
     async (page: number, pageSize: number): Promise<Creator[]> => {
@@ -405,6 +440,29 @@ export function CreatorDirectoryScreen({
         })}
       </ScrollView>
 
+      {/* Near You section (#762) */}
+      {nearbyLoading && (
+        <ActivityIndicator size="small" style={{ paddingVertical: Spacing.sm }} />
+      )}
+      {nearbyCreators.length > 0 && (
+        <View style={nearYouStyles.section}>
+          <Text style={[nearYouStyles.title, { color: colors.text }]}>Near You</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: Spacing.sm, paddingHorizontal: Spacing.base }}>
+            {nearbyCreators.map((c) => (
+              <Pressable
+                key={c.id}
+                onPress={() => onSelectCreator?.(c.id)}
+                style={[nearYouStyles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}
+              >
+                <Text style={[nearYouStyles.name, { color: colors.text }]} numberOfLines={1}>{c.name}</Text>
+                <Text style={[nearYouStyles.discipline, { color: colors.primary }]}>{c.discipline}</Text>
+                <Text style={[nearYouStyles.distance, { color: colors.textTertiary }]}>{c.distanceKm.toFixed(1)} km</Text>
+              </Pressable>
+            ))}
+          </ScrollView>
+        </View>
+      )}
+
       {/* Virtualized infinite list */}
       <VirtualizedScrollList
         infiniteConfig={infiniteConfig}
@@ -483,4 +541,13 @@ const styles = StyleSheet.create({
   emptyIcon: { fontSize: 48 },
   emptyTitle: { fontSize: FontSize.xl, fontWeight: FontWeight.bold, textAlign: "center" },
   emptySubtitle: { fontSize: FontSize.base, textAlign: "center", lineHeight: 22 },
+});
+
+const nearYouStyles = StyleSheet.create({
+  section: { paddingVertical: Spacing.sm },
+  title: { fontSize: FontSize.lg, fontWeight: FontWeight.bold, paddingHorizontal: Spacing.base, marginBottom: Spacing.xs },
+  card: { padding: Spacing.sm, borderRadius: Radius.xl, borderWidth: 1, minWidth: 160 },
+  name: { fontSize: FontSize.base, fontWeight: FontWeight.bold },
+  discipline: { fontSize: FontSize.sm, marginTop: 2 },
+  distance: { fontSize: FontSize.xs, marginTop: 2 },
 });

--- a/mobile/src/services/GeofencingService.ts
+++ b/mobile/src/services/GeofencingService.ts
@@ -302,6 +302,60 @@ export async function stopGeofencing(): Promise<void> {
   }
 }
 
+// ─── Nearby creator discovery (#762) ─────────────────────────────────────────
+
+export interface NearbyCreator {
+  id: string;
+  name: string;
+  discipline: string;
+  latitude: number;
+  longitude: number;
+  distanceKm: number;
+}
+
+export interface NearbyBounty {
+  id: string;
+  title: string;
+  budget: number;
+  latitude: number;
+  longitude: number;
+  distanceKm: number;
+}
+
+export async function fetchNearbyCreators(
+  latitude: number,
+  longitude: number,
+  radiusKm: number,
+  apiBaseUrl: string,
+): Promise<NearbyCreator[]> {
+  const response = await fetch(
+    `${apiBaseUrl}/api/creators/nearby?lat=${latitude}&lng=${longitude}&radius=${radiusKm}`,
+  );
+  if (!response.ok) throw new Error(`Failed to fetch nearby creators: ${response.status}`);
+  const data = await response.json();
+  return data.creators ?? [];
+}
+
+export async function fetchNearbyBounties(
+  latitude: number,
+  longitude: number,
+  radiusKm: number,
+  apiBaseUrl: string,
+): Promise<NearbyBounty[]> {
+  const response = await fetch(
+    `${apiBaseUrl}/api/bounties/nearby?lat=${latitude}&lng=${longitude}&radius=${radiusKm}`,
+  );
+  if (!response.ok) throw new Error(`Failed to fetch nearby bounties: ${response.status}`);
+  const data = await response.json();
+  return data.bounties ?? [];
+}
+
+export async function getCurrentPosition() {
+  const Location = await loadLocation();
+  if (!Location) throw new Error("expo-location is not installed");
+  return Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+}
+
 /**
  * Returns the current geofencing status without starting/stopping anything.
  */


### PR DESCRIPTION
## Summary
- **closes #762**: Add nearby creator discovery to GeofencingService and CreatorDirectoryScreen — `fetchNearbyCreators`/`fetchNearbyBounties` API calls, "Near You" horizontal section with distance display
- **closes #763**: Extract shared bounty application Zod schema to `lib/validations/bounty-application.ts` (min 100 chars proposal, max $1M budget, max 365 days timeline), inline field errors, submit disabled while invalid
- **closes #764**: Add idempotency keys to all payment endpoints — require `Idempotency-Key` header, cache responses for 24h, return cached response on duplicate key without re-processing
- **closes #765**: Add reputation decay to `stellar_insights` contract — exponential decay after 3-month grace period, activity refresh on bounty completion, `is_decaying()` for UI warnings, governance-adjustable decay rate

## Test plan
- [ ] Run `npx vitest run __tests__/bounty-application-validation.test.ts` — all 6 tests pass
- [ ] Verify bounty application form shows inline errors and disables submit when invalid
- [ ] POST to `/api/payments` without `Idempotency-Key` header returns 400
- [ ] POST twice with the same `Idempotency-Key` returns cached response on second call
- [ ] `stellar_insights` contract: score unchanged within 3-month grace period, decays after
- [ ] `stellar_insights` contract: `record_bounty_completion` refreshes activity and stops decay
- [ ] Mobile geofencing: permission prompt explains location usage, "Near You" section renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)