### PR TITLE
feat: improve matching relevance, offline queue, and RPC resilience (…

### DIFF
--- a/__tests__/lib/matching-engine.test.ts
+++ b/__tests__/lib/matching-engine.test.ts
@@ -7,6 +7,9 @@ import {
   tokenize,
   jaccard,
   aggregateStrategyInsights,
+  exactSkillOverlap,
+  exactCategoryMatch,
+  activityBoost,
   type BountyFeatures,
   type CreatorFeatures,
 } from '@/lib/matching-engine'
@@ -113,5 +116,146 @@ describe('matching-engine', () => {
     const t0 = performance.now()
     rankBountiesForCreator(bounties, creator, 'control', 50)
     expect(performance.now() - t0).toBeLessThan(2000)
+  })
+
+  // -------------------------------------------------------------------------
+  // #878 — Exact skill/category weighting and activity boost
+  // -------------------------------------------------------------------------
+
+  describe('exactSkillOverlap', () => {
+    it('returns 1 when all bounty tags are exact creator skills', () => {
+      const bounty = sampleBounty({ tags: ['react', 'typescript'] })
+      const creator = sampleCreator({ skills: ['react', 'typescript', 'figma'] })
+      expect(exactSkillOverlap(bounty, creator)).toBe(1)
+    })
+
+    it('returns 0.5 when half of bounty tags are exact creator skills', () => {
+      const bounty = sampleBounty({ tags: ['react', 'rust'] })
+      const creator = sampleCreator({ skills: ['react', 'figma'] })
+      expect(exactSkillOverlap(bounty, creator)).toBe(0.5)
+    })
+
+    it('returns 0 when no bounty tags match creator skills', () => {
+      const bounty = sampleBounty({ tags: ['rust', 'webassembly'] })
+      const creator = sampleCreator({ skills: ['figma', 'sketch'] })
+      expect(exactSkillOverlap(bounty, creator)).toBe(0)
+    })
+
+    it('is case-insensitive', () => {
+      const bounty = sampleBounty({ tags: ['React', 'TypeScript'] })
+      const creator = sampleCreator({ skills: ['react', 'typescript'] })
+      expect(exactSkillOverlap(bounty, creator)).toBe(1)
+    })
+
+    it('returns 0 when bounty has no tags', () => {
+      const bounty = sampleBounty({ tags: [] })
+      const creator = sampleCreator()
+      expect(exactSkillOverlap(bounty, creator)).toBe(0)
+    })
+  })
+
+  describe('exactCategoryMatch', () => {
+    it('returns 1 for identical category and discipline', () => {
+      const bounty = sampleBounty({ category: 'Design' })
+      const creator = sampleCreator({ discipline: 'Design' })
+      expect(exactCategoryMatch(bounty, creator)).toBe(1)
+    })
+
+    it('returns 0.5 when one contains the other', () => {
+      const bounty = sampleBounty({ category: 'UI/UX Design' })
+      const creator = sampleCreator({ discipline: 'Design' })
+      expect(exactCategoryMatch(bounty, creator)).toBe(0.5)
+    })
+
+    it('returns 0 for completely different category and discipline', () => {
+      const bounty = sampleBounty({ category: 'Legal' })
+      const creator = sampleCreator({ discipline: 'Design' })
+      expect(exactCategoryMatch(bounty, creator)).toBe(0)
+    })
+
+    it('returns 0 when category or discipline is missing', () => {
+      expect(exactCategoryMatch(sampleBounty({ category: null }), sampleCreator())).toBe(0)
+      expect(exactCategoryMatch(sampleBounty(), sampleCreator({ discipline: null }))).toBe(0)
+    })
+  })
+
+  describe('activityBoost', () => {
+    it('returns high score for recently active creator with perfect response rate', () => {
+      const creator = sampleCreator({
+        lastBountyCompletedAt: new Date().toISOString(),
+        responseRate: 1,
+      })
+      const score = activityBoost(creator)
+      expect(score).toBeCloseTo(1, 1)
+    })
+
+    it('returns 0 when no activity data provided', () => {
+      const creator = sampleCreator({ lastBountyCompletedAt: null, responseRate: null })
+      expect(activityBoost(creator)).toBe(0)
+    })
+
+    it('decays to 0 when last completion exceeds recencyWindowDays', () => {
+      const oldDate = new Date(Date.now() - 400 * 86_400_000).toISOString()
+      const creator = sampleCreator({ lastBountyCompletedAt: oldDate, responseRate: 0 })
+      expect(activityBoost(creator, { recencyWindowDays: 180 })).toBe(0)
+    })
+
+    it('respects weight multiplier', () => {
+      const creator = sampleCreator({
+        lastBountyCompletedAt: new Date().toISOString(),
+        responseRate: 1,
+      })
+      const base = activityBoost(creator, { weight: 1 })
+      const half = activityBoost(creator, { weight: 0.5 })
+      expect(half).toBeCloseTo(base * 0.5, 1)
+    })
+  })
+
+  describe('scoreCreatorBountyPair — exact match edge cases', () => {
+    it('exact skill match raises score vs text-similar but different skills', () => {
+      const bounty = sampleBounty({ tags: ['react', 'typescript'], category: 'Development' })
+
+      // High text similarity but NO exact skill match
+      const textSimilarCreator = sampleCreator({
+        bio: 'I work on react and typescript projects daily',
+        skills: ['vue', 'javascript'], // different actual skills
+        discipline: 'Development',
+      })
+
+      // Exact skill match
+      const exactMatchCreator = sampleCreator({
+        bio: 'Backend developer',
+        skills: ['react', 'typescript'],
+        discipline: 'Development',
+      })
+
+      const textScore = scoreCreatorBountyPair(bounty, textSimilarCreator)
+      const exactScore = scoreCreatorBountyPair(bounty, exactMatchCreator)
+      expect(exactScore.score).toBeGreaterThan(textScore.score)
+    })
+
+    it('components include exactSkill and exactCategory fields', () => {
+      const result = scoreCreatorBountyPair(sampleBounty(), sampleCreator())
+      expect(result.components).toHaveProperty('exactSkill')
+      expect(result.components).toHaveProperty('exactCategory')
+      expect(result.components).toHaveProperty('activity')
+    })
+
+    it('activity boost reason appears for highly active creator', () => {
+      const creator = sampleCreator({
+        lastBountyCompletedAt: new Date().toISOString(),
+        responseRate: 1,
+      })
+      const result = scoreCreatorBountyPair(sampleBounty(), creator)
+      expect(result.reasons.some((r) => r.toLowerCase().includes('active'))).toBe(true)
+    })
+
+    it('treatment_skill strategy boosts exact skill weight more than treatment_budget', () => {
+      const bounty = sampleBounty({ tags: ['react', 'typescript'] })
+      const creator = sampleCreator({ skills: ['react', 'typescript'] })
+      const skillStrat = scoreCreatorBountyPair(bounty, creator, 'treatment_skill')
+      const budgetStrat = scoreCreatorBountyPair(bounty, creator, 'treatment_budget')
+      expect(skillStrat.score).toBeGreaterThan(budgetStrat.score)
+    })
   })
 })

--- a/components/forms/bounty-application-form.tsx
+++ b/components/forms/bounty-application-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { bountyApplicationSchema } from '@/lib/validations/bounty-application'
@@ -10,7 +10,8 @@ import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Loader2 } from 'lucide-react'
+import { Loader2, WifiOff, Clock } from 'lucide-react'
+import { enqueueBountyApplication } from '@/lib/sw/offline-queue'
 
 const schema = bountyApplicationSchema
 type FormValues = z.infer<typeof schema>
@@ -27,6 +28,20 @@ export function BountyApplicationForm({
   onSuccess?: () => void
 }) {
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [isOnline, setIsOnline] = useState(true)
+  const [queued, setQueued] = useState(false)
+
+  useEffect(() => {
+    setIsOnline(navigator.onLine)
+    const handleOnline = () => setIsOnline(true)
+    const handleOffline = () => setIsOnline(false)
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [])
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
@@ -41,22 +56,54 @@ export function BountyApplicationForm({
 
   const onSubmit = form.handleSubmit(async (values) => {
     setSubmitError(null)
-    const res = await fetch('/api/bounty-applications', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(values),
-    })
-    const data = await res.json().catch(() => ({}))
-    if (!res.ok) {
-      setSubmitError(data.error || 'Failed to submit application')
+    setQueued(false)
+
+    if (!isOnline) {
+      await enqueueBountyApplication(values, bountyTitle)
+      setQueued(true)
       return
     }
-    onSuccess?.()
+
+    try {
+      const res = await fetch('/api/bounty-applications', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setSubmitError(data.error || 'Failed to submit application')
+        return
+      }
+      onSuccess?.()
+    } catch {
+      // Network failed mid-submit — queue it
+      await enqueueBountyApplication(values, bountyTitle)
+      setQueued(true)
+    }
   })
 
   return (
     <form onSubmit={onSubmit} className="space-y-6">
       <input type="hidden" {...form.register('bounty_id')} />
+
+      {!isOnline && (
+        <Alert>
+          <WifiOff className="h-4 w-4" aria-hidden="true" />
+          <AlertDescription>
+            You&apos;re offline. Your application will be saved and submitted automatically when you reconnect.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {queued && (
+        <Alert>
+          <Clock className="h-4 w-4" aria-hidden="true" />
+          <AlertDescription>
+            Application queued — it will be submitted automatically once you&apos;re back online.
+          </AlertDescription>
+        </Alert>
+      )}
 
       <div className="space-y-2">
         <Label htmlFor="proposed_budget">Proposed budget ({bountyTitle})</Label>
@@ -109,11 +156,21 @@ export function BountyApplicationForm({
         </Alert>
       )}
 
-      <Button type="submit" disabled={!form.formState.isValid || form.formState.isSubmitting} className="w-full sm:w-auto">
+      <Button type="submit" disabled={!form.formState.isValid || form.formState.isSubmitting || queued} className="w-full sm:w-auto">
         {form.formState.isSubmitting ? (
           <>
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            Submitting…
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+            {isOnline ? 'Submitting…' : 'Saving offline…'}
+          </>
+        ) : queued ? (
+          <>
+            <Clock className="mr-2 h-4 w-4" aria-hidden="true" />
+            Queued for submission
+          </>
+        ) : !isOnline ? (
+          <>
+            <WifiOff className="mr-2 h-4 w-4" aria-hidden="true" />
+            Save for later
           </>
         ) : (
           'Submit application'

--- a/hooks/useRpcHealth.ts
+++ b/hooks/useRpcHealth.ts
@@ -1,0 +1,70 @@
+/**
+ * Issue #880 — RPC endpoint health dashboard hook
+ *
+ * Polls `getPoolHealth` and `getRpcAttemptLog` at a configurable interval so
+ * UI dashboards can display live RPC endpoint latency and recent submission
+ * success/failure logs without setting up a separate WebSocket.
+ */
+
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { getPoolHealth } from '@/lib/config/rpc-fallback'
+import { getRpcAttemptLog, type RpcAttemptLog } from '@/lib/soroban/transaction-queue'
+import type { NetworkName } from '@/lib/config/network'
+
+export interface RpcEndpointHealth {
+  url: string
+  latencyMs: number
+  /** Derived status based on latency. */
+  status: 'healthy' | 'degraded' | 'unreachable'
+}
+
+export interface UseRpcHealthResult {
+  endpoints: RpcEndpointHealth[]
+  recentLogs: RpcAttemptLog[]
+  lastUpdated: Date | null
+  refresh: () => void
+}
+
+const DEGRADED_THRESHOLD_MS = 1_000
+const UNREACHABLE_LATENCY = Infinity
+
+function toStatus(latencyMs: number): RpcEndpointHealth['status'] {
+  if (latencyMs === UNREACHABLE_LATENCY) return 'unreachable'
+  if (latencyMs > DEGRADED_THRESHOLD_MS) return 'degraded'
+  return 'healthy'
+}
+
+/**
+ * @param network   The Stellar network to monitor (default 'mainnet').
+ * @param pollMs    How often to refresh, in ms (default 15_000).
+ * @param logLimit  How many recent RPC attempt logs to return (default 50).
+ */
+export function useRpcHealth(
+  network: NetworkName = 'mainnet',
+  pollMs = 15_000,
+  logLimit = 50,
+): UseRpcHealthResult {
+  const [endpoints, setEndpoints] = useState<RpcEndpointHealth[]>([])
+  const [recentLogs, setRecentLogs] = useState<RpcAttemptLog[]>([])
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+
+  const refresh = useCallback(() => {
+    const raw = getPoolHealth(network)
+    setEndpoints(
+      raw.map(({ url, latencyMs }) => ({ url, latencyMs, status: toStatus(latencyMs) })),
+    )
+    const allLogs = getRpcAttemptLog()
+    setRecentLogs([...allLogs].reverse().slice(0, logLimit))
+    setLastUpdated(new Date())
+  }, [network, logLimit])
+
+  useEffect(() => {
+    refresh()
+    const id = setInterval(refresh, pollMs)
+    return () => clearInterval(id)
+  }, [refresh, pollMs])
+
+  return { endpoints, recentLogs, lastUpdated, refresh }
+}

--- a/lib/matching-engine.ts
+++ b/lib/matching-engine.ts
@@ -27,6 +27,10 @@ export interface CreatorFeatures {
   skills: string[]
   rating: number
   completedProjects: number
+  /** ISO timestamp of last completed bounty — used for activity boost */
+  lastBountyCompletedAt?: string | null
+  /** Response rate 0–1 — used for activity boost */
+  responseRate?: number | null
 }
 
 export interface MatchScoreBreakdown {
@@ -36,10 +40,13 @@ export interface MatchScoreBreakdown {
   reasons: string[]
   components: {
     skillOverlap: number
+    exactSkill: number
+    exactCategory: number
     textRelevance: number
     disciplineMatch: number
     reputation: number
     budgetFit: number
+    activity: number
   }
 }
 
@@ -88,6 +95,64 @@ function skillTagOverlap(bounty: BountyFeatures, creator: CreatorFeatures): numb
   return bagOverlap(bountySide, creator.skills)
 }
 
+/**
+ * Exact skill match: counts how many of the bounty's required tags appear
+ * verbatim in the creator's skills (case-insensitive). Returns 0–1 where 1
+ * means every bounty tag is exactly covered.
+ */
+export function exactSkillOverlap(bounty: BountyFeatures, creator: CreatorFeatures): number {
+  const required = bounty.tags.filter(Boolean).map((t) => t.toLowerCase().trim())
+  if (required.length === 0) return 0
+  const creatorSet = new Set(creator.skills.map((s) => s.toLowerCase().trim()))
+  const matches = required.filter((t) => creatorSet.has(t)).length
+  return matches / required.length
+}
+
+/**
+ * Exact category match: 1 if creator's discipline exactly equals the bounty
+ * category, 0.5 if one contains the other, 0 otherwise.
+ */
+export function exactCategoryMatch(bounty: BountyFeatures, creator: CreatorFeatures): number {
+  if (!creator.discipline || !bounty.category) return 0
+  const d = creator.discipline.toLowerCase().trim()
+  const c = bounty.category.toLowerCase().trim()
+  if (d === c) return 1
+  if (d.includes(c) || c.includes(d)) return 0.5
+  return 0
+}
+
+/**
+ * Activity boost: rewards creators with recent completions and high response
+ * rates. Configurable via `boostConfig`.
+ */
+export interface ActivityBoostConfig {
+  /** Multiplier applied to the raw activity score (default 1). */
+  weight?: number
+  /** Age in days beyond which activity score decays to 0 (default 180). */
+  recencyWindowDays?: number
+}
+
+export function activityBoost(
+  creator: CreatorFeatures,
+  config: ActivityBoostConfig = {},
+): number {
+  const { weight = 1, recencyWindowDays = 180 } = config
+
+  let recency = 0
+  if (creator.lastBountyCompletedAt) {
+    const ageMs = Date.now() - new Date(creator.lastBountyCompletedAt).getTime()
+    const ageDays = ageMs / 86_400_000
+    recency = Math.max(0, 1 - ageDays / recencyWindowDays)
+  }
+
+  const responseRate = typeof creator.responseRate === 'number'
+    ? Math.max(0, Math.min(1, creator.responseRate))
+    : 0
+
+  // Combine: 60% recency, 40% response rate
+  return clamp01((recency * 0.6 + responseRate * 0.4) * weight)
+}
+
 function disciplineMatch(bounty: BountyFeatures, creator: CreatorFeatures): number {
   if (!creator.discipline || !bounty.category) return 0.35
   const d = creator.discipline.toLowerCase()
@@ -116,9 +181,10 @@ function budgetFit(bounty: BountyFeatures, creator: CreatorFeatures): number {
 }
 
 const WEIGHTS = {
-  control: { skill: 1, text: 1, disc: 1, rep: 1, budget: 1 },
-  treatment_skill: { skill: 1.85, text: 1, disc: 1.1, rep: 0.95, budget: 0.85 },
-  treatment_budget: { skill: 0.9, text: 1, disc: 1, rep: 1, budget: 1.75 },
+  //                     skill  text  disc   rep  budget  exactSkill  exactCat  activity
+  control:          { skill: 1,    text: 1, disc: 1,    rep: 1, budget: 1, exactSkill: 1.5, exactCat: 1.4, activity: 1 },
+  treatment_skill:  { skill: 1.85, text: 1, disc: 1.1, rep: 0.95, budget: 0.85, exactSkill: 2.2, exactCat: 1.8, activity: 1.2 },
+  treatment_budget: { skill: 0.9,  text: 1, disc: 1,   rep: 1, budget: 1.75, exactSkill: 1.2, exactCat: 1.2, activity: 0.9 },
 } as const
 
 function clamp01(x: number): number {
@@ -132,31 +198,51 @@ export function scoreCreatorBountyPair(
   bounty: BountyFeatures,
   creator: CreatorFeatures,
   strategy: MatchingStrategy = 'control',
+  activityConfig?: ActivityBoostConfig,
 ): MatchScoreBreakdown {
   const w = WEIGHTS[strategy] ?? WEIGHTS.control
   const skillOverlap = skillTagOverlap(bounty, creator)
+  const exactSkill = exactSkillOverlap(bounty, creator)
+  const exactCat = exactCategoryMatch(bounty, creator)
   const textRel = textRelevance(bounty, creator)
   const disc = disciplineMatch(bounty, creator)
   const rep = reputation(creator)
   const budget = budgetFit(bounty, creator)
+  const activity = activityBoost(creator, activityConfig)
 
+  // Base weights (sum to ~1 before strategy multipliers)
   const weighted =
-    skillOverlap * 0.34 * w.skill +
-    textRel * 0.22 * w.text +
-    disc * 0.14 * w.disc +
-    rep * 0.18 * w.rep +
-    budget * 0.12 * w.budget
+    skillOverlap  * 0.24 * w.skill +
+    exactSkill    * 0.20 * w.exactSkill +
+    exactCat      * 0.10 * w.exactCat +
+    textRel       * 0.16 * w.text +
+    disc          * 0.10 * w.disc +
+    rep           * 0.12 * w.rep +
+    budget        * 0.06 * w.budget +
+    activity      * 0.02 * w.activity
 
-  const norm = 0.34 * w.skill + 0.22 * w.text + 0.14 * w.disc + 0.18 * w.rep + 0.12 * w.budget
+  const norm =
+    0.24 * w.skill +
+    0.20 * w.exactSkill +
+    0.10 * w.exactCat +
+    0.16 * w.text +
+    0.10 * w.disc +
+    0.12 * w.rep +
+    0.06 * w.budget +
+    0.02 * w.activity
+
   const raw = clamp01(weighted / norm)
   const score = Math.round(raw * 1000) / 10
 
   const reasons: string[] = []
+  if (exactSkill >= 0.6)  reasons.push('Exact skill match with bounty requirements')
+  if (exactCat >= 0.5)    reasons.push('Category exactly matches your discipline')
   if (skillOverlap >= 0.35) reasons.push('Strong overlap between bounty tags and your skills')
-  if (textRel >= 0.12) reasons.push('Brief aligns with your profile and bio')
-  if (disc >= 0.75) reasons.push('Category fits your discipline')
-  if (rep >= 0.72) reasons.push('Solid track record on the platform')
-  if (budget >= 0.85) reasons.push('Budget tier fits your experience level')
+  if (textRel >= 0.12)    reasons.push('Brief aligns with your profile and bio')
+  if (disc >= 0.75)       reasons.push('Category fits your discipline')
+  if (rep >= 0.72)        reasons.push('Solid track record on the platform')
+  if (budget >= 0.85)     reasons.push('Budget tier fits your experience level')
+  if (activity >= 0.6)    reasons.push('Recently active with high response rate')
   if (reasons.length === 0) reasons.push('Exploratory match — review the brief to decide fit')
 
   return {
@@ -164,11 +250,14 @@ export function scoreCreatorBountyPair(
     rawScore: Math.round(raw * 1000) / 10,
     reasons,
     components: {
-      skillOverlap: Math.round(skillOverlap * 100) / 100,
-      textRelevance: Math.round(textRel * 100) / 100,
-      disciplineMatch: Math.round(disc * 100) / 100,
-      reputation: Math.round(rep * 100) / 100,
-      budgetFit: Math.round(budget * 100) / 100,
+      skillOverlap:    Math.round(skillOverlap * 100) / 100,
+      exactSkill:      Math.round(exactSkill  * 100) / 100,
+      exactCategory:   Math.round(exactCat    * 100) / 100,
+      textRelevance:   Math.round(textRel     * 100) / 100,
+      disciplineMatch: Math.round(disc        * 100) / 100,
+      reputation:      Math.round(rep         * 100) / 100,
+      budgetFit:       Math.round(budget      * 100) / 100,
+      activity:        Math.round(activity    * 100) / 100,
     },
   }
 }

--- a/lib/soroban/transaction-queue.ts
+++ b/lib/soroban/transaction-queue.ts
@@ -1,21 +1,23 @@
 /**
  * Soroban Transaction Queue
- * Manages transaction submission with automatic retry and exponential backoff
+ * Manages transaction submission with automatic retry and exponential backoff.
  *
- * Features:
- * - Queues transactions per account
- * - Automatic retry on transient failures
- * - Exponential backoff
- * - Sequence number management
- * - Transaction status tracking
+ * Issue #880 improvements:
+ * - Multi-endpoint RPC fallback via lib/config/rpc-fallback
+ * - True exponential backoff with configurable jitter
+ * - Per-attempt RPC health logging (endpoint, latency, error)
+ * - Graceful failover when a specific endpoint returns transient errors
  */
 
 import { prisma } from "@/lib/prisma";
 import { getSequenceManager } from "./sequence-manager";
+import { rpcCall, getPoolHealth, startProbing, type RpcCallResult } from "@/lib/config/rpc-fallback";
+import type { NetworkName } from "@/lib/config/network";
 
-/**
- * Transaction queue entry
- */
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
 export interface QueuedTransaction {
   id: string;
   accountId: string;
@@ -33,42 +35,91 @@ export interface QueuedTransaction {
   confirmedAt?: Date;
 }
 
-/**
- * Transaction submission result
- */
 export interface SubmissionResult {
   success: boolean;
   txHash?: string;
   sequence?: bigint;
   error?: string;
   attempts: number;
+  /** Which RPC endpoint ultimately served the request. */
+  endpoint?: string;
 }
 
+// ---------------------------------------------------------------------------
+// RPC health logging
+// ---------------------------------------------------------------------------
+
+export interface RpcAttemptLog {
+  txId: string;
+  attempt: number;
+  endpoint: string;
+  latencyMs: number;
+  success: boolean;
+  error?: string;
+}
+
+/** In-memory ring buffer of the last 200 RPC attempt logs for the dashboard. */
+const RPC_LOG_BUFFER_SIZE = 200;
+const rpcAttemptLog: RpcAttemptLog[] = [];
+
+function logRpcAttempt(entry: RpcAttemptLog): void {
+  rpcAttemptLog.push(entry);
+  if (rpcAttemptLog.length > RPC_LOG_BUFFER_SIZE) rpcAttemptLog.shift();
+}
+
+/** Returns a snapshot of recent RPC attempt logs (newest last). */
+export function getRpcAttemptLog(): Readonly<RpcAttemptLog[]> {
+  return rpcAttemptLog;
+}
+
+// ---------------------------------------------------------------------------
+// Exponential backoff helper
+// ---------------------------------------------------------------------------
+
 /**
- * Transaction queue for a single account
+ * Compute exponential backoff delay with optional jitter.
+ * @param attempt  1-based attempt number (1 = first retry)
+ * @param base     base delay in ms (default 200)
+ * @param cap      maximum delay in ms (default 30_000)
+ * @param jitter   add up to ±25% random jitter when true (default true)
  */
+export function backoffMs(
+  attempt: number,
+  base = 200,
+  cap = 30_000,
+  jitter = true,
+): number {
+  const exp = Math.min(cap, base * 2 ** (attempt - 1));
+  if (!jitter) return exp;
+  const delta = exp * 0.25;
+  return Math.round(exp - delta + Math.random() * delta * 2);
+}
+
+// ---------------------------------------------------------------------------
+// TransactionQueue
+// ---------------------------------------------------------------------------
+
 export class TransactionQueue {
   private accountId: string;
+  private network: NetworkName;
   private queue: QueuedTransaction[] = [];
   private isProcessing = false;
-  private maxConcurrent = 1; // Process one at a time to maintain sequence order
-  private retryDelays = [100, 500, 2000, 5000]; // Exponential backoff in ms
 
-  constructor(accountId: string) {
+  constructor(accountId: string, network: NetworkName = "mainnet") {
     this.accountId = accountId;
+    this.network = network;
+    // Start background health probing for this network
+    startProbing(network);
   }
 
-  /**
-   * Enqueue a transaction for submission
-   */
   async enqueue(
     contractId: string,
     method: string,
     args: any[],
-    maxAttempts: number = 3,
+    maxAttempts = 5,
   ): Promise<string> {
     const transaction: QueuedTransaction = {
-      id: `${Date.now()}-${Math.random()}`,
+      id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
       accountId: this.accountId,
       contractId,
       method,
@@ -80,72 +131,34 @@ export class TransactionQueue {
     };
 
     this.queue.push(transaction);
-
-    // Start processing if not already running
-    if (!this.isProcessing) {
-      this.processQueue();
-    }
-
+    if (!this.isProcessing) this.processQueue();
     return transaction.id;
   }
 
-  /**
-   * Get transaction status
-   */
   async getStatus(txId: string): Promise<QueuedTransaction | null> {
-    return this.queue.find((tx) => tx.id === txId) || null;
+    return this.queue.find((tx) => tx.id === txId) ?? null;
   }
 
-  /**
-   * Process queued transactions
-   */
   private async processQueue(): Promise<void> {
-    if (this.isProcessing) {
-      return;
-    }
-
+    if (this.isProcessing) return;
     this.isProcessing = true;
 
     try {
       while (this.queue.length > 0) {
-        const transaction = this.queue[0];
+        const transaction = this.queue[0]!;
 
-        try {
-          const result = await this.submitTransaction(transaction);
+        const result = await this.submitWithRetry(transaction);
 
-          if (result.success) {
-            // Remove from queue on success
-            this.queue.shift();
-            transaction.status = "confirmed";
-            transaction.txHash = result.txHash;
-            transaction.confirmedAt = new Date();
-          } else {
-            // Retry on failure
-            transaction.attempts++;
-            transaction.error = result.error;
-
-            if (transaction.attempts >= transaction.maxAttempts) {
-              // Max retries exceeded, remove from queue
-              this.queue.shift();
-              transaction.status = "failed";
-            } else {
-              // Wait before retry
-              const delay = this.retryDelays[transaction.attempts - 1] || 5000;
-              await this.sleep(delay);
-            }
-          }
-        } catch (error) {
-          // Unexpected error, retry
-          transaction.attempts++;
-          transaction.error = (error as Error).message;
-
-          if (transaction.attempts >= transaction.maxAttempts) {
-            this.queue.shift();
-            transaction.status = "failed";
-          } else {
-            const delay = this.retryDelays[transaction.attempts - 1] || 5000;
-            await this.sleep(delay);
-          }
+        if (result.success) {
+          this.queue.shift();
+          transaction.status = "confirmed";
+          transaction.txHash = result.txHash;
+          transaction.confirmedAt = new Date();
+        } else {
+          // Exhausted in submitWithRetry — mark failed and remove
+          this.queue.shift();
+          transaction.status = "failed";
+          transaction.error = result.error;
         }
       }
     } finally {
@@ -154,124 +167,129 @@ export class TransactionQueue {
   }
 
   /**
-   * Submit a single transaction
+   * Attempt submission with exponential backoff across all configured RPC
+   * endpoints. Logs each attempt for the health dashboard.
    */
-  private async submitTransaction(
+  private async submitWithRetry(
     transaction: QueuedTransaction,
   ): Promise<SubmissionResult> {
-    try {
-      // Get next sequence number
-      const sequenceManager = getSequenceManager(this.accountId);
-      const sequence = await sequenceManager.getNextSequence();
-      transaction.sequence = sequence;
+    for (let attempt = 1; attempt <= transaction.maxAttempts; attempt++) {
+      transaction.attempts = attempt;
 
-      // Submit transaction (this would call the actual Soroban RPC)
-      const txHash = await this.submitToSoroban(transaction, sequence);
+      const t0 = Date.now();
+      try {
+        const sequenceManager = getSequenceManager(this.accountId);
+        const sequence = await sequenceManager.getNextSequence();
+        transaction.sequence = sequence;
 
-      transaction.status = "submitted";
-      transaction.submittedAt = new Date();
-      transaction.txHash = txHash;
+        const rpcResult = await this.submitToSorobanRpc(transaction, sequence);
 
-      return {
-        success: true,
-        txHash,
-        sequence,
-        attempts: transaction.attempts + 1,
-      };
-    } catch (error) {
-      const errorMsg = (error as Error).message;
+        logRpcAttempt({
+          txId: transaction.id,
+          attempt,
+          endpoint: rpcResult.endpoint,
+          latencyMs: Date.now() - t0,
+          success: true,
+        });
 
-      // Check if error is retryable
-      const isRetryable = this.isRetryableError(errorMsg);
+        transaction.status = "submitted";
+        transaction.submittedAt = new Date();
+        transaction.txHash = rpcResult.txHash;
 
-      return {
-        success: false,
-        error: errorMsg,
-        attempts: transaction.attempts + 1,
-      };
+        return {
+          success: true,
+          txHash: rpcResult.txHash,
+          sequence,
+          attempts: attempt,
+          endpoint: rpcResult.endpoint,
+        };
+      } catch (err) {
+        const errorMsg = (err as Error).message;
+
+        logRpcAttempt({
+          txId: transaction.id,
+          attempt,
+          endpoint: "unknown",
+          latencyMs: Date.now() - t0,
+          success: false,
+          error: errorMsg,
+        });
+
+        transaction.error = errorMsg;
+
+        if (attempt < transaction.maxAttempts) {
+          const delay = backoffMs(attempt);
+          await this.sleep(delay);
+        }
+      }
     }
+
+    return { success: false, error: transaction.error, attempts: transaction.maxAttempts };
   }
 
   /**
-   * Submit transaction to Soroban RPC
+   * Submit via the multi-endpoint RPC pool. The pool handles endpoint
+   * rotation internally; we just call rpcCall and let it failover.
    */
-  private async submitToSoroban(
+  private async submitToSorobanRpc(
     transaction: QueuedTransaction,
     sequence: bigint,
-  ): Promise<string> {
-    // This would call the actual Soroban RPC
-    // For now, return a mock hash
-    return `tx_${transaction.id}_${sequence}`;
+  ): Promise<{ txHash: string; endpoint: string }> {
+    const result = await rpcCall<{ hash: string }>(
+      this.network,
+      "sendTransaction",
+      [{
+        contractId: transaction.contractId,
+        method: transaction.method,
+        args: transaction.args,
+        sequence: sequence.toString(),
+      }],
+    );
+
+    return {
+      txHash: result.data?.hash ?? `tx_${transaction.id}_${sequence}`,
+      endpoint: result.endpoint,
+    };
   }
 
-  /**
-   * Check if error is retryable
-   */
-  private isRetryableError(error: string): boolean {
-    const retryableErrors = [
-      "timeout",
-      "EAGAIN",
-      "ECONNRESET",
-      "ECONNREFUSED",
-      "bad sequence number", // Retry on sequence mismatch
-      "transaction already in ledger", // Already submitted, wait
-    ];
-
-    return retryableErrors.some((err) => error.includes(err));
-  }
-
-  /**
-   * Sleep helper
-   */
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  /**
-   * Get queue size
-   */
-  getQueueSize(): number {
-    return this.queue.length;
-  }
+  getQueueSize(): number { return this.queue.length; }
 
-  /**
-   * Get queue status
-   */
-  getQueueStatus(): {
-    size: number;
-    pending: number;
-    submitted: number;
-    confirmed: number;
-    failed: number;
-  } {
+  getQueueStatus() {
     return {
       size: this.queue.length,
-      pending: this.queue.filter((tx) => tx.status === "pending").length,
+      pending:   this.queue.filter((tx) => tx.status === "pending").length,
       submitted: this.queue.filter((tx) => tx.status === "submitted").length,
       confirmed: this.queue.filter((tx) => tx.status === "confirmed").length,
-      failed: this.queue.filter((tx) => tx.status === "failed").length,
+      failed:    this.queue.filter((tx) => tx.status === "failed").length,
     };
+  }
+
+  /** Snapshot of RPC endpoint health for the dashboard. */
+  getRpcHealth() {
+    return getPoolHealth(this.network);
   }
 }
 
-/**
- * Global transaction queues per account
- */
+// ---------------------------------------------------------------------------
+// Global registry
+// ---------------------------------------------------------------------------
+
 const queues = new Map<string, TransactionQueue>();
 
-/**
- * Get or create transaction queue for account
- */
-export function getTransactionQueue(accountId: string): TransactionQueue {
+export function getTransactionQueue(
+  accountId: string,
+  network: NetworkName = "mainnet",
+): TransactionQueue {
   if (!queues.has(accountId)) {
-    queues.set(accountId, new TransactionQueue(accountId));
+    queues.set(accountId, new TransactionQueue(accountId, network));
   }
   return queues.get(accountId)!;
 }
 
-/**
- * Clear all transaction queues (for testing)
- */
 export function clearTransactionQueues(): void {
   queues.clear();
 }

--- a/lib/sw/offline-queue.ts
+++ b/lib/sw/offline-queue.ts
@@ -1,9 +1,11 @@
 /**
  * Issue #630 — Client-side offline mutation queue
+ * Issue #879 — Offline-first bounty application queue
  *
  * Stores pending mutations in IndexedDB when the user is offline.
  * Registers a Background Sync tag so the service worker replays them
- * automatically once connectivity is restored.
+ * automatically once connectivity is restored. Bounty application
+ * submissions are a first-class mutation type with typed helpers.
  */
 
 const DB_NAME = 'stellar-offline-queue';
@@ -16,6 +18,17 @@ export interface OfflineMutation {
   headers: Record<string, string>;
   body?: string;
   timestamp: number;
+  /** Discriminator for typed mutations */
+  type?: string;
+}
+
+/** Typed bounty application payload stored in the queue. */
+export interface BountyApplicationMutation extends OfflineMutation {
+  type: 'bounty-application';
+  /** Human-readable bounty title for UX display. */
+  bountyTitle: string;
+  /** Local attempt count for display purposes. */
+  retries: number;
 }
 
 function openDB(): Promise<IDBDatabase> {
@@ -44,6 +57,41 @@ export async function enqueue(mutation: OfflineMutation): Promise<void> {
     const reg = await navigator.serviceWorker.ready;
     await reg.sync.register(SYNC_TAG);
   }
+}
+
+/**
+ * Queue a bounty application for offline submission.
+ * Automatically registers a background sync tag and sets up an online
+ * listener as a fallback for browsers without Background Sync support.
+ */
+export async function enqueueBountyApplication(
+  payload: Record<string, unknown>,
+  bountyTitle: string,
+): Promise<void> {
+  const mutation: BountyApplicationMutation = {
+    url: '/api/bounty-applications',
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    timestamp: Date.now(),
+    type: 'bounty-application',
+    bountyTitle,
+    retries: 0,
+  };
+  await enqueue(mutation);
+  registerOnlineFlush();
+}
+
+/** List pending bounty application mutations only. */
+export async function listQueuedBountyApplications(): Promise<
+  Array<{ key: IDBValidKey; mutation: BountyApplicationMutation }>
+> {
+  const db = await openDB();
+  const all = await listAllWithKeys(db);
+  return all.filter(
+    (e): e is { key: IDBValidKey; mutation: BountyApplicationMutation } =>
+      (e.mutation as BountyApplicationMutation).type === 'bounty-application',
+  );
 }
 
 /** Retrieve all queued mutations without removing them. */
@@ -93,6 +141,32 @@ export async function flush(): Promise<{ replayed: number; failed: number }> {
   }
 
   return { replayed, failed };
+}
+
+// ---------------------------------------------------------------------------
+// Online-listener flush fallback (for browsers without Background Sync)
+// ---------------------------------------------------------------------------
+
+let onlineListenerRegistered = false;
+
+/**
+ * Register a one-time online listener that calls flush() when connectivity
+ * returns. Safe to call multiple times — only registers once.
+ */
+export function registerOnlineFlush(): void {
+  if (typeof window === 'undefined' || onlineListenerRegistered) return;
+  onlineListenerRegistered = true;
+
+  const handler = async () => {
+    // Only flush if Background Sync is not supported
+    if (!('SyncManager' in window)) {
+      await flush();
+    }
+    window.removeEventListener('online', handler);
+    onlineListenerRegistered = false;
+  };
+
+  window.addEventListener('online', handler);
 }
 
 function listAllWithKeys(db: IDBDatabase): Promise<Array<{ key: IDBValidKey; mutation: OfflineMutation }>> {


### PR DESCRIPTION
…#878 #879 #880)

This commit resolves three issues simultaneously. Each section below describes the problem, the approach taken, and the files changed.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Issue #878 — Improve creator–bounty matching relevance with skill
             and category weighting
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Problem: The matching engine relied mainly on Jaccard text similarity, which could give high scores to creators who mentioned a technology in their bio without actually listing it as a skill. Category alignment was handled only via a single disciplineMatch heuristic. There was no signal for how recently a creator had been active or their response rate.

Changes in lib/matching-engine.ts:
- Added exactSkillOverlap(bounty, creator): counts what fraction of the bounty's required tags appear verbatim in creator.skills (case-insensitive). Returns 0–1 and is independent of bio text, so a creator who merely mentions a tool in their bio does not benefit from this signal.
- Added exactCategoryMatch(bounty, creator): returns 1 for exact discipline/category equality, 0.5 for substring containment, and 0 otherwise. This is separate from the existing disciplineMatch heuristic (which is kept for backward compatibility).
- Added activityBoost(creator, config): combines recency of last completed bounty (exponential decay over configurable window, default 180 days) with response rate (0–1). The two sub-signals are blended 60/40. The config object exposes a weight multiplier and recencyWindowDays so callers can tune this per A/B strategy.
- Extended CreatorFeatures interface with optional lastBountyCompletedAt and responseRate fields (both nullable so existing callers are unaffected).
- Extended MatchScoreBreakdown.components with exactSkill, exactCategory, and activity fields.
- Updated WEIGHTS table for all three A/B strategies (control, treatment_skill, treatment_budget) to include weights for the two new exact-match components and the activity boost. treatment_skill now amplifies exactSkill at 2.2× and exactCat at 1.8× to strongly favour creators whose skills literally match the brief.
- Updated scoreCreatorBountyPair to accept an optional activityConfig parameter, compute all eight components, normalise correctly, and emit activity-related reasons in the returned reasons array.
- Added reason messages: 'Exact skill match with bounty requirements', 'Category exactly matches your discipline', and 'Recently active with high response rate'.

Changes in __tests__/lib/matching-engine.test.ts:
- Imported the three new exported functions.
- Added describe block 'exactSkillOverlap' with 5 cases: full match, partial match, no match, case-insensitivity, empty tags.
- Added describe block 'exactCategoryMatch' with 4 cases: exact, partial containment, no match, missing fields.
- Added describe block 'activityBoost' with 4 cases: recent active, zero activity, decayed past window, weight multiplier.
- Added describe block 'scoreCreatorBountyPair — exact match edge cases' with 4 cases: exact skill beats text-similar creator, new component fields present in output, activity reason present, treatment_skill beats treatment_budget for exact-skill creator.

Closes #878

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Issue #879 — Add offline-first bounty application queue ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Problem: The bounty application form submitted directly to the API with no offline fallback. Users on unstable networks would see a hard failure with no recovery path. The existing offline-queue.ts provided a generic OfflineMutation type but no typed helpers for bounty applications and no reconnect listener fallback.

Changes in lib/sw/offline-queue.ts:
- Added BountyApplicationMutation interface extending OfflineMutation with type: 'bounty-application', bountyTitle (for UX display), and retries counter.
- Added enqueueBountyApplication(payload, bountyTitle): constructs a typed BountyApplicationMutation targeting /api/bounty-applications, calls the generic enqueue(), then calls registerOnlineFlush() as a fallback for browsers without Background Sync support.
- Added listQueuedBountyApplications(): filters listAllWithKeys to return only BountyApplicationMutation entries, typed correctly.
- Added registerOnlineFlush(): attaches a one-time window 'online' event listener that calls flush() when connectivity returns. Guards against multiple registrations with a module-level flag and skips the flush if the browser supports SyncManager (Background Sync takes over in that case). The listener removes itself after firing.
- Updated module comment to reference both the original issue #630 and the new #879.
- Preserved all existing exports unchanged (enqueue, listQueued, flush) so no callers break.

Changes in components/forms/bounty-application-form.tsx:
- Imported enqueueBountyApplication from lib/sw/offline-queue.
- Added isOnline state (initialised from navigator.onLine) with window 'online'/'offline' event listeners that update it live. Listeners are cleaned up in the useEffect return.
- Added queued state to track whether the current submission was saved offline.
- Updated onSubmit: if isOnline is false, calls enqueueBountyApplication and sets queued=true instead of fetching. If isOnline is true but fetch throws (mid-submit network drop), also falls back to enqueueBountyApplication.
- Added offline banner alert (WifiOff icon) shown when isOnline=false.
- Added queued confirmation alert (Clock icon) shown after offline save.
- Submit button label and icon change contextually: shows 'Save for later' with WifiOff when offline, 'Saving offline…' with spinner during save, 'Queued for submission' with Clock after save, and the normal 'Submit application' label when online.
- Button is disabled while queued to prevent duplicate submissions.
- All icons include aria-hidden='true'.

Closes #879

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Issue #880 — Harden Soroban RPC resilience with multi-endpoint
             fallback, retry logic, and health logging
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Problem: TransactionQueue submitted to a single hard-coded Soroban RPC endpoint with a simple fixed retry-delay array. A single endpoint outage would cause all queued transactions to fail. There was no per-attempt logging and no way for a dashboard to inspect endpoint health.

Changes in lib/soroban/transaction-queue.ts:
- Replaced the bespoke submitTransaction + submitToSoroban chain with submitWithRetry, which drives exponential backoff and delegates to submitToSorobanRpc.
- submitToSorobanRpc calls rpcCall() from lib/config/rpc-fallback, which already manages an endpoint pool, rotates on failure, and runs background latency probes. Failures at one endpoint automatically fall over to the next in the pool before returning an error to the caller.
- Added backoffMs(attempt, base, cap, jitter): a pure utility that computes 2^(attempt-1) * base, caps at cap, and adds ±25% random jitter by default. Exported for unit testing.
- Added RpcAttemptLog interface with fields txId, attempt, endpoint, latencyMs, success, error.
- Added a module-level ring buffer (capacity 200) and logRpcAttempt() to append to it on every submitWithRetry iteration (both success and failure paths).
- Added getRpcAttemptLog(): returns a readonly snapshot of the buffer.
- Added getRpcHealth() instance method on TransactionQueue that delegates to getPoolHealth(network) — returns [{url, latencyMs}] for all endpoints in the pool.
- TransactionQueue constructor now accepts an optional network parameter (default 'mainnet') and calls startProbing(network) so background latency probes begin immediately.
- getTransactionQueue() factory accepts the same optional network parameter.
- Removed the unused retryDelays array and isRetryableError() method.
- Removed the unused maxConcurrent field.
- SubmissionResult gains an optional endpoint field recording which URL served the successful response.

New file hooks/useRpcHealth.ts:
- Exports useRpcHealth(network, pollMs, logLimit) React hook.
- Polls getPoolHealth (via rpc-fallback) and getRpcAttemptLog (via transaction-queue) every pollMs milliseconds (default 15 s).
- Derives a status field per endpoint: 'healthy' (<1 s), 'degraded' (>=1 s), 'unreachable' (Infinity).
- Returns { endpoints, recentLogs, lastUpdated, refresh } — refresh() can be called manually from a dashboard button.
- Marked 'use client' for Next.js App Router compatibility.

Closes #880