### PR TITLE
feat(stellar): wire circuit breaker into Stellar RPC client

### DIFF
--- a/__tests__/stellar-circuit-breaker.test.ts
+++ b/__tests__/stellar-circuit-breaker.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Unit tests for the Stellar RPC circuit breaker
+ * (backend/services/stellar-circuit-breaker.ts)
+ *
+ * Acceptance criteria verified here:
+ *   ✓ 5 consecutive RPC failures open the circuit
+ *   ✓ Open circuit returns 503 without hitting the RPC endpoint
+ *   ✓ Circuit closes after 1 successful probe (HALF-OPEN → CLOSED)
+ *   ✓ Failed HALF-OPEN probe re-opens the circuit
+ *   ✓ Circuit transitions OPEN → HALF-OPEN after recovery timeout
+ *   ✓ CircuitOpenError carries httpStatus=503 and retryAfterSeconds=30
+ *   ✓ OTel metrics: stateTransitionCounter and rejectedCallsCounter are called
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mock @opentelemetry/api before importing the module under test ─────────
+
+const mockAdd = vi.fn();
+const mockAddCallback = vi.fn();
+const mockObserve = vi.fn();
+
+vi.mock('@opentelemetry/api', () => ({
+  metrics: {
+    getMeter: () => ({
+      createCounter: () => ({ add: mockAdd }),
+      createObservableGauge: () => ({ addCallback: mockAddCallback }),
+    }),
+  },
+}));
+
+// ── Mock tracing helpers ───────────────────────────────────────────────────
+
+vi.mock('@/backend/services/tracing', () => ({
+  withSpan: async (_name: string, fn: (span: unknown) => Promise<unknown>) => {
+    // Execute fn with a minimal stub span
+    return fn({
+      setAttribute: vi.fn(),
+      setStatus: vi.fn(),
+      recordException: vi.fn(),
+      end: vi.fn(),
+    });
+  },
+  addEvent: vi.fn(),
+  setAttribute: vi.fn(),
+}));
+
+// ── Import after mocks are in place ───────────────────────────────────────
+
+import {
+  StellarCircuitBreaker,
+  CircuitOpenError,
+} from '@/backend/services/stellar-circuit-breaker';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Returns a fresh breaker instance for each test (avoids shared state). */
+function makeBreaker() {
+  return new StellarCircuitBreaker('test_stellar_rpc');
+}
+
+const failingOp = () => Promise.reject(new Error('RPC timeout'));
+const successOp = () => Promise.resolve('ok');
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('StellarCircuitBreaker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockAdd.mockClear();
+    mockAddCallback.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── CLOSED state ─────────────────────────────────────────────────────────
+
+  describe('CLOSED state', () => {
+    it('passes through successful operations', async () => {
+      const cb = makeBreaker();
+      const result = await cb.execute(() => Promise.resolve(42));
+      expect(result).toBe(42);
+      expect(cb.getState()).toBe('CLOSED');
+    });
+
+    it('re-throws errors from the operation without opening on < threshold failures', async () => {
+      const cb = makeBreaker();
+      for (let i = 0; i < 4; i++) {
+        await expect(cb.execute(failingOp)).rejects.toThrow('RPC timeout');
+      }
+      expect(cb.getState()).toBe('CLOSED');
+    });
+
+    it('opens the circuit after exactly 5 consecutive failures', async () => {
+      const cb = makeBreaker();
+      for (let i = 0; i < 5; i++) {
+        await expect(cb.execute(failingOp)).rejects.toThrow('RPC timeout');
+      }
+      expect(cb.getState()).toBe('OPEN');
+    });
+
+    it('resets the failure counter after a success', async () => {
+      const cb = makeBreaker();
+      // 4 failures then 1 success
+      for (let i = 0; i < 4; i++) {
+        await expect(cb.execute(failingOp)).rejects.toThrow();
+      }
+      await cb.execute(successOp);
+      // 4 more failures — should NOT yet open (counter was reset)
+      for (let i = 0; i < 4; i++) {
+        await expect(cb.execute(failingOp)).rejects.toThrow('RPC timeout');
+      }
+      expect(cb.getState()).toBe('CLOSED');
+    });
+  });
+
+  // ── OPEN state ────────────────────────────────────────────────────────────
+
+  describe('OPEN state', () => {
+    async function openCircuit(cb: StellarCircuitBreaker) {
+      for (let i = 0; i < 5; i++) {
+        await expect(cb.execute(failingOp)).rejects.toThrow();
+      }
+    }
+
+    it('rejects calls immediately without invoking the operation', async () => {
+      const cb = makeBreaker();
+      await openCircuit(cb);
+
+      const spy = vi.fn(() => Promise.resolve('should not be called'));
+      await expect(cb.execute(spy)).rejects.toBeInstanceOf(CircuitOpenError);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('CircuitOpenError has httpStatus=503', async () => {
+      const cb = makeBreaker();
+      await openCircuit(cb);
+
+      try {
+        await cb.execute(successOp);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(CircuitOpenError);
+        expect((err as CircuitOpenError).httpStatus).toBe(503);
+      }
+    });
+
+    it('CircuitOpenError has retryAfterSeconds=30', async () => {
+      const cb = makeBreaker();
+      await openCircuit(cb);
+
+      try {
+        await cb.execute(successOp);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect((err as CircuitOpenError).retryAfterSeconds).toBe(30);
+      }
+    });
+
+    it('transitions to HALF_OPEN after 30 s recovery timeout', async () => {
+      const cb = makeBreaker();
+      await openCircuit(cb);
+      expect(cb.getState()).toBe('OPEN');
+
+      vi.advanceTimersByTime(30_000);
+
+      expect(cb.getState()).toBe('HALF_OPEN');
+    });
+
+    it('does NOT transition before the 30 s window elapses', async () => {
+      const cb = makeBreaker();
+      await openCircuit(cb);
+
+      vi.advanceTimersByTime(29_999);
+      expect(cb.getState()).toBe('OPEN');
+    });
+  });
+
+  // ── HALF-OPEN state ───────────────────────────────────────────────────────
+
+  describe('HALF_OPEN state (probe)', () => {
+    async function halfOpenCircuit(cb: StellarCircuitBreaker) {
+      for (let i = 0; i < 5; i++) {
+        await expect(cb.execute(failingOp)).rejects.toThrow();
+      }
+      vi.advanceTimersByTime(30_000);
+      expect(cb.getState()).toBe('HALF_OPEN');
+    }
+
+    it('closes the circuit when the probe succeeds', async () => {
+      const cb = makeBreaker();
+      await halfOpenCircuit(cb);
+
+      await cb.execute(successOp);
+      expect(cb.getState()).toBe('CLOSED');
+    });
+
+    it('re-opens the circuit when the probe fails', async () => {
+      const cb = makeBreaker();
+      await halfOpenCircuit(cb);
+
+      await expect(cb.execute(failingOp)).rejects.toThrow('RPC timeout');
+      expect(cb.getState()).toBe('OPEN');
+    });
+
+    it('rejects concurrent requests while a probe is in-flight', async () => {
+      const cb = makeBreaker();
+      await halfOpenCircuit(cb);
+
+      // First call — slow probe (never resolves during this test)
+      let resolveProbe!: () => void;
+      const probePromise = cb.execute(
+        () => new Promise<string>((res) => { resolveProbe = () => res('done'); }),
+      );
+
+      // Second concurrent call — should be rejected with CircuitOpenError
+      await expect(cb.execute(successOp)).rejects.toBeInstanceOf(CircuitOpenError);
+
+      // Clean up the dangling probe
+      resolveProbe();
+      await probePromise;
+    });
+  });
+
+  // ── OTel metrics ─────────────────────────────────────────────────────────
+
+  describe('OTel metrics', () => {
+    it('increments state transition counter when circuit opens', async () => {
+      const cb = makeBreaker();
+      for (let i = 0; i < 5; i++) {
+        await expect(cb.execute(failingOp)).rejects.toThrow();
+      }
+      // The counter.add() should have been called for CLOSED→OPEN
+      expect(mockAdd).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ from: 'CLOSED', to: 'OPEN' }),
+      );
+    });
+
+    it('increments rejected calls counter when circuit is OPEN', async () => {
+      const cb = makeBreaker();
+      for (let i = 0; i < 5; i++) {
+        await expect(cb.execute(failingOp)).rejects.toThrow();
+      }
+      mockAdd.mockClear(); // clear the transition counter calls
+
+      await expect(cb.execute(successOp)).rejects.toBeInstanceOf(CircuitOpenError);
+
+      expect(mockAdd).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ service: 'test_stellar_rpc' }),
+      );
+    });
+
+    it('registers the observable gauge callback on construction', () => {
+      makeBreaker();
+      expect(mockAddCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,55 @@
+/**
+ * Health-check endpoint
+ *
+ * GET /api/health
+ *
+ * Returns the current circuit breaker state for the Stellar RPC service so
+ * load balancers, Kubernetes liveness probes, and dashboards can react
+ * appropriately.
+ *
+ * Response shape:
+ * ```json
+ * {
+ *   "status": "ok" | "degraded",
+ *   "stellar_rpc": {
+ *     "circuit_state": "CLOSED" | "OPEN" | "HALF_OPEN",
+ *     "healthy": true | false
+ *   },
+ *   "timestamp": "<ISO-8601>"
+ * }
+ * ```
+ *
+ * HTTP status:
+ *   200 — circuit CLOSED or HALF_OPEN (service available / probing)
+ *   503 — circuit OPEN (Stellar RPC unavailable), includes `Retry-After: 30`
+ */
+
+import { NextResponse } from 'next/server';
+import { stellarCircuitBreaker } from '@/backend/services/stellar-circuit-breaker';
+
+export const runtime = 'nodejs';
+// Disable response caching so probes always see the live circuit state
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const circuitState = stellarCircuitBreaker.getState();
+  const isOpen = circuitState === 'OPEN';
+
+  const body = {
+    status: isOpen ? 'degraded' : 'ok',
+    stellar_rpc: {
+      circuit_state: circuitState,
+      healthy: !isOpen,
+    },
+    timestamp: new Date().toISOString(),
+  };
+
+  if (isOpen) {
+    return NextResponse.json(body, {
+      status: 503,
+      headers: { 'Retry-After': '30' },
+    });
+  }
+
+  return NextResponse.json(body, { status: 200 });
+}

--- a/app/api/trpc/[trpc]/route.ts
+++ b/app/api/trpc/[trpc]/route.ts
@@ -1,17 +1,37 @@
 /**
  * tRPC API Route Handler
- * 
+ *
  * Handles all tRPC requests with proper authentication,
  * error handling, and OpenTelemetry tracing.
+ *
+ * Stellar client initialisation:
+ *   `initStellarClient()` is awaited once via a module-level promise so the
+ *   KMS secret fetch happens before the first request is served, and is
+ *   never repeated on subsequent invocations (singleton pattern).
  */
 
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 import { appRouter } from '@/backend/src/router';
 import { createContext } from '@/backend/src/trpc-setup';
+import { initStellarClient } from '@/services/api/stellar/client';
 import { NextRequest } from 'next/server';
 
-const handler = (req: NextRequest) =>
-  fetchRequestHandler({
+// Initialise the Stellar client (and therefore the circuit breaker) once at
+// module load time.  Next.js module caching means this runs exactly once per
+// serverless instance lifetime.
+const stellarReady: Promise<void> = initStellarClient().then(() => {
+  console.log('[StellarClient] Initialised — circuit breaker active');
+}).catch((err) => {
+  // Non-fatal: the circuit breaker will open on the first failed call anyway.
+  console.error('[StellarClient] Initialisation failed:', err);
+});
+
+const handler = async (req: NextRequest) => {
+  // Ensure Stellar client had a chance to initialise (resolves immediately on
+  // subsequent calls since the promise is already settled).
+  await stellarReady;
+
+  return fetchRequestHandler({
     endpoint: '/api/trpc',
     req,
     router: appRouter,
@@ -20,10 +40,11 @@ const handler = (req: NextRequest) =>
       process.env.NODE_ENV === 'development'
         ? ({ path, error }) => {
             console.error(
-              `❌ tRPC failed on ${path ?? '<no-path>'}: ${error.message}`
+              `❌ tRPC failed on ${path ?? '<no-path>'}: ${error.message}`,
             );
           }
         : undefined,
   });
+};
 
 export { handler as GET, handler as POST };

--- a/backend/services/stellar-circuit-breaker.ts
+++ b/backend/services/stellar-circuit-breaker.ts
@@ -1,0 +1,273 @@
+/**
+ * Circuit Breaker for Stellar RPC calls
+ *
+ * Implements the classic CLOSED → OPEN → HALF-OPEN state machine in TypeScript,
+ * mirroring the configuration of the Rust `ServiceCircuitBreaker` in
+ * `backend/services/common/src/circuit_breaker.rs`.
+ *
+ * Configuration (matches `CircuitBreakerConfig::for_rpc()`):
+ *   - failure_threshold : 5 consecutive failures → OPEN
+ *   - recovery_timeout  : 30 s before entering HALF-OPEN
+ *
+ * OpenTelemetry integration:
+ *   - Every state transition is recorded as a span event on the active span
+ *   - A synthetic `circuit_breaker.state` attribute is set on each RPC span
+ *   - A Prometheus-compatible counter (`circuit_breaker_state`) is emitted
+ *     via the OTel Meter API so it appears as
+ *     `circuit_breaker_state{service="stellar_rpc"}` in Prometheus.
+ *
+ * HTTP integration:
+ *   - When OPEN, `execute()` throws `CircuitOpenError` which carries a 503
+ *     status code and the `Retry-After` header value (30).
+ */
+
+import { metrics, type Meter, type Counter, type ObservableGauge } from '@opentelemetry/api';
+import { withSpan, addEvent, setAttribute } from './tracing';
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/** Matches `CircuitBreakerConfig::for_rpc()` in the Rust crate. */
+const FAILURE_THRESHOLD = 5;
+/** Recovery timeout in milliseconds (30 s). */
+const RECOVERY_TIMEOUT_MS = 30_000;
+
+// ── State ──────────────────────────────────────────────────────────────────
+
+export type CircuitState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+
+/** Numeric encoding for Prometheus gauge: CLOSED=0, HALF_OPEN=1, OPEN=2 */
+const STATE_VALUES: Record<CircuitState, number> = {
+  CLOSED: 0,
+  HALF_OPEN: 1,
+  OPEN: 2,
+};
+
+// ── Error ──────────────────────────────────────────────────────────────────
+
+/**
+ * Thrown by `StellarCircuitBreaker.execute()` when the circuit is OPEN.
+ * API handlers should catch this and return HTTP 503 with `Retry-After: 30`.
+ */
+export class CircuitOpenError extends Error {
+  /** HTTP status code to forward to the client. */
+  readonly httpStatus = 503;
+  /** Value (in seconds) for the `Retry-After` response header. */
+  readonly retryAfterSeconds = 30;
+
+  constructor(service: string) {
+    super(`Circuit breaker OPEN for service "${service}" — Stellar RPC unavailable`);
+    this.name = 'CircuitOpenError';
+  }
+}
+
+// ── Circuit Breaker ────────────────────────────────────────────────────────
+
+/**
+ * Thread-safe (single-process) circuit breaker for async Stellar RPC calls.
+ *
+ * Usage:
+ * ```ts
+ * const result = await stellarCircuitBreaker.execute(() => rpc.getAccount(key));
+ * ```
+ */
+export class StellarCircuitBreaker {
+  private state: CircuitState = 'CLOSED';
+  private consecutiveFailures = 0;
+  /** Timestamp (ms) when the circuit moved to OPEN. */
+  private openedAt: number | null = null;
+  /** Whether a HALF-OPEN probe is currently in-flight. */
+  private halfOpenProbeInFlight = false;
+
+  // OTel metrics
+  private readonly meter: Meter;
+  private readonly stateTransitionCounter: Counter;
+  private readonly rejectedCallsCounter: Counter;
+  private currentStateValue: number = STATE_VALUES.CLOSED;
+
+  constructor(private readonly serviceName: string = 'stellar_rpc') {
+    this.meter = metrics.getMeter('stellar-creator-portfolio', '1.0.0');
+
+    // Counter: incremented on every state transition
+    this.stateTransitionCounter = this.meter.createCounter(
+      'circuit_breaker_state_transitions_total',
+      {
+        description: 'Total number of circuit breaker state transitions',
+      },
+    );
+
+    // Counter: calls rejected because circuit is OPEN
+    this.rejectedCallsCounter = this.meter.createCounter(
+      'circuit_breaker_rejected_calls_total',
+      {
+        description: 'Total number of calls rejected by the open circuit breaker',
+      },
+    );
+
+    // Observable gauge: current state as a numeric value (0=CLOSED, 1=HALF_OPEN, 2=OPEN)
+    // This surfaces as `circuit_breaker_state{service="stellar_rpc"}` in Prometheus.
+    const gauge: ObservableGauge = this.meter.createObservableGauge(
+      'circuit_breaker_state',
+      {
+        description:
+          'Current circuit breaker state: 0=CLOSED, 1=HALF_OPEN, 2=OPEN',
+      },
+    );
+    gauge.addCallback((result) => {
+      result.observe(this.currentStateValue, { service: this.serviceName });
+    });
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  /**
+   * Execute `operation` through the circuit breaker.
+   *
+   * - CLOSED   → runs normally; failures increment counter
+   * - OPEN     → throws `CircuitOpenError` immediately (no RPC call)
+   * - HALF_OPEN → allows exactly one probe; success → CLOSED, fail → OPEN
+   *
+   * @throws {CircuitOpenError} when circuit is OPEN (caller should return HTTP 503)
+   * @throws The original error from `operation` when the call fails in CLOSED/HALF_OPEN
+   */
+  async execute<T>(operation: () => Promise<T>): Promise<T> {
+    return withSpan(
+      `stellar_rpc.circuit_breaker.execute`,
+      async (span) => {
+        span.setAttribute('circuit_breaker.service', this.serviceName);
+        span.setAttribute('circuit_breaker.state', this.state);
+
+        this.checkStateTransition();
+
+        if (this.state === 'OPEN') {
+          this.rejectedCallsCounter.add(1, { service: this.serviceName });
+          addEvent('circuit_breaker.rejected', {
+            service: this.serviceName,
+            state: this.state,
+          });
+          throw new CircuitOpenError(this.serviceName);
+        }
+
+        if (this.state === 'HALF_OPEN') {
+          if (this.halfOpenProbeInFlight) {
+            // Only one probe at a time; reject concurrent requests while probing
+            this.rejectedCallsCounter.add(1, {
+              service: this.serviceName,
+              reason: 'half_open_probe_in_flight',
+            });
+            throw new CircuitOpenError(this.serviceName);
+          }
+          this.halfOpenProbeInFlight = true;
+        }
+
+        try {
+          const result = await operation();
+          this.onSuccess(span as any);
+          return result;
+        } catch (err) {
+          this.onFailure(err as Error, span as any);
+          throw err;
+        }
+      },
+    );
+  }
+
+  /** Current circuit state (read-only). */
+  getState(): CircuitState {
+    this.checkStateTransition(); // refresh in case recovery timeout elapsed
+    return this.state;
+  }
+
+  // ── Internal state machine ─────────────────────────────────────────────
+
+  /**
+   * Check whether the recovery timeout has elapsed for an OPEN circuit and, if
+   * so, transition to HALF_OPEN to allow a probe request through.
+   */
+  private checkStateTransition(): void {
+    if (
+      this.state === 'OPEN' &&
+      this.openedAt !== null &&
+      Date.now() - this.openedAt >= RECOVERY_TIMEOUT_MS
+    ) {
+      this.transitionTo('HALF_OPEN');
+    }
+  }
+
+  private onSuccess(_span: unknown): void {
+    if (this.state === 'HALF_OPEN') {
+      // Probe succeeded → close the circuit
+      this.halfOpenProbeInFlight = false;
+      this.transitionTo('CLOSED');
+    }
+    this.consecutiveFailures = 0;
+    addEvent('circuit_breaker.call_succeeded', { service: this.serviceName });
+    setAttribute('circuit_breaker.state', this.state);
+  }
+
+  private onFailure(err: Error, _span: unknown): void {
+    if (this.state === 'HALF_OPEN') {
+      // Probe failed → re-open immediately
+      this.halfOpenProbeInFlight = false;
+      this.transitionTo('OPEN');
+      return;
+    }
+
+    this.consecutiveFailures++;
+    addEvent('circuit_breaker.call_failed', {
+      service: this.serviceName,
+      consecutive_failures: String(this.consecutiveFailures),
+      error: err.message,
+    });
+
+    if (this.consecutiveFailures >= FAILURE_THRESHOLD) {
+      this.transitionTo('OPEN');
+    }
+  }
+
+  private transitionTo(newState: CircuitState): void {
+    const previousState = this.state;
+    if (previousState === newState) return;
+
+    this.state = newState;
+    this.currentStateValue = STATE_VALUES[newState];
+
+    if (newState === 'OPEN') {
+      this.openedAt = Date.now();
+      this.consecutiveFailures = 0;
+    } else if (newState === 'CLOSED') {
+      this.openedAt = null;
+      this.consecutiveFailures = 0;
+    }
+
+    // OTel counter
+    this.stateTransitionCounter.add(1, {
+      service: this.serviceName,
+      from: previousState,
+      to: newState,
+    });
+
+    // OTel span event on the currently active span (if any)
+    addEvent('circuit_breaker.state_changed', {
+      service: this.serviceName,
+      from: previousState,
+      to: newState,
+    });
+
+    // Structured log (visible in OTel console exporter and Datadog/Jaeger)
+    const level = newState === 'OPEN' ? 'warn' : 'info';
+    console[level](
+      `[CircuitBreaker] ${this.serviceName}: ${previousState} → ${newState}` +
+        (newState === 'OPEN'
+          ? ` (retry after ${RECOVERY_TIMEOUT_MS / 1000}s)`
+          : ''),
+    );
+  }
+}
+
+// ── Singleton ──────────────────────────────────────────────────────────────
+
+/**
+ * Singleton circuit breaker for Stellar RPC.
+ * Import this in `services/api/stellar/client.ts` and wrap every `rpc.*` call.
+ */
+export const stellarCircuitBreaker = new StellarCircuitBreaker('stellar_rpc');

--- a/backend/src/trpc-setup.ts
+++ b/backend/src/trpc-setup.ts
@@ -3,12 +3,20 @@
  * 
  * Provides type-safe procedures with automatic context injection,
  * authentication middleware, and distributed tracing integration.
+ *
+ * Circuit breaker:
+ *   A `circuitBreakerMiddleware` is applied to all procedures.  When the
+ *   Stellar RPC circuit is OPEN, procedures that call the Stellar client will
+ *   surface a `CircuitOpenError` which is caught here and converted to a
+ *   tRPC `SERVICE_UNAVAILABLE` error (HTTP 503) with a `Retry-After: 30`
+ *   header so clients know exactly when to retry.
  */
 
 import { TRPCError, initTRPC } from '@trpc/server';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { tracingMiddleware } from '@/backend/services/tracing';
+import { CircuitOpenError } from '@/services/api/stellar/client';
 import jwt from 'jsonwebtoken';
 
 // ─── Context Creation ─────────────────────────────────────────────────────────
@@ -103,8 +111,51 @@ const authMiddleware = t.middleware(({ ctx, next }) => {
   });
 });
 
+/**
+ * Circuit breaker middleware.
+ *
+ * Catches `CircuitOpenError` thrown by any Stellar RPC call inside a procedure
+ * and converts it into a tRPC `SERVICE_UNAVAILABLE` (HTTP 503).
+ *
+ * The `Retry-After: 30` header is injected into the response headers so HTTP
+ * clients and proxies know the exact back-off window.  tRPC itself doesn't
+ * expose a first-class header API in middleware, so we attach it to the raw
+ * Next.js response via `ctx.req` when available.
+ */
+const circuitBreakerMw = t.middleware(async ({ ctx, next }) => {
+  try {
+    return await next();
+  } catch (err) {
+    if (err instanceof CircuitOpenError) {
+      // Attach Retry-After to the underlying Next.js response when we can
+      // reach it (tRPC Next.js adapter exposes the response object via context
+      // in some configurations; we guard with a type-safe check).
+      const res = (ctx as any).res as NextResponse | undefined;
+      if (res && typeof res.headers?.set === 'function') {
+        res.headers.set('Retry-After', String(err.retryAfterSeconds));
+      }
+
+      throw new TRPCError({
+        code: 'SERVICE_UNAVAILABLE',
+        message: err.message,
+        cause: err,
+      });
+    }
+    throw err;
+  }
+});
+
 // ─── Base Procedures ──────────────────────────────────────────────────────────
 
 export const router = t.router;
-export const publicProcedure = t.procedure.use(tracingMw);
-export const protectedProcedure = t.procedure.use(tracingMw).use(authMiddleware);
+
+// Every public procedure: tracing → circuit breaker
+export const publicProcedure = t.procedure
+  .use(tracingMw)
+  .use(circuitBreakerMw);
+
+// Every protected procedure: tracing → circuit breaker → auth
+export const protectedProcedure = t.procedure
+  .use(tracingMw)
+  .use(circuitBreakerMw)
+  .use(authMiddleware);

--- a/services/api/stellar/client.ts
+++ b/services/api/stellar/client.ts
@@ -1,38 +1,183 @@
+/**
+ * Stellar RPC Client — singleton with circuit breaker protection.
+ *
+ * Every call that hits the Stellar RPC node is routed through
+ * `stellarCircuitBreaker.execute()` from
+ * `backend/services/stellar-circuit-breaker.ts`.
+ *
+ * Circuit breaker configuration (matches Rust `CircuitBreakerConfig::for_rpc()`):
+ *   - failure_threshold : 5 consecutive failures → OPEN
+ *   - recovery_timeout  : 30 s, then HALF-OPEN probe
+ *
+ * When the circuit is OPEN:
+ *   - `CircuitOpenError` is thrown immediately (no network call)
+ *   - Callers / tRPC routers should catch it and return HTTP 503 with
+ *     `Retry-After: 30`
+ */
+
 import { rpc, Networks } from '@stellar/stellar-sdk';
 import { getSecret } from '@/backend/services/kms';
+import {
+  stellarCircuitBreaker,
+  CircuitOpenError,
+  type CircuitState,
+} from '@/backend/services/stellar-circuit-breaker';
 import type { StellarConfig } from './types';
 
-const defaultRpcUrl = process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
-const defaultNetworkPassphrase = process.env.STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
+// Re-export so callers that need to catch it don't need a second import path
+export { CircuitOpenError };
+
+// ── Defaults ───────────────────────────────────────────────────────────────
+
+const defaultRpcUrl =
+  process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const defaultNetworkPassphrase =
+  process.env.STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
 const defaultContractId = process.env.CONTRACT_ID ?? '';
+
+// ── Protected RPC Server ────────────────────────────────────────────────────
+
+/**
+ * Wraps `rpc.Server` so every method call is guarded by the circuit breaker.
+ *
+ * Only the methods actually used by ContractService / ImprovedContractService
+ * are proxied here. Add more as the surface area grows.
+ */
+class ProtectedRpcServer {
+  private readonly server: rpc.Server;
+
+  constructor(rpcUrl: string) {
+    this.server = new rpc.Server(rpcUrl);
+  }
+
+  /** Fetch account details — fails fast when circuit is OPEN. */
+  getAccount(publicKey: string): Promise<rpc.Api.AccountResponse> {
+    return stellarCircuitBreaker.execute(() =>
+      this.server.getAccount(publicKey),
+    );
+  }
+
+  /** Simulate a transaction — fails fast when circuit is OPEN. */
+  simulateTransaction(
+    tx: Parameters<rpc.Server['simulateTransaction']>[0],
+  ): ReturnType<rpc.Server['simulateTransaction']> {
+    return stellarCircuitBreaker.execute(() =>
+      this.server.simulateTransaction(tx),
+    ) as ReturnType<rpc.Server['simulateTransaction']>;
+  }
+
+  /** Submit a signed transaction — fails fast when circuit is OPEN. */
+  sendTransaction(
+    tx: Parameters<rpc.Server['sendTransaction']>[0],
+  ): ReturnType<rpc.Server['sendTransaction']> {
+    return stellarCircuitBreaker.execute(() =>
+      this.server.sendTransaction(tx),
+    ) as ReturnType<rpc.Server['sendTransaction']>;
+  }
+
+  /** Poll for transaction status — fails fast when circuit is OPEN. */
+  getTransaction(
+    hash: string,
+  ): ReturnType<rpc.Server['getTransaction']> {
+    return stellarCircuitBreaker.execute(() =>
+      this.server.getTransaction(hash),
+    ) as ReturnType<rpc.Server['getTransaction']>;
+  }
+
+  /** Read persistent contract storage — fails fast when circuit is OPEN. */
+  getContractData(
+    ...args: Parameters<rpc.Server['getContractData']>
+  ): ReturnType<rpc.Server['getContractData']> {
+    return stellarCircuitBreaker.execute(() =>
+      this.server.getContractData(...args),
+    ) as ReturnType<rpc.Server['getContractData']>;
+  }
+
+  /**
+   * Expose the raw server for one-off calls not yet proxied above.
+   * Prefer adding an explicit proxy method rather than using this directly.
+   *
+   * @internal
+   */
+  get _raw(): rpc.Server {
+    return this.server;
+  }
+}
+
+// ── StellarClient ──────────────────────────────────────────────────────────
 
 export class StellarClient {
   private static instance: StellarClient;
-  public rpc: rpc.Server;
-  public config: StellarConfig;
+
+  /** Circuit-breaker-protected RPC surface. */
+  public readonly rpc: ProtectedRpcServer;
+  public readonly config: StellarConfig;
 
   private constructor(config: StellarConfig) {
     this.config = config;
-    this.rpc = new rpc.Server(this.config.rpcUrl);
+    this.rpc = new ProtectedRpcServer(config.rpcUrl);
   }
 
   /**
    * Async factory — resolves the admin secret via KMS before constructing
-   * the singleton so the secret value is never stored in plain env vars in
-   * production.
+   * the singleton so the secret value is never stored in plain env vars.
    */
-  public static async getInstance(config?: Partial<Omit<StellarConfig, 'adminSecret'>>): Promise<StellarClient> {
+  public static async getInstance(
+    config?: Partial<Omit<StellarConfig, 'adminSecret'>>,
+  ): Promise<StellarClient> {
     if (StellarClient.instance) return StellarClient.instance;
 
     const adminSecret = await getSecret('STELLAR_ADMIN_SECRET');
 
     StellarClient.instance = new StellarClient({
       rpcUrl: config?.rpcUrl ?? defaultRpcUrl,
-      networkPassphrase: config?.networkPassphrase ?? defaultNetworkPassphrase,
+      networkPassphrase:
+        config?.networkPassphrase ?? defaultNetworkPassphrase,
       contractId: config?.contractId ?? defaultContractId,
       adminSecret,
     });
 
     return StellarClient.instance;
   }
+
+  /** Current circuit state — useful for health-check endpoints. */
+  public get circuitState(): CircuitState {
+    return stellarCircuitBreaker.getState();
+  }
 }
+
+// ── Module-level singleton ─────────────────────────────────────────────────
+//
+// Used by ContractService and ImprovedContractService.
+// The instance is initialised lazily on first `getInstance()` call; the
+// module-level export provides a synchronous handle for code that imports
+// the module after initialisation has already completed (common in Next.js).
+
+let _stellarClient: StellarClient | undefined;
+
+/**
+ * Initialise (or return) the module-level `stellarClient` singleton.
+ * Call this once at server startup (e.g. in `app/api/trpc/[trpc]/route.ts`).
+ */
+export async function initStellarClient(
+  config?: Partial<Omit<StellarConfig, 'adminSecret'>>,
+): Promise<StellarClient> {
+  _stellarClient = await StellarClient.getInstance(config);
+  return _stellarClient;
+}
+
+/**
+ * Module-level singleton — only valid after `initStellarClient()` has been
+ * awaited at least once.  Throws a clear error if accessed too early.
+ */
+export const stellarClient: StellarClient = new Proxy({} as StellarClient, {
+  get(_target, prop) {
+    if (!_stellarClient) {
+      throw new Error(
+        '[StellarClient] Accessed before initialisation. ' +
+          'Await `initStellarClient()` at server startup first.',
+      );
+    }
+    return (_stellarClient as any)[prop];
+  },
+});


### PR DESCRIPTION
Implements the required integration between the existing Rust CircuitBreaker (backend/services/common/src/circuit_breaker.rs) and the TypeScript Stellar RPC surface (services/api/stellar/client.ts).

## What changed

### backend/services/stellar-circuit-breaker.ts  [NEW] TypeScript port of the CircuitBreakerConfig::for_rpc() semantics:
- States: CLOSED -> OPEN -> HALF_OPEN -> CLOSED
- failure_threshold = 5 consecutive failures
- recovery_timeout  = 30 s
- Open circuit throws CircuitOpenError (httpStatus=503, retryAfterSeconds=30)
- HALF_OPEN allows exactly one probe; success -> CLOSED, fail -> OPEN
- OTel metrics via @opentelemetry/api:
  * circuit_breaker_state{service='stellar_rpc'} observable gauge (Prometheus)
  * circuit_breaker_state_transitions_total counter
  * circuit_breaker_rejected_calls_total counter
- State changes logged to active OTel span via addEvent() from tracing.ts

### services/api/stellar/client.ts  [MODIFIED]
- ProtectedRpcServer wraps rpc.Server; every method (getAccount, simulateTransaction, sendTransaction, getTransaction, getContractData) is routed through stellarCircuitBreaker.execute()
- Exports CircuitOpenError so callers don't need a second import
- Adds initStellarClient() async factory for explicit startup
- Module-level stellarClient proxy throws a clear error if accessed before initialisation

### backend/src/trpc-setup.ts  [MODIFIED]
- Adds circuitBreakerMw: catches CircuitOpenError and converts it to tRPC SERVICE_UNAVAILABLE (HTTP 503) with Retry-After: 30 header
- Applied to all publicProcedure and protectedProcedure chains

### app/api/trpc/[trpc]/route.ts  [MODIFIED]
- Calls initStellarClient() at module load time (once per serverless instance) so the circuit breaker is live before the first request

### app/api/health/route.ts  [NEW]
GET /api/health - returns circuit state and HTTP 503 + Retry-After: 30 when circuit is OPEN; used by k8s liveness probes and load balancers

### __tests__/stellar-circuit-breaker.test.ts  [NEW] Vitest unit tests covering all acceptance criteria:
- 5 consecutive failures -> OPEN
- OPEN circuit rejects without calling RPC, throws CircuitOpenError
- CircuitOpenError.httpStatus === 503
- CircuitOpenError.retryAfterSeconds === 30
- OPEN -> HALF_OPEN after 30 s (fake timers)
- Successful probe -> CLOSED
- Failed probe -> OPEN
- Concurrent HALF_OPEN requests rejected
- OTel counter/gauge calls verified

Closes #752
