### PR TITLE
fix: OTA rollback, contract events, and webhook consolidation

### DIFF
--- a/backend/contracts/bounty/src/lib.rs
+++ b/backend/contracts/bounty/src/lib.rs
@@ -149,6 +149,11 @@ impl BountyContract {
             .persistent()
             .set(&bounty_counter_key, &counter);
 
+        env.events().publish(
+            (symbol_short!("bounty"), symbol_short!("created")),
+            (bounty_id, creator, budget, deadline),
+        );
+
         bounty_id
     }
 
@@ -241,6 +246,11 @@ impl BountyContract {
             .persistent()
             .set(&app_counter_key, &counter);
 
+        env.events().publish(
+            (symbol_short!("bounty"), symbol_short!("applied")),
+            (bounty_id, application_id, freelancer),
+        );
+
         application_id
     }
 
@@ -269,10 +279,16 @@ impl BountyContract {
         let application = Self::get_application(env.clone(), application_id);
         assert_eq!(application.bounty_id, bounty_id, "Application does not match bounty");
 
-        bounty.selected_freelancer = Some(application.freelancer);
+        let selected = application.freelancer;
+        bounty.selected_freelancer = Some(selected.clone());
         bounty.status = BountyStatus::InProgress;
 
         env.storage().persistent().set(&bounty_key, &bounty);
+
+        env.events().publish(
+            (symbol_short!("bounty"), symbol_short!("selected")),
+            (bounty_id, application_id, selected),
+        );
 
         true
     }
@@ -323,9 +339,15 @@ impl BountyContract {
         );
 
         bounty.status = BountyStatus::Completed;
-        bounty.completed_at = Some(env.ledger().timestamp());
+        let completed_at = env.ledger().timestamp();
+        bounty.completed_at = Some(completed_at);
 
         env.storage().persistent().set(&bounty_key, &bounty);
+
+        env.events().publish(
+            (symbol_short!("bounty"), symbol_short!("completed")),
+            (bounty_id, completed_at),
+        );
 
         true
     }
@@ -344,6 +366,11 @@ impl BountyContract {
         bounty.status = BountyStatus::Cancelled;
 
         env.storage().persistent().set(&bounty_key, &bounty);
+
+        env.events().publish(
+            (symbol_short!("bounty"), symbol_short!("cancelled")),
+            (bounty_id,),
+        );
 
         true
     }

--- a/backend/contracts/governance/src/lib.rs
+++ b/backend/contracts/governance/src/lib.rs
@@ -188,6 +188,11 @@ impl GovernanceContract {
         env.storage().persistent().extend_ttl(&proposal_key, 4096, ledger_ttl);
         env.storage().persistent().extend_ttl(&proposal_counter_key, 4096, ledger_ttl);
 
+        env.events().publish(
+            (symbol_short!("gov"), symbol_short!("created")),
+            (proposal_id, proposer, proposal.voting_deadline),
+        );
+
         proposal_id
     }
 
@@ -233,6 +238,11 @@ impl GovernanceContract {
         let ledger_ttl = 30 * 24 * 3600 / 5; // ~30 days (5 second blocks)
         env.storage().persistent().extend_ttl(&proposal_key, 4096, ledger_ttl);
         env.storage().persistent().extend_ttl(&vote_key, 4096, ledger_ttl);
+
+        env.events().publish(
+            (symbol_short!("gov"), symbol_short!("voted")),
+            (proposal_id, voter, vote_yes),
+        );
 
         true
     }

--- a/backend/services/api/src/main.rs
+++ b/backend/services/api/src/main.rs
@@ -19,7 +19,7 @@ mod ml;
 mod ml_handlers;
 mod reputation;
 mod verification_rewards;
-mod webhook;
+mod webhooks;
 mod websocket;
 
 pub const API_VERSION: &str = "1";
@@ -1379,7 +1379,7 @@ async fn main() -> std::io::Result<()> {
                     .route("/escrow/{id}", web::get().to(get_escrow))
                     .route(
                         "/webhooks/payment",
-                        web::post().to(webhook::payment_webhook),
+                        web::post().to(webhooks::payment_webhook),
                     )
                     .route(
                         "/payments/{id}/status",

--- a/backend/services/api/src/webhooks/mod.rs
+++ b/backend/services/api/src/webhooks/mod.rs
@@ -1,0 +1,9 @@
+/// Webhook handling — consolidated from the former webhook.rs and webhooks.rs.
+///
+/// - `stripe`  — HMAC-verified payment event handler (Stripe / Coinbase Commerce)
+/// - `soroban` — Soroban event webhook registry and fire-and-forget delivery
+pub mod stripe;
+pub mod soroban;
+
+pub use stripe::payment_webhook;
+pub use soroban::{register_webhook, list_webhooks, delete_webhook, trigger_webhooks};

--- a/backend/services/api/src/webhooks/soroban.rs
+++ b/backend/services/api/src/webhooks/soroban.rs
@@ -1,3 +1,8 @@
+/// Soroban event webhook registry and delivery
+///
+/// Allows external consumers to register HTTPS endpoints that receive
+/// platform events (bounty, escrow, governance) as they are emitted by
+/// the Soroban contracts indexed by the event indexer.
 use actix_web::{web, HttpResponse};
 use deadpool_redis::{redis::AsyncCommands, Pool};
 use serde::{Deserialize, Serialize};

--- a/backend/services/api/src/webhooks/stripe.rs
+++ b/backend/services/api/src/webhooks/stripe.rs
@@ -1,12 +1,11 @@
-/// Webhook handler for external payment events — Issue #346
+/// Stripe (and Coinbase Commerce) payment webhook handler — Issue #346
 ///
-/// Receives signed webhook payloads from external payment processors
-/// (e.g. Stripe, Coinbase Commerce) and maps them to escrow operations
-/// via the Stellar SDK.
+/// Receives signed webhook payloads from external payment processors and maps
+/// them to escrow operations via the Stellar SDK.
 ///
-/// Security: every incoming request must carry a valid HMAC-SHA256
-/// signature in the `X-Webhook-Signature` header.  The secret is read
-/// from the `WEBHOOK_SECRET` environment variable.
+/// Security: every incoming request must carry a valid HMAC-SHA256 signature
+/// in the `X-Webhook-Signature` header.  The secret is read from the
+/// `WEBHOOK_SECRET` environment variable.
 use actix_web::{web, HttpRequest, HttpResponse};
 use hmac::{Hmac, Mac};
 use sha2::Sha256;

--- a/mobile/src/ota/rollback.ts
+++ b/mobile/src/ota/rollback.ts
@@ -1,21 +1,36 @@
 /**
- * #603 — OTA Rollback Manager
+ * #745 — OTA Rollback Manager
  *
- * Tracks consecutive crash counts in AsyncStorage.
- * After MAX_CRASH_COUNT crashes the app auto-rolls back to the last
- * known-good bundle, preventing a crash-loop from bricking the install.
+ * Snapshots the current bundle hash before an update is applied, runs a
+ * smoke test after the update loads, and automatically reverts to the last
+ * known-good bundle if the smoke test fails three times consecutively.
  *
  * Integration:
- *   Call `recordLaunch()` early in your root component (before any async work).
- *   Call `recordStableLaunch()` once the app has been running for STABLE_MS.
+ *   1. Call `snapshotCurrentBundle(hash)` immediately before applying an update.
+ *   2. Call `armStabilityTimer(version)` in your root component.
+ *   3. The timer calls `recordStableLaunch()` after STABLE_MS — resetting the
+ *      failure counter and backing up the bundle.
+ *   4. Optionally call `runSmokeTest(router)` after the new bundle loads to
+ *      check HomeScreen reachability; the manager handles rollback automatically.
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import * as FileSystem from 'expo-file-system'
+import * as Updates from 'expo-updates'
+
+import { TelemetryCollector } from '../services/TelemetryCollector'
+import { SentryErrorTracker } from '../services/SentryErrorTracker'
+import { ROUTES } from '../constants/routes'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
 
 const CRASH_COUNT_KEY = '@ota/crash_count'
 const LAST_GOOD_VERSION_KEY = '@ota/last_good_version'
+const BUNDLE_HASH_KEY = '@ota/bundle_hash_snapshot'
+const SMOKE_FAIL_KEY = '@ota/smoke_fail_count'
+
 const MAX_CRASH_COUNT = 3
+const MAX_SMOKE_FAILURES = 3
 /** App must run for this long without crashing to be considered stable (ms). */
 const STABLE_MS = 10_000
 
@@ -38,13 +53,129 @@ async function resetCrashCount(): Promise<void> {
   await AsyncStorage.removeItem(CRASH_COUNT_KEY)
 }
 
+async function getSmokeFailCount(): Promise<number> {
+  const raw = await AsyncStorage.getItem(SMOKE_FAIL_KEY)
+  return raw ? parseInt(raw, 10) : 0
+}
+
+async function setSmokeFailCount(n: number): Promise<void> {
+  await AsyncStorage.setItem(SMOKE_FAIL_KEY, String(n))
+}
+
+async function resetSmokeFailCount(): Promise<void> {
+  await AsyncStorage.removeItem(SMOKE_FAIL_KEY)
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Snapshot the current bundle hash to AsyncStorage before applying an OTA
+ * update.  Call this immediately before `applyUpdate()` so the rollback
+ * manager can identify the pre-update state.
+ */
+export async function snapshotCurrentBundle(hash: string): Promise<void> {
+  await AsyncStorage.setItem(BUNDLE_HASH_KEY, hash)
+
+  // Also back up the current bundle file so we can restore it on rollback.
+  const info = await FileSystem.getInfoAsync(CURRENT_BUNDLE)
+  if (info.exists) {
+    await FileSystem.makeDirectoryAsync(BUNDLE_DIR, { intermediates: true })
+    await FileSystem.copyAsync({ from: CURRENT_BUNDLE, to: BACKUP_BUNDLE })
+  }
+}
+
+/**
+ * Run a lightweight smoke test: attempt to navigate to HomeScreen and confirm
+ * the route resolves without error.
+ *
+ * Pass the Expo Router `router` object (from `useRouter()`).
+ * Returns `true` if the navigation call succeeded, `false` otherwise.
+ */
+export async function runSmokeTest(
+  router: { navigate: (route: string) => void },
+): Promise<boolean> {
+  try {
+    router.navigate(ROUTES.APP.HOME)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Record the outcome of a smoke test after a new bundle loads.
+ *
+ * - On pass: resets the consecutive failure counter.
+ * - On fail: increments the counter; triggers rollback when MAX_SMOKE_FAILURES
+ *   consecutive failures are reached.
+ *
+ * @param passed      Whether the smoke test passed.
+ * @param bundleVersion  The newly applied bundle version string.
+ */
+export async function recordSmokeTestResult(
+  passed: boolean,
+  bundleVersion: string,
+): Promise<void> {
+  if (passed) {
+    await resetSmokeFailCount()
+    return
+  }
+
+  const count = await getSmokeFailCount()
+  const next = count + 1
+  await setSmokeFailCount(next)
+
+  if (next >= MAX_SMOKE_FAILURES) {
+    await triggerRollback(bundleVersion, `smoke test failed ${next} times consecutively`)
+  }
+}
+
+/**
+ * Revert to the last known-good bundle, report the event to telemetry and
+ * Sentry, then reload the app via `Updates.reloadAsync()`.
+ *
+ * Called automatically by `recordSmokeTestResult` when the threshold is
+ * reached; may also be called manually.
+ */
+export async function triggerRollback(
+  bundleVersion: string,
+  reason: string,
+): Promise<void> {
+  const previousHash = await AsyncStorage.getItem(BUNDLE_HASH_KEY)
+
+  // Restore backup bundle to the current slot.
+  const backupInfo = await FileSystem.getInfoAsync(BACKUP_BUNDLE)
+  if (backupInfo.exists) {
+    await FileSystem.copyAsync({ from: BACKUP_BUNDLE, to: CURRENT_BUNDLE })
+  } else {
+    console.warn('[OTA Rollback] No backup bundle found — reload may use built-in bundle')
+  }
+
+  await resetSmokeFailCount()
+  await resetCrashCount()
+
+  // Report to telemetry.
+  TelemetryCollector.getInstance().logEvent({
+    name: 'ota_rollback',
+    category: 'ota',
+    value: { bundleVersion, reason, previousHash: previousHash ?? 'unknown' },
+  })
+
+  // Notify the dev team via Sentry.
+  SentryErrorTracker.getInstance().captureMessage(
+    `[OTA] Rollback triggered for bundle ${bundleVersion}: ${reason}`,
+    'error',
+  )
+
+  // Reload the app so it picks up the restored bundle.
+  await Updates.reloadAsync()
+}
 
 /**
  * Call once at app startup (before any async work).
  * Increments the crash counter and triggers rollback if the threshold is hit.
  *
- * Returns `true` if a rollback was performed (app should reload).
+ * Returns `true` if a rollback was performed (app will reload).
  */
 export async function recordLaunch(): Promise<boolean> {
   const count = await getCrashCount()
@@ -55,7 +186,8 @@ export async function recordLaunch(): Promise<boolean> {
     console.warn(
       `[OTA Rollback] ${next} consecutive crashes detected – rolling back`,
     )
-    await rollback()
+    const version = (await AsyncStorage.getItem(LAST_GOOD_VERSION_KEY)) ?? 'unknown'
+    await triggerRollback(version, `${next} consecutive crashes`)
     return true
   }
 
@@ -64,15 +196,16 @@ export async function recordLaunch(): Promise<boolean> {
 
 /**
  * Call once the app has been running stably for STABLE_MS.
- * Resets the crash counter and backs up the current bundle.
+ * Resets crash and smoke-test failure counters, then backs up the current bundle.
  */
 export async function recordStableLaunch(version: string): Promise<void> {
   await resetCrashCount()
+  await resetSmokeFailCount()
   await AsyncStorage.setItem(LAST_GOOD_VERSION_KEY, version)
 
-  // Back up the current bundle so rollback has something to restore
   const info = await FileSystem.getInfoAsync(CURRENT_BUNDLE)
   if (info.exists) {
+    await FileSystem.makeDirectoryAsync(BUNDLE_DIR, { intermediates: true })
     await FileSystem.copyAsync({ from: CURRENT_BUNDLE, to: BACKUP_BUNDLE })
   }
 }


### PR DESCRIPTION
## Summary

- **#745** — Rewrote `mobile/src/ota/rollback.ts` with full rollback capability: snapshots bundle hash before update (`snapshotCurrentBundle`), runs HomeScreen smoke test after apply (`runSmokeTest`), auto-triggers rollback via `Updates.reloadAsync()` after 3 consecutive failures, and reports events to `TelemetryCollector` + `SentryErrorTracker`.
- **#743** — Added missing structured events to Soroban contracts: `bounty.created`, `bounty.applied`, `bounty.selected`, `bounty.completed`, `bounty.cancelled`, `gov.created`, and `gov.voted`.
- **#739** — Consolidated `webhook.rs` and `webhooks.rs` into `webhooks/stripe.rs` (Stripe payment handler) and `webhooks/soroban.rs` (event registry + delivery); `webhooks/mod.rs` re-exports both; `main.rs` updated accordingly.

## Test plan

- [ ] OTA: call `snapshotCurrentBundle(hash)` before `applyUpdate()`; simulate 3 smoke test failures and confirm `triggerRollback` is called with correct version + reason
- [ ] OTA: confirm `TelemetryCollector.logEvent` and `SentryErrorTracker.captureMessage` are called on rollback
- [ ] Contracts: deploy bounty contract, create/apply/select/complete/cancel bounties, verify all events appear in Soroban event stream
- [ ] Contracts: create a governance proposal and cast a vote, verify `gov.created` and `gov.voted` events
- [ ] Webhooks: `POST /api/v1/webhooks/payment` still works with valid Stripe HMAC signature
- [ ] Webhooks: no references to the deleted `webhook.rs` / `webhooks.rs` remain

Closes #745
Closes #743
Closes #739