### PR TITLE
chore: remove stale/unused variables from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,6 @@ CORS_ALLOWED_ORIGINS="http://localhost:3000,http://localhost:3001"
 AWS_ACCESS_KEY_ID="your-aws-access-key-id"
 AWS_SECRET_ACCESS_KEY="your-aws-secret-access-key"
 AWS_REGION="us-east-1"
-AWS_S3_BUCKET="your-s3-bucket-name"
 
 # Stripe
 STRIPE_SECRET_KEY="sk_test_..."
@@ -84,9 +83,7 @@ ENCRYPTION_KEY="a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1"
 
 # Error Tracking & Monitoring
 NEXT_PUBLIC_SENTRY_DSN="https://your-sentry-dsn@sentry.io/project-id"
-SENTRY_AUTH_TOKEN="your-sentry-auth-token"
 SENTRY_ENVIRONMENT="development"
-SENTRY_RELEASE="1.0.0"
 ENABLE_ERROR_TRACKING=true
 
 # ---------------------------------------------------------------------------
@@ -152,8 +149,6 @@ TURN_TLS_PORT=5349
 STUN_URL=stun:stun.l.google.com:19302
 # Credential TTL in seconds (default 86400 = 24h)
 TURN_CREDENTIAL_TTL=86400
-# JWT secret for signaling auth (generate: openssl rand -hex 32)
-SIGNALING_JWT_SECRET=your-signaling-jwt-secret-here
 # Max concurrent connections per process
 SIGNALING_MAX_CONNECTIONS=10000
 # Heartbeat interval in ms


### PR DESCRIPTION
Grepped every variable name in `.env.example` against real usage across
the codebase and removed the 4 with zero references anywhere:
`AWS_S3_BUCKET`, `SENTRY_AUTH_TOKEN`, `SENTRY_RELEASE`,
`SIGNALING_JWT_SECRET`. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/
`AWS_REGION` were kept since they're consumed by
`.github/workflows/ota-release.yml`.

Closes #1014