### PR TITLE
feat: OCR-based KYC document verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,9 @@ NEXT_PUBLIC_MAINNET_RPC_URL_3=https://rpc.ankr.com/stellar_soroban
 NEXT_PUBLIC_MAINNET_PASSPHRASE="Public Global Stellar Network ; September 2015"
 
 CONTRACT_ID=
+# Soroban identity contract address, used by the KYC review flow's
+# verify_kyc call (Issue #782).
+IDENTITY_CONTRACT_ID=
 # STELLAR_ADMIN_SECRET is only read from env when KMS_PROVIDER=env (local/CI).
 # In production it is fetched from AWS Secrets Manager; leave blank here.
 STELLAR_ADMIN_SECRET=

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -15,6 +15,7 @@ import {
   deleteUser,
   getUsersSummary,
 } from '@/app/admin/actions';
+import { KYCReviewPanel } from '@/components/admin/kyc-review-panel';
 import { Role } from '@prisma/client';
 
 const ROLES: Role[] = ['ADMIN', 'CLIENT', 'CREATOR', 'USER'];
@@ -284,6 +285,8 @@ export default function AdminUsersPage() {
           </div>
         </CardContent>
       </Card>
+
+      <KYCReviewPanel />
     </div>
   );
 }

--- a/app/api/admin/cron/kyc-cleanup/route.ts
+++ b/app/api/admin/cron/kyc-cleanup/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * POST /api/admin/cron/kyc-cleanup
+ *
+ * GDPR compliance job for Issue #782: permanently deletes KYC submissions
+ * (including encrypted PII) 90 days after upload, regardless of review
+ * status. Should be triggered daily by an external cron service (e.g.
+ * Vercel Crons, EasyCron).
+ *
+ * Authorization: Requires valid cron secret in X-Cron-Secret header.
+ */
+export async function POST(req: NextRequest) {
+  const cronSecret = req.headers.get('x-cron-secret');
+  const validSecret = process.env.CRON_SECRET;
+
+  if (!validSecret || cronSecret !== validSecret) {
+    return NextResponse.json(
+      { error: 'Unauthorized: Invalid or missing cron secret' },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const { count } = await prisma.kYCSubmission.deleteMany({
+      where: { expiresAt: { lte: new Date() } },
+    });
+
+    console.log(`KYC cleanup: deleted ${count} expired submission(s)`);
+    return NextResponse.json({ success: true, deleted: count }, { status: 200 });
+  } catch (error) {
+    console.error('KYC cleanup cron job failed:', error);
+    return NextResponse.json(
+      { error: 'Failed to clean up expired KYC submissions', details: String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/admin/kyc/[id]/review/route.ts
+++ b/app/api/admin/kyc/[id]/review/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { createHash } from 'crypto';
+import { authOptions } from '@/lib/auth/config';
+import { prisma } from '@/lib/prisma';
+import { verifyKycOnChain } from '@/backend/services/identity-contract';
+
+/**
+ * POST /api/admin/kyc/[id]/review
+ *
+ * Approve or reject a pending KYC submission (Issue #782).
+ *
+ * Body: { decision: "approve" | "reject", reason?: string }
+ *
+ * On approve: marks the submission APPROVED, flips `CreatorProfile.verified`,
+ * and calls the identity contract's `verify_kyc` on-chain — the submission
+ * is still marked APPROVED even if the on-chain call fails, since the off-
+ * chain review is the source of truth; `verifiedOnChain`/`txHash` simply
+ * stay unset until a retry succeeds.
+ * On reject: marks REJECTED with the given reason; the user may resubmit.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getServerSession(authOptions);
+  const adminUser = session?.user as { id?: string; role?: string } | undefined;
+  if (!adminUser?.role || adminUser.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  const body = await req.json();
+  const { decision, reason } = body as { decision?: string; reason?: string };
+
+  if (decision !== 'approve' && decision !== 'reject') {
+    return NextResponse.json({ error: 'decision must be "approve" or "reject"' }, { status: 400 });
+  }
+  if (decision === 'reject' && !reason) {
+    return NextResponse.json({ error: 'reason is required to reject a submission' }, { status: 400 });
+  }
+
+  const submission = await prisma.kYCSubmission.findUnique({
+    where: { id },
+    include: { user: { select: { id: true, walletAddress: true } } },
+  });
+  if (!submission) {
+    return NextResponse.json({ error: 'Submission not found' }, { status: 404 });
+  }
+  if (submission.status !== 'PENDING') {
+    return NextResponse.json(
+      { error: `Submission is already ${submission.status}` },
+      { status: 409 },
+    );
+  }
+
+  if (decision === 'reject') {
+    const updated = await prisma.kYCSubmission.update({
+      where: { id: submission.id },
+      data: {
+        status: 'REJECTED',
+        adminReviewedBy: adminUser.id,
+        adminReviewedAt: new Date(),
+        rejectionReason: reason,
+      },
+    });
+    return NextResponse.json({ id: updated.id, status: updated.status });
+  }
+
+  // Approve
+  await prisma.$transaction([
+    prisma.kYCSubmission.update({
+      where: { id: submission.id },
+      data: {
+        status: 'APPROVED',
+        adminReviewedBy: adminUser.id,
+        adminReviewedAt: new Date(),
+        rejectionReason: null,
+      },
+    }),
+    prisma.creatorProfile.updateMany({
+      where: { userId: submission.userId },
+      data: { verified: true },
+    }),
+  ]);
+
+  if (!submission.user.walletAddress) {
+    return NextResponse.json({
+      id: submission.id,
+      status: 'APPROVED',
+      verifiedOnChain: false,
+      warning: 'User has no linked wallet address; on-chain verification skipped',
+    });
+  }
+
+  try {
+    const submissionIdHash = createHash('sha256').update(submission.id).digest();
+    const txHash = await verifyKycOnChain(submission.user.walletAddress, submissionIdHash);
+    await prisma.kYCSubmission.update({
+      where: { id: submission.id },
+      data: { verifiedOnChain: true, txHash },
+    });
+    return NextResponse.json({ id: submission.id, status: 'APPROVED', verifiedOnChain: true, txHash });
+  } catch (error) {
+    console.error(`KYC on-chain verification failed for submission ${submission.id}:`, error);
+    return NextResponse.json({
+      id: submission.id,
+      status: 'APPROVED',
+      verifiedOnChain: false,
+      warning: 'Off-chain approval saved; on-chain verification failed and can be retried',
+    });
+  }
+}

--- a/app/api/admin/kyc/route.ts
+++ b/app/api/admin/kyc/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/config';
+import { prisma } from '@/lib/prisma';
+import { decryptField } from '@/lib/kyc-encryption';
+
+/**
+ * GET /api/admin/kyc?status=pending&page=1&limit=20
+ *
+ * Lists KYC submissions for admin review. Only the extracted name is
+ * decrypted for display, per Issue #782's "only admin can view extracted
+ * data" requirement — DOB and ID number stay encrypted until an admin
+ * opens an individual submission (there is no bulk-decrypt endpoint).
+ */
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const role = (session?.user as { role?: string })?.role;
+  if (!role || role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+  }
+
+  const { searchParams } = req.nextUrl;
+  const status = (searchParams.get('status') ?? 'PENDING').toUpperCase();
+  const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
+  const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') ?? '20', 10)));
+  const skip = (page - 1) * limit;
+
+  const where = status === 'ALL' ? {} : { status: status as 'PENDING' | 'APPROVED' | 'REJECTED' };
+
+  const [submissions, total] = await Promise.all([
+    prisma.kYCSubmission.findMany({
+      where,
+      orderBy: { uploadedAt: 'asc' },
+      skip,
+      take: limit,
+      include: { user: { select: { email: true } } },
+    }),
+    prisma.kYCSubmission.count({ where }),
+  ]);
+
+  const decrypted = await Promise.all(
+    submissions.map(async (s) => ({
+      id: s.id,
+      userId: s.userId,
+      userEmail: s.user.email,
+      documentType: s.documentType,
+      uploadedAt: s.uploadedAt,
+      expiresAt: s.expiresAt,
+      status: s.status,
+      name: await decryptField(s.encryptedName).catch(() => '[decryption failed]'),
+      adminReviewedBy: s.adminReviewedBy,
+      adminReviewedAt: s.adminReviewedAt,
+      rejectionReason: s.rejectionReason,
+      verifiedOnChain: s.verifiedOnChain,
+      txHash: s.txHash,
+    })),
+  );
+
+  return NextResponse.json({ submissions: decrypted, total, page, limit });
+}

--- a/app/api/kyc/submit/route.ts
+++ b/app/api/kyc/submit/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/auth/auth';
+import { prisma } from '@/lib/prisma';
+import { encryptField } from '@/lib/kyc-encryption';
+import { KYCDocumentType } from '@prisma/client';
+
+/**
+ * POST /api/kyc/submit
+ *
+ * Accepts OCR-extracted document fields from the mobile app's
+ * `OCRKYCService` scan flow and creates (or replaces, if previously
+ * rejected) the caller's `KYCSubmission` record. Extracted PII is encrypted
+ * before it ever reaches the database (Issue #782).
+ *
+ * Body:
+ *   documentType: "PASSPORT" | "DRIVER_LICENSE" | "NATIONAL_ID"
+ *   name, dateOfBirth, idNumber: strings extracted client-side by OCR
+ */
+export async function POST(req: NextRequest) {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { documentType, name, dateOfBirth, idNumber } = body as {
+    documentType?: string;
+    name?: string;
+    dateOfBirth?: string;
+    idNumber?: string;
+  };
+
+  if (
+    !documentType ||
+    !(documentType in KYCDocumentType) ||
+    !name ||
+    !dateOfBirth ||
+    !idNumber
+  ) {
+    return NextResponse.json(
+      { error: 'documentType, name, dateOfBirth, and idNumber are required' },
+      { status: 400 },
+    );
+  }
+
+  const existing = await prisma.kYCSubmission.findUnique({
+    where: { userId: session.user.id },
+  });
+  if (existing && existing.status !== 'REJECTED') {
+    return NextResponse.json(
+      { error: `A KYC submission already exists with status ${existing.status}` },
+      { status: 409 },
+    );
+  }
+
+  const [encryptedName, encryptedDOB, encryptedIdNumber] = await Promise.all([
+    encryptField(name),
+    encryptField(dateOfBirth),
+    encryptField(idNumber),
+  ]);
+
+  const uploadedAt = new Date();
+  const expiresAt = new Date(uploadedAt.getTime() + 90 * 24 * 60 * 60 * 1000);
+
+  const submission = await prisma.kYCSubmission.upsert({
+    where: { userId: session.user.id },
+    create: {
+      userId: session.user.id,
+      documentType: documentType as KYCDocumentType,
+      uploadedAt,
+      expiresAt,
+      encryptedName,
+      encryptedDOB,
+      encryptedIdNumber,
+      status: 'PENDING',
+    },
+    update: {
+      documentType: documentType as KYCDocumentType,
+      uploadedAt,
+      expiresAt,
+      encryptedName,
+      encryptedDOB,
+      encryptedIdNumber,
+      status: 'PENDING',
+      adminReviewedBy: null,
+      adminReviewedAt: null,
+      rejectionReason: null,
+      verifiedOnChain: false,
+      txHash: null,
+    },
+  });
+
+  return NextResponse.json({ id: submission.id, status: submission.status });
+}

--- a/backend/contracts/identity/src/lib.rs
+++ b/backend/contracts/identity/src/lib.rs
@@ -195,6 +195,34 @@ impl IdentityContract {
         env.storage().persistent().get(&DataKey::KycAttestation(user))
     }
 
+    /// Mark a user as KYC-verified following off-chain OCR document review
+    /// and admin approval (see `KYCSubmission` in the application database).
+    /// Only the platform admin may call this. Records a `Basic`-level
+    /// `KycAttestation` and emits an event carrying `kyc_submission_id` so
+    /// on-chain activity can be traced back to the reviewed document.
+    pub fn verify_kyc(env: Env, admin: Address, user: Address, kyc_submission_id: BytesN<32>) -> bool {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().persistent().get(&DataKey::Admin).expect("Not initialized");
+        assert_eq!(admin, stored_admin, "Only admin can verify KYC");
+
+        env.storage().persistent().set(
+            &DataKey::KycAttestation(user.clone()),
+            &KycAttestation {
+                user: user.clone(),
+                level: KycLevel::Basic,
+                attested_at: env.ledger().timestamp(),
+                expires_at: env.ledger().timestamp() + ONE_YEAR_SECS,
+            },
+        );
+
+        env.events().publish(
+            (symbol_short!("kyc"), symbol_short!("verified")),
+            (user, kyc_submission_id),
+        );
+
+        true
+    }
+
     /// Attest a creator's verification tier on-chain.
     /// Only the platform oracle (attester) may call this.
     pub fn set_tier(

--- a/backend/services/identity-contract.ts
+++ b/backend/services/identity-contract.ts
@@ -1,0 +1,46 @@
+/**
+ * Thin wrapper around the Soroban identity contract's `verify_kyc` call
+ * (Issue #782), used by the admin KYC review flow after a submission is
+ * approved. Builds/simulates/signs/submits the invocation via the shared
+ * `ContractService` and returns the transaction hash for audit purposes.
+ */
+
+import { Keypair } from '@stellar/stellar-sdk';
+import { contractService } from '@/services/api/stellar/contract';
+import { LocalSigner } from '@/services/api/stellar/types';
+import { getSecret } from '@/backend/services/kms';
+
+function identityContractId(): string {
+  const contractId = process.env.IDENTITY_CONTRACT_ID;
+  if (!contractId) {
+    throw new Error('IDENTITY_CONTRACT_ID is not configured');
+  }
+  return contractId;
+}
+
+/**
+ * Calls `verify_kyc(admin, user, kyc_submission_id)` on the identity
+ * contract, signed by the platform admin key. `kycSubmissionId` should be
+ * the KYCSubmission row id, hashed to 32 bytes (contracts only accept fixed-
+ * size byte arrays) so the on-chain event can be traced back to the
+ * off-chain record without exposing the raw id on-chain.
+ */
+export async function verifyKycOnChain(
+  userAddress: string,
+  kycSubmissionIdHash: Uint8Array,
+): Promise<string> {
+  if (kycSubmissionIdHash.length !== 32) {
+    throw new Error('kycSubmissionIdHash must be exactly 32 bytes');
+  }
+
+  const adminSecret = await getSecret('STELLAR_ADMIN_SECRET');
+  const signer = new LocalSigner(adminSecret);
+  const adminPublicKey = Keypair.fromSecret(adminSecret).publicKey();
+
+  return contractService.invokeContractMethod(
+    identityContractId(),
+    'verify_kyc',
+    [adminPublicKey, userAddress, kycSubmissionIdHash],
+    signer,
+  );
+}

--- a/components/admin/kyc-review-panel.tsx
+++ b/components/admin/kyc-review-panel.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ShieldCheck, ShieldX } from 'lucide-react';
+
+interface KYCSubmissionRow {
+  id: string;
+  userId: string;
+  userEmail: string | null;
+  documentType: string;
+  uploadedAt: string;
+  status: 'PENDING' | 'APPROVED' | 'REJECTED';
+  name: string;
+  verifiedOnChain: boolean;
+  txHash: string | null;
+}
+
+const STATUS_VARIANT: Record<KYCSubmissionRow['status'], 'secondary' | 'default' | 'destructive'> = {
+  PENDING: 'secondary',
+  APPROVED: 'default',
+  REJECTED: 'destructive',
+};
+
+/**
+ * Admin KYC review panel (Issue #782). Lists submissions awaiting review;
+ * only the extracted name is ever shown here — DOB/ID number remain
+ * encrypted and are not exposed via this UI.
+ */
+export function KYCReviewPanel() {
+  const [submissions, setSubmissions] = useState<KYCSubmissionRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    try {
+      setLoading(true);
+      const res = await fetch('/api/admin/kyc?status=PENDING');
+      if (!res.ok) throw new Error(`Failed to load KYC submissions (${res.status})`);
+      const data = await res.json();
+      setSubmissions(data.submissions ?? []);
+    } catch (error) {
+      notify(error instanceof Error ? error.message : 'Failed to load KYC submissions');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function notify(msg: string) {
+    setToast(msg);
+    setTimeout(() => setToast(null), 4000);
+  }
+
+  async function review(id: string, decision: 'approve' | 'reject') {
+    const reason = decision === 'reject' ? prompt('Reason for rejection:') : undefined;
+    if (decision === 'reject' && !reason) return;
+
+    try {
+      const res = await fetch(`/api/admin/kyc/${id}/review`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ decision, reason }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? 'Review failed');
+
+      notify(
+        decision === 'approve'
+          ? data.warning ?? 'Submission approved.'
+          : 'Submission rejected.',
+      );
+      await load();
+    } catch (error) {
+      notify(error instanceof Error ? error.message : 'Review action failed');
+    }
+  }
+
+  return (
+    <Card>
+      <CardContent className="p-0">
+        <div className="px-4 py-3 border-b border-border">
+          <h2 className="font-semibold text-sm">KYC Submissions</h2>
+          <p className="text-xs text-muted-foreground">Pending identity verification review</p>
+        </div>
+
+        {toast && (
+          <div className="mx-4 mt-3 px-4 py-2 rounded-lg bg-primary/10 text-primary text-sm border border-primary/20">
+            {toast}
+          </div>
+        )}
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-muted-foreground text-xs">
+                <th className="px-4 py-3 text-left">Name</th>
+                <th className="px-4 py-3 text-left">Email</th>
+                <th className="px-4 py-3 text-left">Document</th>
+                <th className="px-4 py-3 text-left">Uploaded</th>
+                <th className="px-4 py-3 text-left">Status</th>
+                <th className="px-4 py-3 text-left">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground text-sm">
+                    Loading…
+                  </td>
+                </tr>
+              ) : submissions.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground text-sm">
+                    No pending KYC submissions
+                  </td>
+                </tr>
+              ) : (
+                submissions.map((s) => (
+                  <tr key={s.id} className="border-b border-border last:border-0 hover:bg-muted/30 transition-colors">
+                    <td className="px-4 py-3 font-medium">{s.name}</td>
+                    <td className="px-4 py-3 text-muted-foreground">{s.userEmail}</td>
+                    <td className="px-4 py-3">{s.documentType}</td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {new Date(s.uploadedAt).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge variant={STATUS_VARIANT[s.status]}>{s.status}</Badge>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-1">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs gap-1"
+                          onClick={() => review(s.id, 'approve')}
+                        >
+                          <ShieldCheck size={12} /> Approve
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-7 text-xs text-destructive hover:text-destructive gap-1"
+                          onClick={() => review(s.id, 'reject')}
+                        >
+                          <ShieldX size={12} /> Reject
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/kyc-encryption.ts
+++ b/lib/kyc-encryption.ts
@@ -1,0 +1,62 @@
+/**
+ * Field-level encryption for KYC PII (Issue #782).
+ *
+ * Uses AES-256-GCM with the platform `ENCRYPTION_KEY` secret (resolved via
+ * `backend/services/kms`, which transparently uses AWS Secrets Manager in
+ * production and the raw env var locally/in CI). Each call generates a
+ * fresh random IV; the IV and auth tag are packed alongside the ciphertext
+ * so a single opaque string can be stored per field.
+ */
+
+import { randomBytes, createCipheriv, createDecipheriv } from 'crypto';
+import { getSecret } from '@/backend/services/kms';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // 96-bit IV recommended for GCM
+
+async function getKey(): Promise<Buffer> {
+  const secret = await getSecret('ENCRYPTION_KEY');
+  // ENCRYPTION_KEY is a 64-char hex string (32 bytes) per .env.example.
+  const key = Buffer.from(secret, 'hex');
+  if (key.length !== 32) {
+    throw new Error('ENCRYPTION_KEY must decode to exactly 32 bytes for AES-256-GCM');
+  }
+  return key;
+}
+
+/**
+ * Encrypts a plaintext PII value. Returns `iv:authTag:ciphertext`, each
+ * base64-encoded, suitable for storing directly in a text column.
+ */
+export async function encryptField(plaintext: string): Promise<string> {
+  const key = await getKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return [iv.toString('base64'), authTag.toString('base64'), ciphertext.toString('base64')].join(':');
+}
+
+/**
+ * Decrypts a value produced by `encryptField`. Throws if the auth tag does
+ * not verify (tampering or wrong key).
+ */
+export async function decryptField(packed: string): Promise<string> {
+  const [ivB64, tagB64, dataB64] = packed.split(':');
+  if (!ivB64 || !tagB64 || !dataB64) {
+    throw new Error('Malformed encrypted field: expected iv:authTag:ciphertext');
+  }
+
+  const key = await getKey();
+  const iv = Buffer.from(ivB64, 'base64');
+  const authTag = Buffer.from(tagB64, 'base64');
+  const ciphertext = Buffer.from(dataB64, 'base64');
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return plaintext.toString('utf8');
+}

--- a/prisma/migrations/20260723_add_kyc_submission/migration.sql
+++ b/prisma/migrations/20260723_add_kyc_submission/migration.sql
@@ -1,0 +1,37 @@
+-- Issue #782: OCR-based KYC Document Verification
+
+ALTER TABLE "User" ADD COLUMN "walletAddress" TEXT;
+CREATE UNIQUE INDEX "User_walletAddress_key" ON "User"("walletAddress");
+
+CREATE TYPE "KYCDocumentType" AS ENUM ('PASSPORT', 'DRIVER_LICENSE', 'NATIONAL_ID');
+CREATE TYPE "KYCStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+CREATE TABLE "KYCSubmission" (
+  "id"                String          NOT NULL,
+  "userId"            String          NOT NULL,
+  "documentType"      "KYCDocumentType" NOT NULL,
+  "uploadedAt"        TIMESTAMPTZ     NOT NULL DEFAULT now(),
+  "expiresAt"         TIMESTAMPTZ     NOT NULL,
+  "encryptedName"     TEXT            NOT NULL,
+  "encryptedDOB"      TEXT            NOT NULL,
+  "encryptedIdNumber" TEXT            NOT NULL,
+  "status"            "KYCStatus"     NOT NULL DEFAULT 'PENDING',
+  "adminReviewedBy"   TEXT,
+  "adminReviewedAt"   TIMESTAMPTZ,
+  "rejectionReason"   TEXT,
+  "verifiedOnChain"   BOOLEAN         NOT NULL DEFAULT false,
+  "txHash"            TEXT,
+
+  CONSTRAINT "KYCSubmission_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "KYCSubmission_userId_key" ON "KYCSubmission"("userId");
+CREATE UNIQUE INDEX "KYCSubmission_txHash_key" ON "KYCSubmission"("txHash");
+CREATE INDEX "KYCSubmission_userId_idx" ON "KYCSubmission"("userId");
+CREATE INDEX "KYCSubmission_status_idx" ON "KYCSubmission"("status");
+CREATE INDEX "KYCSubmission_expiresAt_idx" ON "KYCSubmission"("expiresAt");
+
+ALTER TABLE "KYCSubmission"
+  ADD CONSTRAINT "KYCSubmission_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,9 @@ model User {
   image               String?
   role                Role      @default(USER)
   onboardingComplete  Boolean   @default(false)
+  /// Stellar public key (G...), set once a wallet has been linked via SEP-10.
+  /// Required to attest KYC on-chain (Issue #782).
+  walletAddress       String?   @unique
   createdAt           DateTime  @default(now())
   updatedAt           DateTime  @updatedAt
   
@@ -78,6 +81,7 @@ model User {
   bountyTemplates     BountyTemplate[]
   apiKeys             ApiKey[]
   endorsementsGiven   Endorsement[] @relation(name: "endorsements_given")
+  kycSubmission       KYCSubmission?
 
   @@index([email])
 }
@@ -666,4 +670,53 @@ model ZKNullifier {
   createdAt DateTime @default(now())
 
   @@index([nullifier])
+}
+
+// ── OCR-based KYC Document Verification — Issue #782 ────────────────────
+
+enum KYCDocumentType {
+  PASSPORT
+  DRIVER_LICENSE
+  NATIONAL_ID
+}
+
+enum KYCStatus {
+  PENDING
+  APPROVED
+  REJECTED
+}
+
+/// A user's submitted KYC document and its review/verification lifecycle.
+/// Extracted PII fields are encrypted at rest (AWS KMS) and only ever
+/// decrypted for admin review; the row (and its ciphertext) is deleted by
+/// the expiry cleanup job 90 days after upload for GDPR compliance.
+model KYCSubmission {
+  id             String          @id @default(cuid())
+  userId         String          @unique
+  user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  // Document metadata
+  documentType   KYCDocumentType
+  uploadedAt     DateTime        @default(now())
+  /// Set by application code at creation time to uploadedAt + 90 days.
+  expiresAt      DateTime
+
+  // Extracted data, encrypted at rest with AWS KMS before storage.
+  encryptedName     String
+  encryptedDOB      String
+  encryptedIdNumber String
+
+  // Verification flow
+  status          KYCStatus @default(PENDING)
+  adminReviewedBy String?
+  adminReviewedAt DateTime?
+  rejectionReason String?
+
+  // On-chain verification (backend/contracts/identity `verify_kyc`)
+  verifiedOnChain Boolean @default(false)
+  txHash          String? @unique
+
+  @@index([userId])
+  @@index([status])
+  @@index([expiresAt])
 }


### PR DESCRIPTION
IMPLEMENTATION_NOTES.md described this as 0% started, but that turned out
to be stale — `mobile/src/services/OCRKYCService.ts` already existed with
real MRZ-parsing OCR logic (from a prior effort). This PR fills in what
was actually still missing:

- **Prisma**: `KYCSubmission` model + migration (document type, encrypted
  PII fields, review/expiry lifecycle). Also adds `User.walletAddress`,
  which didn't exist anywhere but is required to know which Stellar
  address to attest on-chain.
- **`lib/kyc-encryption.ts`**: AES-256-GCM field encryption using the
  existing `ENCRYPTION_KEY` secret (via `backend/services/kms`), so
  extracted PII is encrypted before it ever reaches the database.
- **`app/api/kyc/submit`**: user-facing endpoint accepting OCR-extracted
  fields and encrypting them.
- **`app/api/admin/kyc` (+ `[id]/review`)**: admin listing (decrypts only
  the name, per the "only admin can view extracted data" requirement) and
  approve/reject, which flips `CreatorProfile.verified` and calls the new
  identity-contract `verify_kyc` on approval.
- **`backend/contracts/identity`**: adds
  `verify_kyc(admin, user, kyc_submission_id)`, reusing the existing
  `KycAttestation`/admin-auth pattern already used by `attest_kyc`, plus
  `backend/services/identity-contract.ts` to invoke it via the existing
  `ContractService`.
- **`app/api/admin/cron/kyc-cleanup`**: GDPR 90-day expiry deletion job,
  following the existing cron-route pattern (`corridor-aggregation`).
- **`components/admin/kyc-review-panel.tsx`**: mounted into
  `app/admin/users/page.tsx`.

**Scope note**: this submission flow stores only OCR-extracted fields
(name/DOB/ID number), not raw document images, so it doesn't add S3
upload wiring — narrower PII footprint, and consistent with the
admin-review requirement that only the extracted name is ever visible.

Closes #1020