### PR TITLE
feat: add slippage-tolerance control for yield deposits

### DIFF
--- a/__tests__/lib/yield-slippage.test.ts
+++ b/__tests__/lib/yield-slippage.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { actualSlippageBps, calculateMinShares } from '@/lib/utils/yield-slippage'
+
+describe('calculateMinShares', () => {
+  it('applies the recommended min_shares formula', () => {
+    // 1000 * (1 - 50/10_000) = 995
+    expect(calculateMinShares({ expectedShares: 1000, maxSlippageBps: 50 })).toBe(995)
+  })
+
+  it('returns expectedShares unchanged at 0 bps tolerance', () => {
+    expect(calculateMinShares({ expectedShares: 250, maxSlippageBps: 0 })).toBe(250)
+  })
+
+  it('returns 0 at 10_000 bps (100%) tolerance', () => {
+    expect(calculateMinShares({ expectedShares: 250, maxSlippageBps: 10_000 })).toBe(0)
+  })
+
+  it('rejects a negative expectedShares', () => {
+    expect(() => calculateMinShares({ expectedShares: -1, maxSlippageBps: 50 })).toThrow(RangeError)
+  })
+
+  it('rejects an out-of-range maxSlippageBps', () => {
+    expect(() => calculateMinShares({ expectedShares: 100, maxSlippageBps: 10_001 })).toThrow(RangeError)
+    expect(() => calculateMinShares({ expectedShares: 100, maxSlippageBps: -1 })).toThrow(RangeError)
+  })
+})
+
+describe('actualSlippageBps', () => {
+  it('computes the bps deviation between expected and actual shares', () => {
+    expect(actualSlippageBps(1000, 990)).toBeCloseTo(100)
+  })
+
+  it('clamps to 0 when actual shares meet or exceed expected', () => {
+    expect(actualSlippageBps(1000, 1000)).toBe(0)
+    expect(actualSlippageBps(1000, 1010)).toBe(0)
+  })
+
+  it('returns 0 when expectedShares is 0', () => {
+    expect(actualSlippageBps(0, 0)).toBe(0)
+  })
+})

--- a/components/features/yield/slippage-tolerance-control.tsx
+++ b/components/features/yield/slippage-tolerance-control.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { calculateMinShares } from '@/lib/utils/yield-slippage'
+
+/**
+ * Frontend half of the yield-deposit slippage-tolerance control described in
+ * IMPLEMENTATION_NOTES.md#yield-deposit-slippage-tolerance. It's
+ * presentational/standalone: it computes and surfaces `min_shares`, but does
+ * not call `deposit_to_yield` directly, since that contract call doesn't
+ * exist yet. Wire `onConfirm` up to the real deposit once it lands.
+ */
+
+export interface SlippageToleranceControlProps {
+  /** Shares quoted for the deposit at request time. */
+  expectedShares: number
+  /** Actual shares the vault would currently mint, if known (e.g. from a fresh quote). */
+  actualShares?: number
+  assetCode: string
+  /** Default tolerance in basis points. Defaults to 50 (0.50%). */
+  defaultMaxSlippageBps?: number
+  onConfirm?: (minShares: number, maxSlippageBps: number) => void
+}
+
+export function SlippageToleranceControl({
+  expectedShares,
+  actualShares,
+  assetCode,
+  defaultMaxSlippageBps = 50,
+  onConfirm,
+}: SlippageToleranceControlProps) {
+  const [maxSlippageBps, setMaxSlippageBps] = useState(defaultMaxSlippageBps)
+
+  const minShares = useMemo(() => {
+    if (!Number.isFinite(maxSlippageBps) || maxSlippageBps < 0 || maxSlippageBps > 10_000) {
+      return null
+    }
+    return calculateMinShares({ expectedShares, maxSlippageBps })
+  }, [expectedShares, maxSlippageBps])
+
+  const belowMinimum =
+    actualShares !== undefined && minShares !== null && actualShares < minShares
+
+  return (
+    <div className="flex flex-col gap-4 rounded-lg border p-4">
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">Expected shares</span>
+        <span className="font-medium">
+          {expectedShares.toLocaleString()} {assetCode}
+        </span>
+      </div>
+
+      {actualShares !== undefined && (
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">Actual shares</span>
+          <span className={belowMinimum ? 'font-medium text-destructive' : 'font-medium'}>
+            {actualShares.toLocaleString()} {assetCode}
+          </span>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="max-slippage-bps">Max slippage tolerance (bps)</Label>
+        <Input
+          id="max-slippage-bps"
+          type="number"
+          min={0}
+          max={10_000}
+          step={1}
+          value={maxSlippageBps}
+          onChange={(e) => setMaxSlippageBps(Number(e.target.value))}
+        />
+        <p className="text-xs text-muted-foreground">
+          {(maxSlippageBps / 100).toFixed(2)}% maximum tolerated deviation from expected shares.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">Recommended min. shares</span>
+        <span className="font-medium">
+          {minShares !== null ? minShares.toLocaleString() : '—'} {assetCode}
+        </span>
+      </div>
+
+      {belowMinimum && (
+        <p className="text-xs text-destructive" role="alert">
+          Actual shares are below your minimum tolerance. Confirming would
+          revert on-chain once deposit_to_yield enforces min_shares.
+        </p>
+      )}
+
+      <Button
+        disabled={minShares === null || belowMinimum}
+        onClick={() => minShares !== null && onConfirm?.(minShares, maxSlippageBps)}
+      >
+        Confirm deposit
+      </Button>
+    </div>
+  )
+}

--- a/lib/utils/yield-slippage.ts
+++ b/lib/utils/yield-slippage.ts
@@ -1,0 +1,33 @@
+/**
+ * Slippage-tolerance math for yield-vault deposits.
+ * Spec: IMPLEMENTATION_NOTES.md#yield-deposit-slippage-tolerance
+ */
+
+const BPS_DENOMINATOR = 10_000
+
+export interface SlippageInput {
+  /** Shares quoted for the deposit at request time. */
+  expectedShares: number
+  /** User-configured tolerance, in basis points (e.g. 50 = 0.50%). */
+  maxSlippageBps: number
+}
+
+/**
+ * recommended min_shares = expected_shares * (1 - max_slippage_bps / 10_000)
+ */
+export function calculateMinShares({ expectedShares, maxSlippageBps }: SlippageInput): number {
+  if (expectedShares < 0) {
+    throw new RangeError('expectedShares must be >= 0')
+  }
+  if (maxSlippageBps < 0 || maxSlippageBps > BPS_DENOMINATOR) {
+    throw new RangeError('maxSlippageBps must be between 0 and 10_000')
+  }
+
+  return expectedShares * (1 - maxSlippageBps / BPS_DENOMINATOR)
+}
+
+/** Actual shares as a percentage of expected shares, e.g. for warning the user pre-confirm. */
+export function actualSlippageBps(expectedShares: number, actualShares: number): number {
+  if (expectedShares <= 0) return 0
+  return Math.max(0, (1 - actualShares / expectedShares) * BPS_DENOMINATOR)
+}


### PR DESCRIPTION
## Summary
Implements the frontend half of `IMPLEMENTATION_NOTES.md`'s yield-deposit slippage-tolerance spec: expected vs. actual shares, a max-slippage-bps input, and the recommended `min_shares` calculation (`expected_shares * (1 - max_slippage_bps / 10_000)`).

`deposit_to_yield` / `max_slippage_bps` don't exist on the contract side yet (this repo has no yield contract at all currently), so `SlippageToleranceControl` is presentational/standalone with an `onConfirm` callback to wire up once that lands, rather than a fabricated contract call. `calculateMinShares` is unit tested directly since that part is real and testable today regardless of contract status.

Fixes #1018