### PR TITLE
test(api): add per-module edge case coverage for db, cqrs_read, cqrs_…

### DIFF
--- a/backend/services/api/src/cqrs_read.rs
+++ b/backend/services/api/src/cqrs_read.rs
@@ -277,3 +277,237 @@ impl ReadStore {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cqrs_write::{handle_command, Command};
+
+    #[test]
+    fn bounty_created_populates_bounty_and_search_views() {
+        let mut store = ReadStore::default();
+        project_event(&mut store, &DomainEvent::BountyCreated {
+            bounty_id: "b-1".to_string(),
+            creator_id: "creator-1".to_string(),
+            title: "Design a logo".to_string(),
+            budget_usd: 500,
+            deadline_ts: 1_700_000_000,
+            occurred_at: 1_600_000_000,
+        });
+
+        let bounty = store.bounties.get("b-1").expect("bounty should be projected");
+        assert_eq!(bounty.status, "open");
+        assert_eq!(bounty.application_count, 0);
+
+        let search_view = store.search_views.get("b-1").expect("search view should be projected");
+        assert!(search_view.needs_refresh);
+    }
+
+    #[test]
+    fn full_bounty_lifecycle_projects_in_order() {
+        let mut store = ReadStore::default();
+        project_event(&mut store, &DomainEvent::BountyCreated {
+            bounty_id: "b-1".to_string(),
+            creator_id: "creator-1".to_string(),
+            title: "Design a logo".to_string(),
+            budget_usd: 500,
+            deadline_ts: 1_700_000_000,
+            occurred_at: 1_600_000_000,
+        });
+        project_event(&mut store, &DomainEvent::BountyApplicationReceived {
+            application_id: "app-1".to_string(),
+            bounty_id: "b-1".to_string(),
+            freelancer_id: "freelancer-1".to_string(),
+            proposed_budget_usd: 450,
+            occurred_at: 1_600_000_100,
+        });
+        project_event(&mut store, &DomainEvent::FreelancerSelected {
+            bounty_id: "b-1".to_string(),
+            application_id: "app-1".to_string(),
+            occurred_at: 1_600_000_200,
+        });
+        project_event(&mut store, &DomainEvent::BountyCompleted {
+            bounty_id: "b-1".to_string(),
+            occurred_at: 1_600_000_300,
+        });
+
+        let bounty = store.bounties.get("b-1").unwrap();
+        assert_eq!(bounty.application_count, 1);
+        assert_eq!(bounty.status, "completed");
+        assert_eq!(bounty.selected_freelancer_id, Some("app-1".to_string()));
+        assert_eq!(bounty.completed_at, Some(1_600_000_300));
+
+        // open_bounties() must not surface a completed bounty.
+        assert!(store.open_bounties().is_empty());
+    }
+
+    #[test]
+    fn out_of_order_events_for_unknown_aggregate_are_dropped_not_panicked() {
+        let mut store = ReadStore::default();
+        // Application/selection/completion events arrive before the bounty's
+        // own BountyCreated event has been projected (e.g. redelivered out of
+        // sequence). The projector must no-op rather than panic or fabricate
+        // a bounty view.
+        project_event(&mut store, &DomainEvent::BountyApplicationReceived {
+            application_id: "app-1".to_string(),
+            bounty_id: "b-missing".to_string(),
+            freelancer_id: "freelancer-1".to_string(),
+            proposed_budget_usd: 450,
+            occurred_at: 1_600_000_100,
+        });
+        project_event(&mut store, &DomainEvent::BountyCompleted {
+            bounty_id: "b-missing".to_string(),
+            occurred_at: 1_600_000_200,
+        });
+
+        assert!(store.bounties.get("b-missing").is_none());
+    }
+
+    #[test]
+    fn escrow_deposit_release_and_refund_update_status() {
+        let mut store = ReadStore::default();
+        project_event(&mut store, &DomainEvent::EscrowDeposited {
+            escrow_id: "e-1".to_string(),
+            bounty_id: "b-1".to_string(),
+            payer_id: "payer-1".to_string(),
+            payee_id: "payee-1".to_string(),
+            amount_usd: 500,
+            occurred_at: 1_600_000_000,
+        });
+        assert_eq!(store.escrows.get("e-1").unwrap().status, "active");
+
+        project_event(&mut store, &DomainEvent::EscrowReleased {
+            escrow_id: "e-1".to_string(),
+            authorizer_id: "auth-1".to_string(),
+            occurred_at: 1_600_000_100,
+        });
+        let escrow = store.escrows.get("e-1").unwrap();
+        assert_eq!(escrow.status, "released");
+        assert_eq!(escrow.settled_at, Some(1_600_000_100));
+    }
+
+    #[test]
+    fn escrow_refund_for_unknown_escrow_is_ignored() {
+        let mut store = ReadStore::default();
+        project_event(&mut store, &DomainEvent::EscrowRefunded {
+            escrow_id: "e-missing".to_string(),
+            authorizer_id: "auth-1".to_string(),
+            occurred_at: 1_600_000_000,
+        });
+        assert!(store.escrows.get("e-missing").is_none());
+    }
+
+    #[test]
+    fn review_submitted_computes_incremental_average() {
+        let mut store = ReadStore::default();
+        project_event(&mut store, &DomainEvent::ReviewSubmitted {
+            review_id: "r-1".to_string(),
+            bounty_id: "b-1".to_string(),
+            creator_id: "creator-1".to_string(),
+            rating: 4,
+            zk_nullifier: "n-1".to_string(),
+            occurred_at: 1_600_000_000,
+        });
+        project_event(&mut store, &DomainEvent::ReviewSubmitted {
+            review_id: "r-2".to_string(),
+            bounty_id: "b-1".to_string(),
+            creator_id: "creator-1".to_string(),
+            rating: 5,
+            zk_nullifier: "n-2".to_string(),
+            occurred_at: 1_600_000_100,
+        });
+
+        let rep = store.creator_reputation("creator-1").expect("reputation should exist");
+        assert_eq!(rep.total_reviews, 2);
+        assert_eq!(rep.average_rating, 4.5);
+    }
+
+    #[test]
+    fn creator_reputation_returns_none_for_creator_with_no_reviews() {
+        let store = ReadStore::default();
+        assert!(store.creator_reputation("nobody").is_none());
+    }
+
+    #[test]
+    fn open_bounties_sorted_newest_first() {
+        let mut store = ReadStore::default();
+        project_event(&mut store, &DomainEvent::BountyCreated {
+            bounty_id: "b-older".to_string(),
+            creator_id: "creator-1".to_string(),
+            title: "Older".to_string(),
+            budget_usd: 100,
+            deadline_ts: 1_700_000_000,
+            occurred_at: 1_600_000_000,
+        });
+        project_event(&mut store, &DomainEvent::BountyCreated {
+            bounty_id: "b-newer".to_string(),
+            creator_id: "creator-1".to_string(),
+            title: "Newer".to_string(),
+            budget_usd: 200,
+            deadline_ts: 1_700_000_000,
+            occurred_at: 1_600_000_500,
+        });
+
+        let open = store.open_bounties();
+        assert_eq!(open.len(), 2);
+        assert_eq!(open[0].bounty_id, "b-newer");
+        assert_eq!(open[1].bounty_id, "b-older");
+    }
+
+    #[test]
+    fn search_bounties_excludes_cancelled_and_matches_case_insensitively() {
+        let mut store = ReadStore::default();
+        project_event(&mut store, &DomainEvent::BountyCreated {
+            bounty_id: "b-1".to_string(),
+            creator_id: "creator-1".to_string(),
+            title: "Design a Landing Page".to_string(),
+            budget_usd: 500,
+            deadline_ts: 1_700_000_000,
+            occurred_at: 1_600_000_000,
+        });
+        store.search_views.get_mut("b-1").unwrap().status = "cancelled".to_string();
+
+        assert!(store.search_bounties("landing").is_empty());
+    }
+
+    #[test]
+    fn schedule_search_view_refresh_and_drain_round_trip() {
+        let mut store = ReadStore::default();
+        project_event(&mut store, &DomainEvent::BountyCreated {
+            bounty_id: "b-1".to_string(),
+            creator_id: "creator-1".to_string(),
+            title: "Design a logo".to_string(),
+            budget_usd: 500,
+            deadline_ts: 1_700_000_000,
+            occurred_at: 1_600_000_000,
+        });
+        // Creation already flags needs_refresh; drain it first so the next
+        // assertion is about schedule_search_view_refresh specifically.
+        assert_eq!(store.drain_pending_refreshes(), vec!["b-1".to_string()]);
+        assert!(store.drain_pending_refreshes().is_empty());
+
+        schedule_search_view_refresh(&mut store, "b-1");
+        assert_eq!(store.drain_pending_refreshes(), vec!["b-1".to_string()]);
+    }
+
+    #[test]
+    fn events_from_command_handler_project_end_to_end() {
+        // Exercise the write-side handler and read-side projector together,
+        // matching how the real event log would drive both sides.
+        let mut store = ReadStore::default();
+        let events = handle_command(
+            Command::CreateBounty {
+                bounty_id: "b-1".to_string(),
+                creator_id: "creator-1".to_string(),
+                title: "Design a logo".to_string(),
+                budget_usd: 500,
+                deadline_ts: 1_700_000_000,
+            },
+            1_600_000_000,
+        ).unwrap();
+        for event in &events {
+            project_event(&mut store, event);
+        }
+        assert!(store.bounties.contains_key("b-1"));
+    }
+}

--- a/backend/services/api/src/cqrs_write.rs
+++ b/backend/services/api/src/cqrs_write.rs
@@ -204,3 +204,142 @@ pub fn handle_command(cmd: Command, now: u64) -> Result<Vec<DomainEvent>, &'stat
 
     Ok(events)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_bounty_produces_single_bounty_created_event() {
+        let cmd = Command::CreateBounty {
+            bounty_id: "b-1".to_string(),
+            creator_id: "creator-1".to_string(),
+            title: "Design a logo".to_string(),
+            budget_usd: 500,
+            deadline_ts: 1_700_000_000,
+        };
+        let events = handle_command(cmd, 1_600_000_000).expect("command should succeed");
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            DomainEvent::BountyCreated { bounty_id, creator_id, title, budget_usd, deadline_ts, occurred_at } => {
+                assert_eq!(bounty_id, "b-1");
+                assert_eq!(creator_id, "creator-1");
+                assert_eq!(title, "Design a logo");
+                assert_eq!(*budget_usd, 500);
+                assert_eq!(*deadline_ts, 1_700_000_000);
+                assert_eq!(*occurred_at, 1_600_000_000);
+            }
+            other => panic!("expected BountyCreated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_for_bounty_produces_application_received_event() {
+        let cmd = Command::ApplyForBounty {
+            application_id: "app-1".to_string(),
+            bounty_id: "b-1".to_string(),
+            freelancer_id: "freelancer-1".to_string(),
+            proposed_budget_usd: 450,
+        };
+        let events = handle_command(cmd, 1_600_000_000).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], DomainEvent::BountyApplicationReceived { .. }));
+    }
+
+    #[test]
+    fn select_freelancer_produces_freelancer_selected_event() {
+        let cmd = Command::SelectFreelancer {
+            bounty_id: "b-1".to_string(),
+            application_id: "app-1".to_string(),
+        };
+        let events = handle_command(cmd, 1_600_000_000).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], DomainEvent::FreelancerSelected { .. }));
+    }
+
+    #[test]
+    fn complete_bounty_produces_bounty_completed_event() {
+        let cmd = Command::CompleteBounty { bounty_id: "b-1".to_string() };
+        let events = handle_command(cmd, 1_600_000_000).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], DomainEvent::BountyCompleted { .. }));
+    }
+
+    #[test]
+    fn deposit_escrow_produces_escrow_deposited_event() {
+        let cmd = Command::DepositEscrow {
+            escrow_id: "e-1".to_string(),
+            bounty_id: "b-1".to_string(),
+            payer_id: "payer-1".to_string(),
+            payee_id: "payee-1".to_string(),
+            amount_usd: 500,
+        };
+        let events = handle_command(cmd, 1_600_000_000).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], DomainEvent::EscrowDeposited { .. }));
+    }
+
+    #[test]
+    fn release_and_refund_escrow_produce_matching_events() {
+        let release = handle_command(
+            Command::ReleaseEscrow { escrow_id: "e-1".to_string(), authorizer_id: "auth-1".to_string() },
+            1_600_000_000,
+        ).unwrap();
+        assert!(matches!(release[0], DomainEvent::EscrowReleased { .. }));
+
+        let refund = handle_command(
+            Command::RefundEscrow { escrow_id: "e-1".to_string(), authorizer_id: "auth-1".to_string() },
+            1_600_000_000,
+        ).unwrap();
+        assert!(matches!(refund[0], DomainEvent::EscrowRefunded { .. }));
+    }
+
+    #[test]
+    fn submit_review_rejects_rating_of_zero() {
+        let cmd = Command::SubmitReview {
+            review_id: "r-1".to_string(),
+            bounty_id: "b-1".to_string(),
+            creator_id: "creator-1".to_string(),
+            rating: 0,
+            zk_proof: "proof".to_string(),
+            zk_nullifier: "nullifier".to_string(),
+        };
+        let result = handle_command(cmd, 1_600_000_000);
+        assert_eq!(result.unwrap_err(), "Rating must be between 1 and 5");
+    }
+
+    #[test]
+    fn submit_review_rejects_rating_above_five() {
+        let cmd = Command::SubmitReview {
+            review_id: "r-1".to_string(),
+            bounty_id: "b-1".to_string(),
+            creator_id: "creator-1".to_string(),
+            rating: 6,
+            zk_proof: "proof".to_string(),
+            zk_nullifier: "nullifier".to_string(),
+        };
+        let result = handle_command(cmd, 1_600_000_000);
+        assert_eq!(result.unwrap_err(), "Rating must be between 1 and 5");
+    }
+
+    #[test]
+    fn submit_review_accepts_valid_rating_and_omits_proof_from_event() {
+        let cmd = Command::SubmitReview {
+            review_id: "r-1".to_string(),
+            bounty_id: "b-1".to_string(),
+            creator_id: "creator-1".to_string(),
+            rating: 5,
+            zk_proof: "secret-proof".to_string(),
+            zk_nullifier: "nullifier-abc".to_string(),
+        };
+        let events = handle_command(cmd, 1_600_000_000).unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            DomainEvent::ReviewSubmitted { rating, zk_nullifier, .. } => {
+                assert_eq!(*rating, 5);
+                assert_eq!(zk_nullifier, "nullifier-abc");
+            }
+            other => panic!("expected ReviewSubmitted, got {other:?}"),
+        }
+    }
+}

--- a/backend/services/api/src/database/db/bounties.rs
+++ b/backend/services/api/src/database/db/bounties.rs
@@ -79,3 +79,70 @@ pub fn apply_for_bounty(bounty_id: u64, application: BountyApplication) -> Resul
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_application(bounty_id: u64) -> BountyApplication {
+        BountyApplication {
+            bounty_id,
+            freelancer: "GFREELANCER".to_string(),
+            proposal: "I can build this".to_string(),
+            proposed_budget: 500,
+            timeline: 7,
+        }
+    }
+
+    #[test]
+    fn get_bounty_by_id_returns_none_for_unknown_id() {
+        assert!(get_bounty_by_id(9999).is_none());
+    }
+
+    #[test]
+    fn get_bounty_by_id_returns_some_for_known_id() {
+        let bounty = get_bounty_by_id(2).expect("bounty 2 exists in mock data");
+        assert_eq!(bounty.creator, "jordan-dev");
+    }
+
+    #[test]
+    fn create_bounty_always_starts_open() {
+        let request = BountyRequest {
+            creator: "test-creator".to_string(),
+            title: "Test Bounty".to_string(),
+            description: "Test Description".to_string(),
+            budget: 1000,
+            deadline: 1234567890,
+        };
+        let created = create_bounty(request);
+        assert_eq!(created.status, "open");
+        assert_eq!(created.budget, 1000);
+    }
+
+    #[test]
+    fn apply_for_bounty_rejects_empty_proposal() {
+        let mut application = sample_application(1);
+        application.proposal = "   ".to_string();
+        let result = apply_for_bounty(1, application);
+        assert_eq!(result, Err("Proposal cannot be empty".to_string()));
+    }
+
+    #[test]
+    fn apply_for_bounty_rejects_non_positive_budget() {
+        let mut application = sample_application(1);
+        application.proposed_budget = 0;
+        let result = apply_for_bounty(1, application);
+        assert_eq!(result, Err("Proposed budget must be positive".to_string()));
+
+        let mut negative_application = sample_application(1);
+        negative_application.proposed_budget = -100;
+        let result = apply_for_bounty(1, negative_application);
+        assert_eq!(result, Err("Proposed budget must be positive".to_string()));
+    }
+
+    #[test]
+    fn apply_for_bounty_accepts_valid_application() {
+        let application = sample_application(1);
+        assert_eq!(apply_for_bounty(1, application), Ok(()));
+    }
+}

--- a/backend/services/api/src/database/db/escrows.rs
+++ b/backend/services/api/src/database/db/escrows.rs
@@ -101,3 +101,56 @@ fn chrono_now() -> String {
     // Stable timestamp placeholder — real impl would use chrono or time crate
     "2026-01-01T00:00:00Z".to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_request() -> EscrowCreateRequest {
+        EscrowCreateRequest {
+            bounty_id: "test-bounty".to_string(),
+            payer_address: "GPAYER".to_string(),
+            payee_address: "GPAYEE".to_string(),
+            amount: 1000,
+            token: "GUSDC".to_string(),
+            timelock: None,
+        }
+    }
+
+    #[test]
+    fn get_escrow_by_id_returns_none_for_unknown_id() {
+        assert!(get_escrow_by_id(9999).is_none());
+    }
+
+    #[test]
+    fn create_escrow_starts_pending_and_preserves_optional_timelock() {
+        let created = create_escrow(sample_request());
+        assert_eq!(created.status, "pending");
+        assert_eq!(created.timelock, None);
+        assert!(created.transaction_hash.is_some());
+    }
+
+    #[test]
+    fn release_escrow_updates_status_for_existing_escrow() {
+        let released = release_escrow(1).expect("escrow 1 exists in mock data");
+        assert_eq!(released.status, "released");
+        assert_eq!(released.transaction_hash, Some("tx_release_1".to_string()));
+    }
+
+    #[test]
+    fn release_escrow_returns_none_for_unknown_id() {
+        assert!(release_escrow(9999).is_none());
+    }
+
+    #[test]
+    fn refund_escrow_updates_status_for_existing_escrow() {
+        let refunded = refund_escrow(2, "GAUTHORIZER".to_string()).expect("escrow 2 exists in mock data");
+        assert_eq!(refunded.status, "refunded");
+        assert_eq!(refunded.transaction_hash, Some("tx_refund_2".to_string()));
+    }
+
+    #[test]
+    fn refund_escrow_returns_none_for_unknown_id() {
+        assert!(refund_escrow(9999, "GAUTHORIZER".to_string()).is_none());
+    }
+}

--- a/backend/services/api/src/database/db/freelancers.rs
+++ b/backend/services/api/src/database/db/freelancers.rs
@@ -74,3 +74,48 @@ pub fn register_freelancer(registration: FreelancerRegistration, address: String
         verified: false, // Verification process would be separate
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_freelancer_by_address_returns_none_for_unknown_address() {
+        assert!(get_freelancer_by_address("GUNKNOWN").is_none());
+    }
+
+    #[test]
+    fn filter_by_discipline_with_empty_string_returns_all() {
+        let freelancers = get_mock_freelancers();
+        let filtered = filter_freelancers_by_discipline(freelancers.clone(), "");
+        assert_eq!(filtered.len(), freelancers.len());
+    }
+
+    #[test]
+    fn filter_by_discipline_is_case_insensitive_partial_match() {
+        let freelancers = get_mock_freelancers();
+        let filtered = filter_freelancers_by_discipline(freelancers, "full stack");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].discipline, "Full Stack Development");
+    }
+
+    #[test]
+    fn filter_by_discipline_with_no_match_returns_empty() {
+        let freelancers = get_mock_freelancers();
+        let filtered = filter_freelancers_by_discipline(freelancers, "Blockchain Auditing");
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn register_freelancer_starts_unverified_with_no_track_record() {
+        let registration = FreelancerRegistration {
+            name: "New Freelancer".to_string(),
+            discipline: "Illustration".to_string(),
+            bio: "Fresh to the platform".to_string(),
+        };
+        let freelancer = register_freelancer(registration, "GNEWADDRESS".to_string());
+        assert_eq!(freelancer.rating, 0.0);
+        assert_eq!(freelancer.completed_projects, 0);
+        assert!(!freelancer.verified);
+    }
+}

--- a/backend/services/api/src/database/db/reviews.rs
+++ b/backend/services/api/src/database/db/reviews.rs
@@ -155,3 +155,97 @@ fn chrono_now() -> String {
     // Stable timestamp placeholder — real impl would use chrono or time crate
     "2026-01-01T00:00:00Z".to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_submission() -> ReviewSubmission {
+        ReviewSubmission {
+            bounty_id: "b-9".to_string(),
+            creator_id: "alex-studio".to_string(),
+            rating: 5,
+            title: "Great work".to_string(),
+            body: "Excellent job!".to_string(),
+            reviewer_name: "Test Reviewer".to_string(),
+        }
+    }
+
+    #[test]
+    fn reviews_for_creator_returns_empty_for_unknown_creator() {
+        assert!(reviews_for_creator("unknown-creator").is_empty());
+    }
+
+    #[test]
+    fn aggregate_reviews_of_empty_slice_is_zeroed() {
+        let aggregation = aggregate_reviews(&[]);
+        assert_eq!(aggregation.total_reviews, 0);
+        assert_eq!(aggregation.average_rating, 0.0);
+        assert_eq!(aggregation.rating_distribution, [0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn aggregate_reviews_computes_distribution_and_average() {
+        let reviews = reviews_for_creator("alex-studio");
+        let aggregation = aggregate_reviews(&reviews);
+        assert_eq!(aggregation.total_reviews, 2);
+        assert_eq!(aggregation.average_rating, 4.5);
+        assert_eq!(aggregation.rating_distribution, [0, 0, 0, 1, 1]);
+    }
+
+    #[test]
+    fn recent_reviews_respects_limit_and_sorts_newest_first() {
+        let reviews = get_mock_reviews();
+        let recent = recent_reviews(&reviews, 2);
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0].id, "rev-alex-studio-b-1");
+        assert_eq!(recent[1].id, "rev-jordan-dev-b-1");
+    }
+
+    #[test]
+    fn submit_review_rejects_empty_bounty_id() {
+        let mut submission = valid_submission();
+        submission.bounty_id = "  ".to_string();
+        assert_eq!(submit_review(submission).unwrap_err(), "Bounty ID is required");
+    }
+
+    #[test]
+    fn submit_review_rejects_empty_creator_id() {
+        let mut submission = valid_submission();
+        submission.creator_id = "".to_string();
+        assert_eq!(submit_review(submission).unwrap_err(), "Creator ID is required");
+    }
+
+    #[test]
+    fn submit_review_rejects_out_of_range_rating() {
+        let mut too_low = valid_submission();
+        too_low.rating = 0;
+        assert_eq!(submit_review(too_low).unwrap_err(), "Rating must be between 1 and 5");
+
+        let mut too_high = valid_submission();
+        too_high.rating = 6;
+        assert_eq!(submit_review(too_high).unwrap_err(), "Rating must be between 1 and 5");
+    }
+
+    #[test]
+    fn submit_review_rejects_empty_title_body_or_reviewer_name() {
+        let mut no_title = valid_submission();
+        no_title.title = " ".to_string();
+        assert_eq!(submit_review(no_title).unwrap_err(), "Title is required");
+
+        let mut no_body = valid_submission();
+        no_body.body = "".to_string();
+        assert_eq!(submit_review(no_body).unwrap_err(), "Feedback is required");
+
+        let mut no_reviewer = valid_submission();
+        no_reviewer.reviewer_name = "  ".to_string();
+        assert_eq!(submit_review(no_reviewer).unwrap_err(), "Your name is required");
+    }
+
+    #[test]
+    fn submit_review_accepts_valid_submission() {
+        let review = submit_review(valid_submission()).expect("valid submission should succeed");
+        assert_eq!(review.id, "rev-alex-studio-b-9");
+        assert_eq!(review.rating, 5);
+    }
+}


### PR DESCRIPTION
…write

Closes #911, closes #913, closes #914, closes #912

## Summary
- Adds dedicated `#[cfg(test)]` modules to bounties/escrows/freelancers/reviews.rs covering unknown-ID lookups and validation-rejection edge cases (#914)
- Adds tests for every Command -> DomainEvent mapping and invalid-rating rejection in cqrs_write.rs (#911)
- Adds tests for project_event/ReadStore in cqrs_read.rs, including an out-of-order-event case (#913)

## Note
#912 (upload.rs) is intentionally not addressed here — it isn't wired into main.rs (no `mod upload;`) and `actix-multipart` isn't a declared dependency, so it's currently dead code. Also worth flagging separately: `cargo check` on upstream/main currently fails with ~56 pre-existing compile errors unrelated to this PR (alerts.rs, main.rs, reputation.rs, webhooks/soroban.rs), so `cargo test` can't run end-to-end yet. The 6 files touched here were verified in isolation (46/46 tests passing) since the full crate doesn't build.

## Test plan
- [ ] Once the crate-wide build is fixed, run `cargo test -p stellar-api` and confirm the new tests pass