### PR TITLE
Test coverage/auth and discovery

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "contracts/test-utils",
     "services/api",
     "services/auth",
+    "services/discovery",
     "tests",
 ]
 resolver = "2"
@@ -38,7 +39,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres"] }
+sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "uuid", "chrono"] }
 diesel = { version = "2.1", features = ["postgres"] }
 
 # Cryptography & Blockchain
@@ -46,6 +47,10 @@ ed25519-dalek = "2.1"
 sha2 = "0.10"
 hmac = { version = "0.12", features = ["std"] }
 hex = "0.4"
+uuid = { version = "1", features = ["v4", "serde"] }
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+oauth2 = "4"
 
 # Auth
 jsonwebtoken = "10"

--- a/backend/services/auth/Cargo.toml
+++ b/backend/services/auth/Cargo.toml
@@ -28,5 +28,9 @@ thiserror.workspace = true
 rand = { version = "0.8", features = ["getrandom"] }
 urlencoding = "2.1"
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }
-jsonwebtoken = { version = "10.4", features = ["use_pem"] }
-uuid = { version = "1", features = ["v4", "serde"] }
+jsonwebtoken = { version = "10.4", features = ["use_pem", "rust_crypto"] }
+sqlx.workspace = true
+uuid.workspace = true
+chrono.workspace = true
+oauth2.workspace = true
+reqwest.workspace = true

--- a/backend/services/auth/src/config.rs
+++ b/backend/services/auth/src/config.rs
@@ -184,7 +184,10 @@ mod tests {
 
     #[test]
     fn rejects_default_jwt_secret() {
-        let err = validate_jwt_secret("change-me-in-production").expect_err("default secret should fail");
+        // Must be >= 32 chars so the length check doesn't fire first and mask
+        // the placeholder check this test is actually targeting.
+        let err = validate_jwt_secret("change-me-in-production-please-fix")
+            .expect_err("default secret should fail");
         assert!(err.to_string().contains("placeholder"));
     }
 

--- a/backend/services/auth/src/db.rs
+++ b/backend/services/auth/src/db.rs
@@ -128,3 +128,288 @@ pub async fn revoke_all_user_tokens(pool: &PgPool, user_id: &str) -> Result<u64,
         .await?;
     Ok(result.rows_affected())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use sqlx::postgres::PgPoolOptions;
+
+    /// Connects to `DATABASE_URL` and ensures the `refresh_tokens` and
+    /// `used_refresh_tokens` tables exist. Returns `None` (causing callers to
+    /// skip) when no database is reachable, since CI does not run a Postgres
+    /// instance for this crate. Run against a real database locally via
+    /// `backend/docker-compose.yml` (schema: `backend/migrations/`).
+    async fn test_pool() -> Option<PgPool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await
+            .ok()?;
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS refresh_tokens (
+                id UUID PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                token_hash BYTEA NOT NULL UNIQUE,
+                family_id UUID NOT NULL,
+                expires_at TIMESTAMPTZ NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .ok()?;
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS used_refresh_tokens (
+                token_hash BYTEA PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                family_id UUID NOT NULL,
+                used_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .ok()?;
+        Some(pool)
+    }
+
+    /// A hash unlikely to collide with any other test run or concurrent test.
+    fn unique_hash() -> Vec<u8> {
+        Uuid::new_v4().as_bytes().to_vec()
+    }
+
+    #[tokio::test]
+    async fn insert_persists_the_exact_row_that_was_written() {
+        let Some(pool) = test_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set/unreachable (see backend/docker-compose.yml)");
+            return;
+        };
+
+        let id = Uuid::new_v4();
+        let family = Uuid::new_v4();
+        let hash = unique_hash();
+        let expires_at = Utc::now() + Duration::hours(1);
+
+        insert_refresh_token(&pool, id, "user-insert", &hash, family, expires_at)
+            .await
+            .expect("insert should succeed");
+
+        let row: (String, Vec<u8>, Uuid, DateTime<Utc>) = sqlx::query_as(
+            "SELECT user_id, token_hash, family_id, expires_at FROM refresh_tokens WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("row should be readable back");
+
+        assert_eq!(row.0, "user-insert");
+        assert_eq!(row.1, hash);
+        assert_eq!(row.2, family);
+        assert_eq!(row.3.timestamp(), expires_at.timestamp());
+
+        sqlx::query("DELETE FROM refresh_tokens WHERE id = $1")
+            .bind(id)
+            .execute(&pool)
+            .await
+            .ok();
+    }
+
+    #[tokio::test]
+    async fn rotate_replaces_old_token_and_preserves_user_and_family() {
+        let Some(pool) = test_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set/unreachable (see backend/docker-compose.yml)");
+            return;
+        };
+
+        let id = Uuid::new_v4();
+        let family = Uuid::new_v4();
+        let old_hash = unique_hash();
+        let expires_at = Utc::now() + Duration::hours(1);
+        insert_refresh_token(&pool, id, "user-rotate", &old_hash, family, expires_at)
+            .await
+            .expect("insert should succeed");
+
+        let new_id = Uuid::new_v4();
+        let new_hash = unique_hash();
+        let (user_id, family_id) =
+            rotate_refresh_token(&pool, &old_hash, new_id, &new_hash, expires_at)
+                .await
+                .expect("rotation of a valid token should succeed");
+
+        assert_eq!(user_id, "user-rotate");
+        assert_eq!(family_id, family);
+
+        // The new row is in place with the same family id. Checked before the
+        // reuse attempt below, because reuse detection revokes every session
+        // for this user — including the row we're about to verify.
+        let row: (String, Uuid) =
+            sqlx::query_as("SELECT user_id, family_id FROM refresh_tokens WHERE id = $1")
+                .bind(new_id)
+                .fetch_one(&pool)
+                .await
+                .expect("rotated row should exist");
+        assert_eq!(row.0, "user-rotate");
+        assert_eq!(row.1, family);
+
+        sqlx::query("DELETE FROM refresh_tokens WHERE id = $1")
+            .bind(new_id)
+            .execute(&pool)
+            .await
+            .ok();
+        sqlx::query("DELETE FROM used_refresh_tokens WHERE token_hash = $1")
+            .bind(&old_hash)
+            .execute(&pool)
+            .await
+            .ok();
+    }
+
+    #[tokio::test]
+    async fn reusing_a_rotated_away_token_is_detected_and_revokes_all_sessions() {
+        let Some(pool) = test_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set/unreachable (see backend/docker-compose.yml)");
+            return;
+        };
+
+        let id = Uuid::new_v4();
+        let family = Uuid::new_v4();
+        let old_hash = unique_hash();
+        let expires_at = Utc::now() + Duration::hours(1);
+        insert_refresh_token(&pool, id, "user-theft", &old_hash, family, expires_at)
+            .await
+            .expect("insert should succeed");
+
+        // Legitimate rotation: old_hash is now recorded in used_refresh_tokens.
+        let (user_id, _) =
+            rotate_refresh_token(&pool, &old_hash, Uuid::new_v4(), &unique_hash(), expires_at)
+                .await
+                .expect("first rotation should succeed");
+
+        // An attacker (or a client that missed the response) replays the old
+        // token. This must be rejected as theft, not treated as merely invalid,
+        // and must revoke every active session for the user.
+        let reuse = rotate_refresh_token(&pool, &old_hash, Uuid::new_v4(), &unique_hash(), expires_at)
+            .await;
+        assert!(
+            matches!(reuse, Err(AuthError::TokenReuseDetected)),
+            "replaying a rotated-away token must be flagged as reuse, not a generic invalid token"
+        );
+
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM refresh_tokens WHERE user_id = $1")
+            .bind(&user_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count query should succeed");
+        assert_eq!(remaining, 0, "reuse detection must revoke all sessions for the user, including the legitimately-rotated one");
+
+        sqlx::query("DELETE FROM used_refresh_tokens WHERE token_hash = $1")
+            .bind(&old_hash)
+            .execute(&pool)
+            .await
+            .ok();
+    }
+
+    #[tokio::test]
+    async fn rotate_unknown_token_is_rejected() {
+        let Some(pool) = test_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set/unreachable (see backend/docker-compose.yml)");
+            return;
+        };
+
+        let result = rotate_refresh_token(
+            &pool,
+            &unique_hash(),
+            Uuid::new_v4(),
+            &unique_hash(),
+            Utc::now() + Duration::hours(1),
+        )
+        .await;
+        assert!(matches!(result, Err(AuthError::InvalidRefreshToken)));
+    }
+
+    #[tokio::test]
+    async fn rotate_expired_token_is_rejected() {
+        let Some(pool) = test_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set/unreachable (see backend/docker-compose.yml)");
+            return;
+        };
+
+        let id = Uuid::new_v4();
+        let family = Uuid::new_v4();
+        let hash = unique_hash();
+        let already_expired = Utc::now() - Duration::hours(1);
+        insert_refresh_token(&pool, id, "user-expired", &hash, family, already_expired)
+            .await
+            .expect("insert should succeed even for an already-expired row");
+
+        let result = rotate_refresh_token(
+            &pool,
+            &hash,
+            Uuid::new_v4(),
+            &unique_hash(),
+            Utc::now() + Duration::hours(1),
+        )
+        .await;
+        assert!(
+            matches!(result, Err(AuthError::InvalidRefreshToken)),
+            "an expired refresh token must not be rotatable"
+        );
+
+        sqlx::query("DELETE FROM refresh_tokens WHERE id = $1")
+            .bind(id)
+            .execute(&pool)
+            .await
+            .ok();
+    }
+
+    #[tokio::test]
+    async fn revoke_all_user_tokens_deletes_only_that_users_rows() {
+        let Some(pool) = test_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set/unreachable (see backend/docker-compose.yml)");
+            return;
+        };
+
+        let expires_at = Utc::now() + Duration::hours(1);
+        let id_a1 = Uuid::new_v4();
+        let id_a2 = Uuid::new_v4();
+        let id_b = Uuid::new_v4();
+        insert_refresh_token(&pool, id_a1, "user-a", &unique_hash(), Uuid::new_v4(), expires_at)
+            .await
+            .expect("insert should succeed");
+        insert_refresh_token(&pool, id_a2, "user-a", &unique_hash(), Uuid::new_v4(), expires_at)
+            .await
+            .expect("insert should succeed");
+        insert_refresh_token(&pool, id_b, "user-b", &unique_hash(), Uuid::new_v4(), expires_at)
+            .await
+            .expect("insert should succeed");
+
+        let revoked = revoke_all_user_tokens(&pool, "user-a")
+            .await
+            .expect("revoke should succeed");
+        assert_eq!(revoked, 2);
+
+        let remaining_a: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM refresh_tokens WHERE user_id = $1")
+            .bind("user-a")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(remaining_a, 0);
+
+        let remaining_b: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM refresh_tokens WHERE user_id = $1")
+            .bind("user-b")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(remaining_b, 1, "revoking user-a must not touch user-b's tokens");
+
+        sqlx::query("DELETE FROM refresh_tokens WHERE id = $1")
+            .bind(id_b)
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/services/auth/src/error.rs
+++ b/backend/services/auth/src/error.rs
@@ -70,3 +70,94 @@ impl ResponseError for AuthError {
         HttpResponse::build(status).json(json!({ "error": msg }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::body::to_bytes;
+    use actix_web::http::StatusCode;
+
+    async fn error_response_parts(err: AuthError) -> (StatusCode, serde_json::Value) {
+        let resp = err.error_response();
+        let status = resp.status();
+        let body = to_bytes(resp.into_body()).await.expect("response body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        (status, json)
+    }
+
+    #[actix_web::test]
+    async fn invalid_refresh_token_is_unauthorized_and_generic() {
+        let (status, json) = error_response_parts(AuthError::InvalidRefreshToken).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(json["error"], "invalid or expired refresh token");
+    }
+
+    #[actix_web::test]
+    async fn mint_not_configured_is_service_unavailable() {
+        let (status, _) = error_response_parts(AuthError::MintNotConfigured).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[actix_web::test]
+    async fn mint_unauthorized_is_unauthorized() {
+        let (status, json) = error_response_parts(AuthError::MintUnauthorized).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(json["error"], "unauthorized mint request");
+    }
+
+    #[actix_web::test]
+    async fn db_error_maps_to_internal_error_without_leaking_details() {
+        let (status, json) = error_response_parts(AuthError::Db(sqlx::Error::RowNotFound)).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(json["error"], "internal error");
+        // The client must not learn that this was specifically a "row not found" —
+        // that would leak whether a given token/user exists in the database.
+        let msg = json["error"].as_str().unwrap().to_lowercase();
+        assert!(!msg.contains("row"));
+        assert!(!msg.contains("sqlx"));
+    }
+
+    #[actix_web::test]
+    async fn jwt_error_maps_to_internal_error_without_leaking_details() {
+        let jwt_err: jsonwebtoken::errors::Error =
+            jsonwebtoken::errors::ErrorKind::InvalidToken.into();
+        let (status, json) = error_response_parts(AuthError::Jwt(jwt_err)).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(json["error"], "internal error");
+    }
+
+    #[actix_web::test]
+    async fn invalid_oauth_provider_is_bad_request() {
+        let (status, json) =
+            error_response_parts(AuthError::InvalidOAuthProvider("bogus".to_string())).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(json["error"], "invalid OAuth provider: bogus");
+    }
+
+    #[actix_web::test]
+    async fn oauth_provider_not_configured_is_service_unavailable() {
+        let (status, _) = error_response_parts(AuthError::OAuthProviderNotConfigured(
+            "github".to_string(),
+        ))
+        .await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[actix_web::test]
+    async fn oauth_flow_failed_is_bad_gateway() {
+        let (status, _) =
+            error_response_parts(AuthError::OAuthFlowFailed("boom".to_string())).await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn invalid_refresh_token_uses_one_generic_message_for_every_case() {
+        // db::rotate_refresh_token returns this same variant whether the token is
+        // unknown, expired, or already rotated away — callers can't distinguish
+        // which case applies from the message alone.
+        assert_eq!(
+            AuthError::InvalidRefreshToken.to_string(),
+            "invalid or expired refresh token"
+        );
+    }
+}

--- a/backend/services/auth/src/handlers.rs
+++ b/backend/services/auth/src/handlers.rs
@@ -328,3 +328,246 @@ pub async fn refresh_tokens(
         "expires_in": config.access_ttl_secs
     })))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{test as awtest, App};
+    use sqlx::postgres::PgPoolOptions;
+
+    fn test_config() -> Config {
+        Config {
+            host: "127.0.0.1".to_string(),
+            port: 8080,
+            database_url: "postgres://localhost/test".to_string(),
+            jwt_secret: "01234567890123456789012345678901".to_string(),
+            access_ttl_secs: 900,
+            refresh_ttl_secs: 604_800,
+            mint_secret: None,
+            dev_mint_allow: true,
+            google_oauth: None,
+            github_oauth: None,
+            twitter_oauth: None,
+        }
+    }
+
+    /// A pool that never actually connects — safe to pass into handlers whose
+    /// code path under test returns before touching the database.
+    fn lazy_pool() -> sqlx::PgPool {
+        PgPoolOptions::new()
+            .connect_lazy("postgres://user:pass@localhost/does-not-matter")
+            .expect("lazy pool construction never touches the network")
+    }
+
+    /// Connects to `DATABASE_URL` and ensures the `refresh_tokens` table
+    /// exists; returns `None` (causing callers to skip) when unreachable, since
+    /// CI does not run a Postgres instance for this crate. Run against a real
+    /// database locally via `backend/docker-compose.yml`.
+    async fn live_pool() -> Option<sqlx::PgPool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pool = PgPoolOptions::new().max_connections(1).connect(&url).await.ok()?;
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS refresh_tokens (
+                id UUID PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                token_hash BYTEA NOT NULL UNIQUE,
+                family_id UUID NOT NULL,
+                expires_at TIMESTAMPTZ NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .ok()?;
+        Some(pool)
+    }
+
+    // ---- pure / DB-independent ----
+
+    #[test]
+    fn extract_mint_header_reads_custom_header() {
+        let req = awtest::TestRequest::default()
+            .insert_header(("x-mint-secret", "shh"))
+            .to_http_request();
+        assert_eq!(extract_mint_header(&req), Some("shh"));
+    }
+
+    #[test]
+    fn extract_mint_header_missing_is_none() {
+        let req = awtest::TestRequest::default().to_http_request();
+        assert_eq!(extract_mint_header(&req), None);
+    }
+
+    #[actix_web::test]
+    async fn health_reports_service_metadata() {
+        let resp = health().await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+        let body = actix_web::body::to_bytes(resp.into_body()).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["service"], "stellar-auth");
+        assert_eq!(json["status"], "healthy");
+    }
+
+    #[test]
+    fn build_oauth_client_succeeds_for_every_known_provider() {
+        let cfg = OAuthProviderConfig {
+            client_id: "id".to_string(),
+            client_secret: "secret".to_string(),
+            redirect_uri: "https://example.com/callback".to_string(),
+        };
+        for provider in [OAuthProvider::Google, OAuthProvider::GitHub, OAuthProvider::Twitter] {
+            assert!(build_oauth_client(provider, &cfg, "https://example.com/callback").is_ok());
+        }
+    }
+
+    #[test]
+    fn build_oauth_client_rejects_an_invalid_redirect_uri() {
+        let cfg = OAuthProviderConfig {
+            client_id: "id".to_string(),
+            client_secret: "secret".to_string(),
+            redirect_uri: "https://example.com/callback".to_string(),
+        };
+        let result = build_oauth_client(OAuthProvider::Google, &cfg, "not a url");
+        assert!(matches!(result, Err(AuthError::OAuthFlowFailed(_))));
+    }
+
+    #[actix_web::test]
+    async fn mint_tokens_rejects_when_not_configured() {
+        let mut cfg = test_config();
+        cfg.dev_mint_allow = false;
+        cfg.mint_secret = None;
+        let req = awtest::TestRequest::default().to_http_request();
+        let result = mint_tokens(
+            req,
+            web::Data::new(cfg),
+            web::Data::new(lazy_pool()),
+            web::Json(MintTokenRequest { user_id: "u1".to_string() }),
+        )
+        .await;
+        assert!(matches!(result, Err(AuthError::MintNotConfigured)));
+    }
+
+    #[actix_web::test]
+    async fn mint_tokens_rejects_a_wrong_mint_secret() {
+        let mut cfg = test_config();
+        cfg.dev_mint_allow = false;
+        cfg.mint_secret = Some("correct-secret".to_string());
+        let req = awtest::TestRequest::default()
+            .insert_header(("x-mint-secret", "wrong"))
+            .to_http_request();
+        let result = mint_tokens(
+            req,
+            web::Data::new(cfg),
+            web::Data::new(lazy_pool()),
+            web::Json(MintTokenRequest { user_id: "u1".to_string() }),
+        )
+        .await;
+        assert!(matches!(result, Err(AuthError::MintUnauthorized)));
+    }
+
+    #[actix_web::test]
+    async fn oauth2_token_exchange_rejects_an_unknown_provider() {
+        let app = awtest::init_service(
+            App::new()
+                .app_data(web::Data::new(test_config()))
+                .app_data(web::Data::new(lazy_pool()))
+                .route("/oauth/{provider}/token", web::post().to(oauth2_token_exchange)),
+        )
+        .await;
+
+        let req = awtest::TestRequest::post()
+            .uri("/oauth/not-a-provider/token")
+            .set_json(serde_json::json!({ "code": "x" }))
+            .to_request();
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn oauth2_authorize_rejects_an_unconfigured_provider() {
+        // test_config() leaves github_oauth as None.
+        let app = awtest::init_service(
+            App::new()
+                .app_data(web::Data::new(test_config()))
+                .route("/oauth/{provider}/authorize", web::get().to(oauth2_authorize)),
+        )
+        .await;
+
+        let req = awtest::TestRequest::get()
+            .uri("/oauth/github/authorize")
+            .to_request();
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    // ---- integration against a real Postgres (skips if DATABASE_URL is unset/unreachable) ----
+
+    #[actix_web::test]
+    async fn mint_then_refresh_rotates_the_token_and_rejects_reuse() {
+        let Some(pool) = live_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set/unreachable (see backend/docker-compose.yml)");
+            return;
+        };
+        let app = awtest::init_service(
+            App::new()
+                .app_data(web::Data::new(test_config()))
+                .app_data(web::Data::new(pool))
+                .route("/token", web::post().to(mint_tokens))
+                .route("/refresh", web::post().to(refresh_tokens)),
+        )
+        .await;
+
+        let mint_req = awtest::TestRequest::post()
+            .uri("/token")
+            .set_json(serde_json::json!({ "user_id": "integration-user" }))
+            .to_request();
+        let mint_resp = awtest::call_service(&app, mint_req).await;
+        assert_eq!(mint_resp.status(), actix_web::http::StatusCode::OK);
+        let mint_body: serde_json::Value = awtest::read_body_json(mint_resp).await;
+        let refresh_token = mint_body["refresh_token"].as_str().unwrap().to_string();
+
+        let refresh_req = awtest::TestRequest::post()
+            .uri("/refresh")
+            .set_json(serde_json::json!({ "refresh_token": refresh_token }))
+            .to_request();
+        let refresh_resp = awtest::call_service(&app, refresh_req).await;
+        assert_eq!(refresh_resp.status(), actix_web::http::StatusCode::OK);
+        let refresh_body: serde_json::Value = awtest::read_body_json(refresh_resp).await;
+        let new_refresh = refresh_body["refresh_token"].as_str().unwrap();
+        assert_ne!(new_refresh, refresh_token, "refresh must rotate the token");
+
+        // The rotated-away (now effectively revoked) token must be rejected —
+        // this is the "revoked/expired refresh" regression this file had zero
+        // coverage for.
+        let reuse_req = awtest::TestRequest::post()
+            .uri("/refresh")
+            .set_json(serde_json::json!({ "refresh_token": refresh_token }))
+            .to_request();
+        let reuse_resp = awtest::call_service(&app, reuse_req).await;
+        assert_eq!(reuse_resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+    }
+
+    #[actix_web::test]
+    async fn refresh_with_a_bogus_token_is_unauthorized() {
+        let Some(pool) = live_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set/unreachable (see backend/docker-compose.yml)");
+            return;
+        };
+        let app = awtest::init_service(
+            App::new()
+                .app_data(web::Data::new(test_config()))
+                .app_data(web::Data::new(pool))
+                .route("/refresh", web::post().to(refresh_tokens)),
+        )
+        .await;
+
+        let req = awtest::TestRequest::post()
+            .uri("/refresh")
+            .set_json(serde_json::json!({ "refresh_token": "not-a-real-token" }))
+            .to_request();
+        let resp = awtest::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+    }
+}

--- a/backend/services/auth/src/main.rs
+++ b/backend/services/auth/src/main.rs
@@ -1,3 +1,18 @@
+// These modules implement an OAuth2 + Postgres-backed refresh-token auth
+// flow that is not yet wired into the routes below (the live server still
+// uses the ed25519/TOTP flow in this file). Kept compiling + tested so the
+// dead code doesn't bit-rot silently.
+#[allow(dead_code)]
+mod config;
+#[allow(dead_code)]
+mod db;
+#[allow(dead_code)]
+mod error;
+#[allow(dead_code)]
+mod handlers;
+#[allow(dead_code)]
+mod tokens;
+
 use actix_web::{middleware, web, App, HttpResponse, HttpServer};
 use rand::RngCore;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};

--- a/backend/services/discovery/src/lib.rs
+++ b/backend/services/discovery/src/lib.rs
@@ -102,3 +102,57 @@ pub async fn create_discovery() -> Result<Box<dyn ServiceDiscovery>> {
 
 // Re-export the async_trait macro so downstream crates don't need the dep.
 pub use async_trait::async_trait;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_info_new_sets_fields_and_generates_unique_id() {
+        let info = ServiceInfo::new("stellar-api", "127.0.0.1", 3001);
+        assert!(info.id.starts_with("stellar-api-"));
+        assert_eq!(info.name, "stellar-api");
+        assert_eq!(info.address, "127.0.0.1");
+        assert_eq!(info.port, 3001);
+        assert!(info.tags.is_empty());
+
+        let other = ServiceInfo::new("stellar-api", "127.0.0.1", 3001);
+        assert_ne!(info.id, other.id, "each instance must get a unique id");
+    }
+
+    #[test]
+    fn with_tags_replaces_the_tag_list() {
+        let info = ServiceInfo::new("svc", "127.0.0.1", 3001)
+            .with_tags(vec!["v1".to_string(), "primary".to_string()]);
+        assert_eq!(info.tags, vec!["v1".to_string(), "primary".to_string()]);
+    }
+
+    // Both branches live in one test because they mutate the shared
+    // CONSUL_HTTP_ADDR process env var; splitting them risks a race if the
+    // test binary runs them concurrently.
+    #[tokio::test]
+    async fn create_discovery_picks_backend_from_env() {
+        std::env::remove_var("CONSUL_HTTP_ADDR");
+        let static_disc = create_discovery()
+            .await
+            .expect("static backend should construct without CONSUL_HTTP_ADDR");
+        let info = ServiceInfo::new("probe", "10.0.0.5", 4000);
+        static_disc
+            .register(info.clone())
+            .await
+            .expect("static register works without any network access");
+        let resolved = static_disc
+            .resolve("probe")
+            .await
+            .expect("static resolve works without any network access");
+        assert_eq!(resolved.map(|s| s.address), Some("10.0.0.5".to_string()));
+
+        std::env::set_var("CONSUL_HTTP_ADDR", "http://127.0.0.1:8500");
+        let consul_disc = create_discovery().await;
+        std::env::remove_var("CONSUL_HTTP_ADDR");
+        assert!(
+            consul_disc.is_ok(),
+            "picking the Consul backend must not require a reachable Consul server"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #907, closes #908, closes #909, closes #910 — adds real, running test coverage for
  backend/services/auth/src/{handlers,db,error}.rs and
  backend/services/discovery/src/lib.rs.
- **Important finding**: handlers.rs/db.rs/error.rs/config.rs/tokens.rs
  were never wired into the auth crate (no `mod` declarations in
  main.rs, and several required deps like sqlx/uuid/chrono/oauth2 were
  missing from Cargo.toml) — they were dead code, uncompiled and
  untested. Same story for services/discovery: not a workspace member.
  This PR wires both in (compile + test only) without changing any
  live routing — the auth server still serves the existing
  ed25519/TOTP flow in main.rs.
- Also fixes a latent bug in an existing config.rs test: its fixture
  string was 23 chars (under the 32-char minimum), so it silently
  never exercised the check it claimed to test. Only surfaced once the
  module was actually compiled into `cargo test`.

## Test plan
- [x] `cargo test --workspace` green (58 auth + 8 discovery tests) run
      locally against a throwaway Postgres container
- [x] `cargo check --workspace --all-targets` clean, no new clippy
      warnings introduced (dead_code silenced via targeted
      `#[allow(dead_code)]` on the new `mod` declarations)
- [x] DB-gated tests skip gracefully (eprintln + return) when
      DATABASE_URL is absent, matching CI (no Postgres service there)