### PR TITLE
fix: harden auth panics, wire up notifications crate, add test coverage

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -423,6 +423,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1112,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
@@ -1149,11 +1161,30 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "email-encoding"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+dependencies = [
+ "base64",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 
 [[package]]
 name = "encoding_rs"
@@ -1620,6 +1651,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,11 +2072,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64",
+ "ed25519-dalek",
  "getrandom 0.2.17",
+ "hmac",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
+ "rand 0.8.6",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -2081,6 +2130,34 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lettre"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+dependencies = [
+ "async-trait",
+ "base64",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "hostname",
+ "httpdate",
+ "idna",
+ "mime",
+ "nom",
+ "percent-encoding",
+ "quoted_printable",
+ "rustls",
+ "socket2 0.6.3",
+ "tokio",
+ "tokio-rustls",
+ "url",
+ "webpki-roots",
+]
 
 [[package]]
 name = "libc"
@@ -2258,6 +2335,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +2487,18 @@ name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2640,6 +2738,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,6 +2932,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2919,7 +3024,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3067,6 +3174,7 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -3783,6 +3891,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "base32",
+ "chrono",
  "dotenvy",
  "ed25519-dalek",
  "hex",
@@ -3872,6 +3981,24 @@ version = "0.1.0"
 dependencies = [
  "soroban-sdk",
  "stellar-contract-test-utils",
+]
+
+[[package]]
+name = "stellar-notifications"
+version = "0.1.0"
+dependencies = [
+ "actix-web",
+ "anyhow",
+ "async-trait",
+ "dotenvy",
+ "lettre",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3968,6 +4095,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4678,6 +4816,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "contracts/test-utils",
     "services/api",
     "services/auth",
+    "services/notifications",
     "tests",
 ]
 resolver = "2"

--- a/backend/services/auth/Cargo.toml
+++ b/backend/services/auth/Cargo.toml
@@ -28,5 +28,11 @@ thiserror.workspace = true
 rand = { version = "0.8", features = ["getrandom"] }
 urlencoding = "2.1"
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }
-jsonwebtoken = { version = "10.4", features = ["use_pem"] }
+# rust_crypto: jsonwebtoken 10 requires an explicit crypto backend (rust_crypto
+# or aws_lc_rs) or every sign/verify call panics at runtime with "Could not
+# automatically determine the process-level CryptoProvider". Pure-Rust backend
+# chosen to match the crate's existing deps (ed25519-dalek, sha2, rand) and
+# avoid an aws-lc-rs C/cmake build dependency.
+jsonwebtoken = { version = "10.4", features = ["use_pem", "rust_crypto"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+chrono = "0.4"

--- a/backend/services/auth/src/main.rs
+++ b/backend/services/auth/src/main.rs
@@ -1,3 +1,5 @@
+mod tokens;
+
 use actix_web::{middleware, web, App, HttpResponse, HttpServer};
 use rand::RngCore;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
@@ -196,7 +198,7 @@ fn rand_string(len: usize) -> String {
     use std::time::SystemTime;
     let seed = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or_default()
         .as_nanos();
     
     (0..len)
@@ -361,7 +363,7 @@ async fn logout(
     }
 
     if let Some(token) = &body.refresh_token {
-        let mut map = store.lock().unwrap();
+        let mut map = store.lock().unwrap_or_else(|e| e.into_inner());
         if map.remove(token).is_some() {
             return HttpResponse::Ok().json(ApiResponse::ok(
                 serde_json::json!({ "revoked": 1 }),
@@ -380,7 +382,7 @@ async fn logout(
 pub fn create_jwt(public_key: &str) -> Result<String, jsonwebtoken::errors::Error> {
     let expiration = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
+        .unwrap_or_default()
         .as_secs() as usize
         + 24 * 3600;
 
@@ -405,10 +407,10 @@ pub fn issue_refresh_token(store: &RefreshStore, subject: &str) -> String {
     let family_id = generate_nonce();
     let expires_at = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or_default()
         .as_secs()
         + 30 * 24 * 3600; // 30 days
-    store.lock().unwrap().insert(
+    store.lock().unwrap_or_else(|e| e.into_inner()).insert(
         token.clone(),
         RefreshEntry {
             subject: subject.to_string(),
@@ -426,12 +428,12 @@ pub fn consume_refresh_token(
     used_store: &UsedTokenStore,
     token: &str,
 ) -> Result<String, &'static str> {
-    let mut map = store.lock().unwrap();
+    let mut map = store.lock().unwrap_or_else(|e| e.into_inner());
 
     if let Some(entry) = map.remove(token) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_secs();
         if entry.expires_at <= now {
             return Err("expired");
@@ -439,13 +441,13 @@ pub fn consume_refresh_token(
         // Record as used for reuse detection
         used_store
             .lock()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .insert(token.to_string(), entry.subject.clone());
         return Ok(entry.subject);
     }
 
     // Check if this token was already consumed (reuse = theft)
-    let used = used_store.lock().unwrap();
+    let used = used_store.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(subject) = used.get(token) {
         let subject = subject.clone();
         drop(used);
@@ -463,7 +465,7 @@ pub fn consume_refresh_token(
 
 /// Revoke all tokens for a given subject
 pub fn revoke_all_tokens_for_subject(store: &RefreshStore, subject: &str) -> usize {
-    let mut map = store.lock().unwrap();
+    let mut map = store.lock().unwrap_or_else(|e| e.into_inner());
     let before = map.len();
     map.retain(|_, entry| entry.subject != subject);
     before - map.len()

--- a/backend/services/auth/src/tokens.rs
+++ b/backend/services/auth/src/tokens.rs
@@ -1,3 +1,8 @@
+// This module is not yet wired into any live HTTP handler in `main.rs` — it's
+// compiled and unit tested here, but nothing in the running service calls it
+// today. Suppress dead_code accordingly rather than scattering allows.
+#![allow(dead_code)]
+
 use chrono::{Duration, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use rand::RngCore;
@@ -76,11 +81,17 @@ impl RevocationList {
     }
 
     pub fn revoke(&self, jti: Uuid) {
-        self.revoked_jtis.lock().unwrap().insert(jti);
+        self.revoked_jtis
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(jti);
     }
 
     pub fn is_revoked(&self, jti: &Uuid) -> bool {
-        self.revoked_jtis.lock().unwrap().contains(jti)
+        self.revoked_jtis
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains(jti)
     }
 }
 
@@ -171,6 +182,25 @@ mod tests {
 
         let result = verify_access_token_with_revocation(&token, secret, &rev_list);
         assert!(matches!(result, Err(TokenError::Revoked)));
+    }
+
+    #[test]
+    fn revocation_check_survives_poisoned_lock() {
+        let rev_list = RevocationList::new();
+        let jti = Uuid::new_v4();
+
+        // Poison the lock by panicking while holding it in another thread.
+        let list_clone = rev_list.clone();
+        let handle = std::thread::spawn(move || {
+            let _guard = list_clone.revoked_jtis.lock().unwrap();
+            panic!("simulated panic while holding lock");
+        });
+        assert!(handle.join().is_err());
+
+        // Revocation checks must still work (not panic) after the lock is poisoned.
+        assert!(!rev_list.is_revoked(&jti));
+        rev_list.revoke(jti);
+        assert!(rev_list.is_revoked(&jti));
     }
 
     #[test]

--- a/backend/services/notifications/Cargo.toml
+++ b/backend/services/notifications/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 tokio.workspace = true
+actix-web.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
@@ -19,7 +20,14 @@ tracing-subscriber.workspace = true
 anyhow.workspace = true
 dotenvy.workspace = true
 thiserror.workspace = true
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["form"] }
+async-trait = "0.1"
 
 # Email delivery
-lettre = { version = "0.11", features = ["tokio1-rustls-tls", "smtp-transport", "hostname"] }
+# default-features disabled: lettre's default `native-tls` feature conflicts
+# with `tokio1-rustls-tls` (both can't be on without `tokio1-native-tls`), so
+# we opt into the rustls path explicitly and re-add the other defaults we need.
+lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "hostname", "builder", "pool"] }
+
+[dev-dependencies]
+tokio = { version = "1.52", features = ["test-util"] }

--- a/backend/services/notifications/src/dispatcher.rs
+++ b/backend/services/notifications/src/dispatcher.rs
@@ -1,15 +1,46 @@
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
-use crate::models::{Notification, NotificationChannel, NotificationError, Result};
+use crate::models::{Notification, NotificationChannel, Result};
 use crate::email::EmailProvider;
 use crate::sms::SmsProvider;
 use crate::push::PushProvider;
 use crate::config::Settings;
 
+/// A channel-specific transport capable of delivering a notification.
+///
+/// Abstracting the concrete providers behind this trait lets `dispatch`'s
+/// routing and retry logic be unit tested without making real network calls.
+#[async_trait::async_trait]
+pub trait NotificationSender: Send + Sync {
+    async fn send_notification(&self, notification: &Notification) -> Result<()>;
+}
+
+#[async_trait::async_trait]
+impl NotificationSender for EmailProvider {
+    async fn send_notification(&self, notification: &Notification) -> Result<()> {
+        let subject = notification.subject.as_deref().unwrap_or("No Subject");
+        self.send(&notification.recipient, subject, &notification.message).await
+    }
+}
+
+#[async_trait::async_trait]
+impl NotificationSender for SmsProvider {
+    async fn send_notification(&self, notification: &Notification) -> Result<()> {
+        self.send(&notification.recipient, &notification.message).await
+    }
+}
+
+#[async_trait::async_trait]
+impl NotificationSender for PushProvider {
+    async fn send_notification(&self, notification: &Notification) -> Result<()> {
+        self.send(&notification.recipient, &notification.message).await
+    }
+}
+
 pub struct NotificationDispatcher {
-    email: Arc<EmailProvider>,
-    sms: Arc<SmsProvider>,
-    push: Arc<PushProvider>,
+    email: Arc<dyn NotificationSender>,
+    sms: Arc<dyn NotificationSender>,
+    push: Arc<dyn NotificationSender>,
 }
 
 impl NotificationDispatcher {
@@ -21,9 +52,27 @@ impl NotificationDispatcher {
         }
     }
 
+    #[cfg(test)]
+    fn from_senders(
+        email: Arc<dyn NotificationSender>,
+        sms: Arc<dyn NotificationSender>,
+        push: Arc<dyn NotificationSender>,
+    ) -> Self {
+        Self { email, sms, push }
+    }
+
+    fn sender_for(&self, channel: &NotificationChannel) -> &Arc<dyn NotificationSender> {
+        match channel {
+            NotificationChannel::Email => &self.email,
+            NotificationChannel::SMS => &self.sms,
+            NotificationChannel::Push => &self.push,
+        }
+    }
+
     pub async fn dispatch(&self, notification: Notification) -> Result<()> {
         let max_retries = 3;
         let mut attempts = 0;
+        let sender = self.sender_for(&notification.channel);
 
         loop {
             attempts += 1;
@@ -34,20 +83,7 @@ impl NotificationDispatcher {
                 notification.recipient
             );
 
-            let result = match notification.channel {
-                NotificationChannel::Email => {
-                    let subject = notification.subject.as_deref().unwrap_or("No Subject");
-                    self.email.send(&notification.recipient, subject, &notification.message).await
-                }
-                NotificationChannel::SMS => {
-                    self.sms.send(&notification.recipient, &notification.message).await
-                }
-                NotificationChannel::Push => {
-                    self.push.send(&notification.recipient, &notification.message).await
-                }
-            };
-
-            match result {
+            match sender.send_notification(&notification).await {
                 Ok(_) => {
                     tracing::info!(
                         "Successfully sent {:?} notification to {}",
@@ -77,5 +113,154 @@ impl NotificationDispatcher {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::NotificationError;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A sender that fails its first `fail_first_n` calls, then succeeds.
+    struct FakeSender {
+        calls: AtomicUsize,
+        fail_first_n: usize,
+    }
+
+    impl FakeSender {
+        fn always_ok() -> Self {
+            Self { calls: AtomicUsize::new(0), fail_first_n: 0 }
+        }
+        fn always_err() -> Self {
+            Self { calls: AtomicUsize::new(0), fail_first_n: usize::MAX }
+        }
+        fn fail_first(n: usize) -> Self {
+            Self { calls: AtomicUsize::new(0), fail_first_n: n }
+        }
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl NotificationSender for FakeSender {
+        async fn send_notification(&self, _notification: &Notification) -> Result<()> {
+            let attempt = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if attempt <= self.fail_first_n {
+                return Err(NotificationError::Delivery {
+                    channel: NotificationChannel::Email,
+                    reason: "simulated failure".to_string(),
+                });
+            }
+            Ok(())
+        }
+    }
+
+    /// A sender that panics if invoked — used to assert a channel's
+    /// notification never reaches the wrong provider.
+    struct PanicSender;
+
+    #[async_trait::async_trait]
+    impl NotificationSender for PanicSender {
+        async fn send_notification(&self, _notification: &Notification) -> Result<()> {
+            panic!("this sender should never be invoked for this channel");
+        }
+    }
+
+    fn test_notification(channel: NotificationChannel) -> Notification {
+        Notification {
+            user_id: "user-1".to_string(),
+            channel,
+            recipient: "test@example.com".to_string(),
+            subject: Some("Subject".to_string()),
+            message: "Body".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn email_notification_routes_to_email_sender_only() {
+        let email = Arc::new(FakeSender::always_ok());
+        let dispatcher = NotificationDispatcher::from_senders(
+            email.clone(),
+            Arc::new(PanicSender),
+            Arc::new(PanicSender),
+        );
+
+        let result = dispatcher.dispatch(test_notification(NotificationChannel::Email)).await;
+        assert!(result.is_ok());
+        assert_eq!(email.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn sms_notification_routes_to_sms_sender_only() {
+        let sms = Arc::new(FakeSender::always_ok());
+        let dispatcher = NotificationDispatcher::from_senders(
+            Arc::new(PanicSender),
+            sms.clone(),
+            Arc::new(PanicSender),
+        );
+
+        let result = dispatcher.dispatch(test_notification(NotificationChannel::SMS)).await;
+        assert!(result.is_ok());
+        assert_eq!(sms.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn push_notification_routes_to_push_sender_only() {
+        let push = Arc::new(FakeSender::always_ok());
+        let dispatcher = NotificationDispatcher::from_senders(
+            Arc::new(PanicSender),
+            Arc::new(PanicSender),
+            push.clone(),
+        );
+
+        let result = dispatcher.dispatch(test_notification(NotificationChannel::Push)).await;
+        assert!(result.is_ok());
+        assert_eq!(push.call_count(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dispatch_retries_and_eventually_succeeds() {
+        let email = Arc::new(FakeSender::fail_first(2));
+        let dispatcher = NotificationDispatcher::from_senders(
+            email.clone(),
+            Arc::new(PanicSender),
+            Arc::new(PanicSender),
+        );
+
+        let result = dispatcher.dispatch(test_notification(NotificationChannel::Email)).await;
+        assert!(result.is_ok());
+        assert_eq!(email.call_count(), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dispatch_returns_err_after_exhausting_retries() {
+        let email = Arc::new(FakeSender::always_err());
+        let dispatcher = NotificationDispatcher::from_senders(
+            email.clone(),
+            Arc::new(PanicSender),
+            Arc::new(PanicSender),
+        );
+
+        let result = dispatcher.dispatch(test_notification(NotificationChannel::Email)).await;
+        assert!(result.is_err());
+        assert_eq!(email.call_count(), 3);
+    }
+
+    /// `NotificationChannel` is a closed enum, so `dispatch` can never see an
+    /// "unknown" channel at runtime — an unrecognized value is rejected here,
+    /// at deserialization, before a `Notification` can even be constructed.
+    #[test]
+    fn unknown_channel_value_fails_deserialization_before_dispatch() {
+        let raw = serde_json::json!({
+            "user_id": "user-1",
+            "channel": "Carrier-Pigeon",
+            "recipient": "test@example.com",
+            "subject": null,
+            "message": "Body"
+        });
+        let result: std::result::Result<Notification, _> = serde_json::from_value(raw);
+        assert!(result.is_err());
     }
 }

--- a/backend/services/notifications/src/main.rs
+++ b/backend/services/notifications/src/main.rs
@@ -34,6 +34,19 @@ async fn ready() -> HttpResponse {
     }))
 }
 
+/// Resolve the host/port the health-check server should bind to from raw
+/// env var values. Pulled out as a pure function so bootstrap parsing can be
+/// unit tested without touching real process environment state.
+fn resolve_server_config(port_var: Option<&str>, host_var: Option<&str>) -> (String, u16) {
+    let port = port_var
+        .and_then(|v| v.parse::<u16>().ok())
+        .unwrap_or(3003);
+    let host = host_var
+        .map(str::to_string)
+        .unwrap_or_else(|| "0.0.0.0".to_string());
+    (host, port)
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Initialize structured logging
@@ -72,12 +85,10 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Start the HTTP server for health/readiness probes in the background
-    let port: u16 = std::env::var("NOTIFICATIONS_PORT")
-        .unwrap_or_else(|_| "3003".to_string())
-        .parse()
-        .unwrap_or(3003);
-    let host = std::env::var("NOTIFICATIONS_HOST")
-        .unwrap_or_else(|_| "0.0.0.0".to_string());
+    let (host, port) = resolve_server_config(
+        std::env::var("NOTIFICATIONS_PORT").ok().as_deref(),
+        std::env::var("NOTIFICATIONS_HOST").ok().as_deref(),
+    );
 
     tracing::info!("Health endpoints available on {}:{}", host, port);
 
@@ -95,3 +106,43 @@ async fn main() -> anyhow::Result<()> {
 
     server.await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_server_config_uses_provided_values() {
+        let (host, port) = resolve_server_config(Some("8080"), Some("127.0.0.1"));
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(port, 8080);
+    }
+
+    #[test]
+    fn resolve_server_config_defaults_when_missing() {
+        let (host, port) = resolve_server_config(None, None);
+        assert_eq!(host, "0.0.0.0");
+        assert_eq!(port, 3003);
+    }
+
+    #[test]
+    fn resolve_server_config_falls_back_on_malformed_port() {
+        let (host, port) = resolve_server_config(Some("not-a-port"), None);
+        assert_eq!(host, "0.0.0.0");
+        assert_eq!(port, 3003);
+    }
+
+    #[test]
+    fn resolve_server_config_falls_back_on_out_of_range_port() {
+        let (_, port) = resolve_server_config(Some("999999"), None);
+        assert_eq!(port, 3003);
+    }
+
+    #[test]
+    fn resolve_server_config_uses_custom_host_with_default_port() {
+        let (host, port) = resolve_server_config(None, Some("192.168.1.1"));
+        assert_eq!(host, "192.168.1.1");
+        assert_eq!(port, 3003);
+    }
+}

--- a/backend/services/notifications/src/models.rs
+++ b/backend/services/notifications/src/models.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[allow(clippy::upper_case_acronyms)] // `SMS` is part of the serde wire format; renaming would be a breaking change
 pub enum NotificationChannel {
     Email,
     SMS,
@@ -26,6 +27,7 @@ pub enum NotificationError {
         reason: String,
     },
     #[error("Rate limited")]
+    #[allow(dead_code)] // reserved for future rate-limiting support
     RateLimited,
     #[error("Invalid recipient: {0}")]
     InvalidRecipient(String),

--- a/backend/services/notifications/src/push.rs
+++ b/backend/services/notifications/src/push.rs
@@ -1,4 +1,4 @@
-use crate::models::{NotificationChannel, NotificationError, Result};
+use crate::models::Result;
 use crate::config::Settings;
 
 pub struct PushProvider {

--- a/backend/services/notifications/src/sms.rs
+++ b/backend/services/notifications/src/sms.rs
@@ -1,5 +1,4 @@
 use reqwest::Client;
-use serde_json::json;
 use crate::models::{NotificationChannel, NotificationError, Result};
 use crate::config::Settings;
 


### PR DESCRIPTION
- auth: poison-recovery on mutex locks, SystemTime fallbacks, wire tokens.rs into the build (was dead code) and fix a runtime-panicking jsonwebtoken crypto-backend gap
- notifications: add to Cargo workspace (wasn't a member), fix lettre/reqwest feature gaps that blocked it from ever compiling, add dispatcher routing tests and bootstrap config-parsing tests

Closes #903, closes #904, closes #905, closes #906