### PR TITLE
Fix/auth and hooks issues

### DIFF
--- a/backend/src/graphql/context.ts
+++ b/backend/src/graphql/context.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import jwt from 'jsonwebtoken';
-import crypto from 'crypto';
+import { hashApiKey } from '@/lib/api-keys';
 
 export interface GraphQLContext {
   req: NextRequest;
@@ -20,7 +20,10 @@ export async function createGraphQLContext(req: NextRequest): Promise<GraphQLCon
   if (authorization?.startsWith('Bearer ')) {
     const token = authorization.slice(7);
     try {
-      const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-key';
+      const JWT_SECRET = process.env.JWT_SECRET;
+      if (!JWT_SECRET) {
+        throw new Error('JWT_SECRET environment variable is not set');
+      }
       const decoded = jwt.verify(token, JWT_SECRET) as any;
 
       const dbUser = await prisma.user.findUnique({
@@ -40,30 +43,26 @@ export async function createGraphQLContext(req: NextRequest): Promise<GraphQLCon
   const apiKeyHeader = headers.get('x-api-key');
   if (!userId && apiKeyHeader) {
     try {
-      const [keyId, secret] = apiKeyHeader.split(':');
-      if (!keyId || !secret) {
-        throw new Error('Invalid API key format');
-      }
+      // Hash the incoming key for comparison against stored keyHash
+      const keyHash = hashApiKey(apiKeyHeader);
 
-      // Find the API key
+      // Find the API key by its hash
       const apiKey = await prisma.apiKey.findUnique({
-        where: { key: keyId },
-        select: { id: true, secretHash: true, userId: true, active: true, expiresAt: true },
+        where: { keyHash },
+        select: { id: true, userId: true, revokedAt: true, expiresAt: true },
       });
 
-      if (!apiKey || !apiKey.active) {
-        throw new Error('API key not found or inactive');
+      if (!apiKey) {
+        throw new Error('API key not found');
+      }
+
+      if (apiKey.revokedAt) {
+        throw new Error('API key has been revoked');
       }
 
       // Check expiration
       if (apiKey.expiresAt && new Date(apiKey.expiresAt) < new Date()) {
         throw new Error('API key expired');
-      }
-
-      // Verify secret hash
-      const secretHash = crypto.createHash('sha256').update(secret).digest('hex');
-      if (secretHash !== apiKey.secretHash) {
-        throw new Error('Invalid API key secret');
       }
 
       userId = apiKey.userId;

--- a/contexts/WalletContext.tsx
+++ b/contexts/WalletContext.tsx
@@ -101,23 +101,58 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   });
 
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (!raw) return;
-      const saved: PersistedWallet = JSON.parse(raw);
-      if (saved.address && saved.publicKey && saved.walletType) {
-        setState((s) => ({
-          ...s,
-          address: saved.address,
-          publicKey: saved.publicKey,
-          network: saved.network,
-          walletType: saved.walletType,
-          isConnected: true,
-        }));
+    let cancelled = false;
+
+    async function restoreAndVerify() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return;
+        const saved: PersistedWallet = JSON.parse(raw);
+        if (!saved.address || !saved.publicKey || !saved.walletType) return;
+
+        // Verify the wallet is actually still connected
+        try {
+          const adapter = await getWalletAdapter(saved.walletType);
+          const [publicKey, network] = await Promise.all([
+            adapter.getPublicKey(),
+            adapter.getNetwork(),
+          ]);
+
+          if (!cancelled) {
+            setState((s) => ({
+              ...s,
+              address: publicKey,
+              publicKey,
+              network,
+              walletType: saved.walletType,
+              isConnected: true,
+            }));
+          }
+        } catch {
+          // Wallet not actually connected; clear saved state
+          if (!cancelled) {
+            localStorage.removeItem(STORAGE_KEY);
+            setState((s) => ({
+              ...s,
+              isConnected: false,
+              address: null,
+              publicKey: null,
+              walletType: null,
+            }));
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          localStorage.removeItem(STORAGE_KEY);
+        }
       }
-    } catch {
-      localStorage.removeItem(STORAGE_KEY);
     }
+
+    restoreAndVerify();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const connect = useCallback(async (walletType: WalletType) => {

--- a/hooks/use-feature-flag.ts
+++ b/hooks/use-feature-flag.ts
@@ -95,11 +95,73 @@ export function useFeatureFlag(flagName: string): UseFlagResult {
 export function useFeatureFlags(
   flagNames: string[],
 ): Record<string, boolean> & { loading: boolean } {
-  const results = flagNames.map(useFeatureFlag);
-  const loading = results.some((r) => r.loading);
-  const map = Object.fromEntries(
-    flagNames.map((name, i) => [name, results[i].enabled]),
-  ) as Record<string, boolean>;
+  const { data: session } = useSession();
+  const [results, setResults] = useState<Record<string, boolean>>({});
+  const [loading, setLoading] = useState(true);
 
-  return { ...map, loading };
+  useEffect(() => {
+    let cancelled = false;
+
+    async function evaluateAll() {
+      try {
+        const flagResults: Record<string, boolean> = {};
+
+        // Evaluate each flag in parallel
+        const promises = flagNames.map(async (flagName) => {
+          const cacheKey = `${flagName}:${session?.user?.email ?? 'anon'}`;
+          const cached = memCache.get(cacheKey);
+
+          if (cached && cached.expiresAt > Date.now()) {
+            return [flagName, cached.result];
+          }
+
+          try {
+            const params = new URLSearchParams({ flag: flagName });
+            if (session?.user) {
+              params.set('userId', (session.user as { id?: string }).id ?? '');
+            }
+
+            const res = await fetch(`/api/feature-flags/evaluate?${params}`, {
+              cache: 'no-store',
+            });
+
+            if (!res.ok) throw new Error('Flag evaluation failed');
+
+            const data: { enabled: boolean } = await res.json();
+
+            memCache.set(cacheKey, {
+              result: data.enabled,
+              expiresAt: Date.now() + CACHE_TTL_MS,
+            });
+
+            return [flagName, data.enabled];
+          } catch {
+            // On error, default to disabled (safe)
+            return [flagName, false];
+          }
+        });
+
+        const results = await Promise.all(promises);
+
+        Object.assign(flagResults, Object.fromEntries(results));
+
+        if (!cancelled) {
+          setResults(flagResults);
+          setLoading(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    evaluateAll();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [flagNames, session]);
+
+  return { ...results, loading };
 }


### PR DESCRIPTION
## Summary                                                                                                                                      
                                                                                                                                                  
  This PR addresses four critical security and functionality bugs in auth and React hooks.                                                        
                                                                                                                                                  
  ## Changes

  ### #1138 — GraphQL context API-key auth queries non-existent schema fields
  - Query by keyHash instead of non-existent 'key' field
  - Hash incoming API key using hashApiKey() for safe comparison
  - Remove query for non-existent secretHash and active fields

  ### #1139 — GraphQL context hardcoded JWT secret fallback
  - Remove fallback to literal 'dev-secret-key'
  - Throw immediately if JWT_SECRET env var is unset
  - Prevents auth bypass in misconfigured deployments

  ### #1136 — WalletContext restores isConnected without re-verification
  - Verify wallet is actually still connected before setting isConnected: true
  - Call wallet adapter's actual connectivity check on mount
  - Clear stale localStorage state if verification fails
  - Prevents false connected state after wallet lock/switch/uninstall

  ### #1134 — useFeatureFlags violates Rules of Hooks
  - Remove nested hook calls in Array.map()
  - Rewrite to single useEffect/useState pair evaluating all flags in parallel
  - Support dynamic flagNames array without triggering hook violations
  - Maintain per-flag caching with 60-second TTL

  Closes #1138, Closes #1139, Closes #1136, Closes #1134
