### PR TITLE
fix: webhook security hardening — authentication, signing, idempotency, and constant-time comparison

### DIFF
--- a/backend/services/api/src/webhooks/soroban.rs
+++ b/backend/services/api/src/webhooks/soroban.rs
@@ -3,13 +3,13 @@
 /// Allows external consumers to register HTTPS endpoints that receive
 /// platform events (bounty, escrow, governance) as they are emitted by
 /// the Soroban contracts indexed by the event indexer.
-use actix_web::{web, HttpResponse};
+use actix_web::{web, HttpRequest, HttpResponse};
 use deadpool_redis::{redis::AsyncCommands, Pool};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use crate::ApiResponse;
+use crate::{ApiResponse, auth::Claims};
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -26,6 +26,7 @@ pub struct WebhookRegistration {
 #[derive(Clone, Serialize, Deserialize, Debug, ToSchema)]
 pub struct Webhook {
     pub id: String,
+    pub owner: String,
     pub url: String,
     pub events: Vec<String>,
 }
@@ -47,13 +48,23 @@ const REDIS_KEY: &str = "webhooks:registry";
     responses(
         (status = 201, description = "Webhook registered"),
         (status = 400, description = "Invalid request"),
+        (status = 401, description = "Unauthorized"),
     ),
     tag = "webhooks"
 )]
 pub async fn register_webhook(
     redis: web::Data<Pool>,
+    req: HttpRequest,
     body: web::Json<WebhookRegistration>,
 ) -> HttpResponse {
+    let claims = match req.extensions().get::<Claims>() {
+        Some(c) => c.clone(),
+        None => return HttpResponse::Unauthorized().json(serde_json::json!({
+            "success": false,
+            "error": "Unauthorized"
+        })),
+    };
+
     if body.url.is_empty() || body.events.is_empty() {
         return HttpResponse::BadRequest().json(serde_json::json!({
             "success": false,
@@ -63,6 +74,7 @@ pub async fn register_webhook(
 
     let webhook = Webhook {
         id: Uuid::new_v4().to_string(),
+        owner: claims.sub.clone(),
         url: body.url.clone(),
         events: body.events.clone(),
     };
@@ -91,13 +103,32 @@ pub async fn register_webhook(
 /// List all registered webhooks
 #[utoipa::path(
     get, path = "/api/webhooks",
-    responses((status = 200, description = "List of webhooks")),
+    responses(
+        (status = 200, description = "List of webhooks"),
+        (status = 401, description = "Unauthorized"),
+    ),
     tag = "webhooks"
 )]
-pub async fn list_webhooks(redis: web::Data<Pool>) -> HttpResponse {
-    let webhooks = load_all(&redis).await;
+pub async fn list_webhooks(
+    redis: web::Data<Pool>,
+    req: HttpRequest,
+) -> HttpResponse {
+    let claims = match req.extensions().get::<Claims>() {
+        Some(c) => c.clone(),
+        None => return HttpResponse::Unauthorized().json(serde_json::json!({
+            "success": false,
+            "error": "Unauthorized"
+        })),
+    };
+
+    let all_webhooks = load_all(&redis).await;
+    let user_webhooks: Vec<_> = all_webhooks
+        .into_iter()
+        .filter(|w| w.owner == claims.sub)
+        .collect();
+
     HttpResponse::Ok().json(ApiResponse::ok(
-        serde_json::json!({ "webhooks": webhooks }),
+        serde_json::json!({ "webhooks": user_webhooks }),
         None::<String>,
     ))
 }
@@ -108,21 +139,58 @@ pub async fn list_webhooks(redis: web::Data<Pool>) -> HttpResponse {
     params(("id" = String, Path, description = "Webhook ID")),
     responses(
         (status = 200, description = "Webhook deleted"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden — not webhook owner"),
         (status = 404, description = "Not found"),
     ),
     tag = "webhooks"
 )]
-pub async fn delete_webhook(redis: web::Data<Pool>, path: web::Path<String>) -> HttpResponse {
+pub async fn delete_webhook(
+    redis: web::Data<Pool>,
+    req: HttpRequest,
+    path: web::Path<String>,
+) -> HttpResponse {
+    let claims = match req.extensions().get::<Claims>() {
+        Some(c) => c.clone(),
+        None => return HttpResponse::Unauthorized().json(serde_json::json!({
+            "success": false,
+            "error": "Unauthorized"
+        })),
+    };
+
     let id = path.into_inner();
-    if let Ok(mut conn) = redis.get().await {
-        let deleted: i64 = conn.hdel(REDIS_KEY, &id).await.unwrap_or(0);
-        if deleted == 0 {
-            return HttpResponse::NotFound().json(serde_json::json!({
-                "success": false,
-                "error": "Webhook not found"
-            }));
-        }
+    let Ok(mut conn) = redis.get().await else {
+        return HttpResponse::InternalServerError().json(serde_json::json!({
+            "success": false,
+            "error": "Database error"
+        }));
+    };
+
+    let webhook_json: Option<String> = conn.hget(REDIS_KEY, &id).await.unwrap_or(None);
+    let webhook = match webhook_json.and_then(|j| serde_json::from_str(&j).ok()) {
+        Some(w) => w,
+        None => return HttpResponse::NotFound().json(serde_json::json!({
+            "success": false,
+            "error": "Webhook not found"
+        })),
+    };
+
+    let webhook: Webhook = webhook;
+    if webhook.owner != claims.sub {
+        return HttpResponse::Forbidden().json(serde_json::json!({
+            "success": false,
+            "error": "Not webhook owner"
+        }));
     }
+
+    let deleted: i64 = conn.hdel(REDIS_KEY, &id).await.unwrap_or(0);
+    if deleted == 0 {
+        return HttpResponse::NotFound().json(serde_json::json!({
+            "success": false,
+            "error": "Webhook not found"
+        }));
+    }
+
     HttpResponse::Ok().json(ApiResponse::ok(
         serde_json::json!({ "id": id }),
         Some("Webhook deleted".to_string()),

--- a/backend/services/api/src/webhooks/soroban.rs
+++ b/backend/services/api/src/webhooks/soroban.rs
@@ -5,6 +5,8 @@
 /// the Soroban contracts indexed by the event indexer.
 use actix_web::{web, HttpRequest, HttpResponse};
 use deadpool_redis::{redis::AsyncCommands, Pool};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -29,6 +31,8 @@ pub struct Webhook {
     pub owner: String,
     pub url: String,
     pub events: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret: Option<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -77,6 +81,7 @@ pub async fn register_webhook(
         owner: claims.sub.clone(),
         url: body.url.clone(),
         events: body.events.clone(),
+        secret: body.secret.clone(),
     };
 
     let serialized = match serde_json::to_string(&webhook) {
@@ -209,8 +214,31 @@ pub async fn trigger_webhooks(redis: &Pool, event: &str, data: serde_json::Value
         let client = client.clone();
         let payload = payload.clone();
         let url = wh.url.clone();
+        let secret = wh.secret.clone();
+
         tokio::spawn(async move {
-            if let Err(e) = client.post(&url).json(&payload).send().await {
+            let payload_bytes = match serde_json::to_vec(&payload) {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::error!("Failed to serialize webhook payload: {}", e);
+                    return;
+                }
+            };
+
+            let mut request = client.post(&url).json(&payload);
+
+            if let Some(sec) = secret {
+                type HmacSha256 = Hmac<Sha256>;
+                let mut mac = HmacSha256::new_from_slice(sec.as_bytes()).unwrap_or_else(|_| {
+                    tracing::warn!("Invalid HMAC secret for webhook");
+                    return;
+                });
+                mac.update(&payload_bytes);
+                let signature = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+                request = request.header("X-Webhook-Signature", signature);
+            }
+
+            if let Err(e) = request.send().await {
                 tracing::warn!("Webhook delivery failed to {}: {}", url, e);
             }
         });

--- a/backend/services/api/src/webhooks/stripe.rs
+++ b/backend/services/api/src/webhooks/stripe.rs
@@ -7,6 +7,7 @@
 /// in the `X-Webhook-Signature` header.  The secret is read from the
 /// `WEBHOOK_SECRET` environment variable.
 use actix_web::{web, HttpRequest, HttpResponse};
+use deadpool_redis::{redis::AsyncCommands, Pool};
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use serde::{Deserialize, Serialize};
@@ -69,6 +70,33 @@ pub fn verify_signature(secret: &str, body: &[u8], signature_header: &str) -> Re
     Ok(())
 }
 
+// ── Idempotency ───────────────────────────────────────────────────────────────
+
+const PROCESSED_EVENTS_PREFIX: &str = "webhook:processed:";
+const PROCESSED_EVENTS_TTL: usize = 86400; // 24 hours
+
+/// Check if an event has already been processed (idempotency check).
+/// Returns `Ok(false)` if new, `Ok(true)` if duplicate, `Err` on Redis error.
+async fn is_event_duplicate(redis: &Pool, event_id: &str) -> Result<bool, String> {
+    let Ok(mut conn) = redis.get().await else {
+        return Err("Redis connection failed".to_string());
+    };
+    let key = format!("{}{}", PROCESSED_EVENTS_PREFIX, event_id);
+    let exists: bool = conn.exists(&key).await.unwrap_or(false);
+    Ok(exists)
+}
+
+/// Mark an event as processed with a TTL.
+async fn mark_event_processed(redis: &Pool, event_id: &str) -> Result<(), String> {
+    let Ok(mut conn) = redis.get().await else {
+        return Err("Redis connection failed".to_string());
+    };
+    let key = format!("{}{}", PROCESSED_EVENTS_PREFIX, event_id);
+    let _: () = conn.set_ex(&key, "1", PROCESSED_EVENTS_TTL).await
+        .map_err(|e| format!("Failed to mark event processed: {}", e))?;
+    Ok(())
+}
+
 // ── Action mapping ────────────────────────────────────────────────────────────
 
 /// Map an incoming webhook event to a human-readable escrow action label.
@@ -87,11 +115,12 @@ pub fn map_event_to_action(event_type: &WebhookEventType) -> &'static str {
 
 /// POST /api/v1/webhooks/payment
 ///
-/// Accepts an external payment event, verifies its signature, and
-/// dispatches the corresponding escrow operation.
+/// Accepts an external payment event, verifies its signature, checks for duplicates,
+/// and dispatches the corresponding escrow operation.
 pub async fn payment_webhook(
     req: HttpRequest,
     body: web::Bytes,
+    redis: web::Data<Pool>,
 ) -> HttpResponse {
     let secret = std::env::var("WEBHOOK_SECRET").unwrap_or_default();
 
@@ -133,15 +162,40 @@ pub async fn payment_webhook(
         }
     };
 
+    // 3. Check idempotency (avoid reprocessing)
+    match is_event_duplicate(&redis, &payload.provider_event_id).await {
+        Ok(true) => {
+            info!(
+                "Duplicate webhook received: {:?} for escrow {} (provider_event_id={})",
+                payload.event_type, payload.escrow_id, payload.provider_event_id
+            );
+            let ack = WebhookAck {
+                received: true,
+                escrow_id: payload.escrow_id.clone(),
+                action_taken: "duplicate".to_string(),
+            };
+            return HttpResponse::Ok().json(ApiResponse::ok(ack, None));
+        }
+        Ok(false) => {
+            if let Err(e) = mark_event_processed(&redis, &payload.provider_event_id).await {
+                warn!("Failed to mark event as processed: {}", e);
+            }
+        }
+        Err(e) => {
+            warn!("Idempotency check failed: {}", e);
+            // Continue processing — don't fail on Redis errors
+        }
+    }
+
     info!(
         "Webhook received: {:?} for escrow {} (provider_event_id={})",
         payload.event_type, payload.escrow_id, payload.provider_event_id
     );
 
-    // 3. Map event → escrow action
+    // 4. Map event → escrow action
     let action = map_event_to_action(&payload.event_type);
 
-    // 4. Dispatch (placeholder — wire to Stellar SDK in production)
+    // 5. Dispatch (placeholder — wire to Stellar SDK in production)
     info!("Dispatching action '{}' for escrow {}", action, payload.escrow_id);
 
     let ack = WebhookAck {

--- a/backend/services/api/src/webhooks/stripe.rs
+++ b/backend/services/api/src/webhooks/stripe.rs
@@ -51,18 +51,19 @@ pub struct WebhookAck {
 /// Verify the HMAC-SHA256 signature supplied in `X-Webhook-Signature`.
 /// Returns `Ok(())` when valid, `Err(reason)` otherwise.
 pub fn verify_signature(secret: &str, body: &[u8], signature_header: &str) -> Result<(), &'static str> {
+    use subtle::ConstantTimeEq;
     type HmacSha256 = Hmac<Sha256>;
 
     let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
         .map_err(|_| "invalid secret")?;
     mac.update(body);
 
-    let expected = mac.finalize().into_bytes();
-    let expected_hex = hex::encode(expected);
-
-    // Constant-time comparison via hex strings
+    let expected_mac = mac.finalize().into_bytes();
     let sig = signature_header.trim_start_matches("sha256=");
-    if sig != expected_hex {
+
+    let provided_bytes = hex::decode(sig).map_err(|_| "invalid hex in signature")?;
+
+    if expected_mac.ct_eq(&provided_bytes[..]).unwrap_u8() == 0 {
         return Err("signature mismatch");
     }
     Ok(())


### PR DESCRIPTION
## Summary

This PR addresses four critical webhook security vulnerabilities:
- **#1065**: Non-constant-time signature comparison → constant-time HMAC verification
- **#1068**: Missing authentication and per-user scoping on Soroban webhooks
- **#1067**: Unsigned outbound deliveries → HMAC-SHA256 signatures with stored secrets
- **#1066**: No idempotency → deduplication with 24-hour TTL using provider_event_id

## Changes

### #1065 — Constant-time signature verification
- Replaced `String::!=` comparison with `subtle::ConstantTimeEq` on raw MAC bytes
- Prevents timing side-channel attacks on webhook signature validation

### #1068 — Per-user webhook scoping & authentication
- Added `owner` field to `Webhook` struct
- Required JWT authentication on all three handlers: `register_webhook`, `list_webhooks`, `delete_webhook`
- Scoped `list_webhooks` to return only caller's webhooks
- Added ownership check to `delete_webhook` (403 if not owner)

### #1067 — Outbound webhook signing
- Added `secret` field to `Webhook` struct (stored, optional)
- `trigger_webhooks` now signs all deliveries with HMAC-SHA256 if secret present
- Adds `X-Webhook-Signature: sha256=<hex>` header to each delivery

### #1066 — Idempotency via provider_event_id
- Track processed event IDs in Redis with 24-hour TTL
- Duplicate detection before processing (returns 200 with `action_taken: "duplicate"`)
- Graceful degradation on Redis errors (continues processing with warning)

## Testing

Code-only delivery. Handler signatures updated but tests require:
- Redis pool mock/fixture for `payment_webhook` tests
- Claims extraction in test setup for Soroban handler tests

Closes #1065, Closes #1066, Closes #1067, Closes #1068