### PR TITLE
fix: address security vulnerabilities in API key and JWT authentication

### DIFF
--- a/backend/limit/lib/security.ts
+++ b/backend/limit/lib/security.ts
@@ -340,6 +340,7 @@ export function validateInput(schema: ValidationSchema) {
         req.query[key] = InputValidator.sanitizeString(
           req.query[key] as string,
         );
+        req.query[key] = InputValidator.sanitizeHtml(req.query[key] as string);
       }
     }
 
@@ -348,6 +349,7 @@ export function validateInput(schema: ValidationSchema) {
       for (const key in req.body) {
         if (typeof req.body[key] === "string") {
           req.body[key] = InputValidator.sanitizeString(req.body[key]);
+          req.body[key] = InputValidator.sanitizeHtml(req.body[key]);
         }
       }
     }

--- a/backend/limit/lib/security.ts
+++ b/backend/limit/lib/security.ts
@@ -5,6 +5,7 @@
 
 import { Request, Response, NextFunction } from "express";
 import crypto from "crypto";
+import jwt from "jsonwebtoken";
 
 /**
  * API Key Authentication
@@ -155,10 +156,16 @@ export function apiKeyAuthentication(
   }
 
   if (authHeader.startsWith("Bearer ")) {
-    // JWT token handling can be added here
     const token = authHeader.substring(7);
     try {
-      // Validate JWT token
+      const jwtSecret = process.env.JWT_SECRET || "your-secret-key";
+      const decoded = jwt.verify(token, jwtSecret) as any;
+
+      if (!decoded || !decoded.id || !decoded.email) {
+        return res.status(401).json({ error: "Invalid token claims" });
+      }
+
+      req.user = { id: decoded.id, email: decoded.email };
       req.requestId = crypto.randomUUID();
       return next();
     } catch (error) {

--- a/backend/limit/lib/security.ts
+++ b/backend/limit/lib/security.ts
@@ -61,14 +61,16 @@ export class ApiKeyManager {
   }
 
   /**
-   * Hash secret for storage
+   * Hash secret for storage using scrypt KDF
    */
-  private hashSecret(secret: string): string {
-    return crypto.createHash("sha256").update(secret).digest("hex");
+  private hashSecret(secret: string, salt?: Buffer): string {
+    const secretSalt = salt || crypto.randomBytes(16);
+    const hash = crypto.scryptSync(secret, secretSalt, 32);
+    return secretSalt.toString("hex") + ":" + hash.toString("hex");
   }
 
   /**
-   * Verify API key and secret
+   * Verify API key and secret using constant-time comparison
    */
   public verify(key: string, secret: string): ApiKey | null {
     const apiKey = this.keys.get(key);
@@ -82,8 +84,19 @@ export class ApiKeyManager {
       return null;
     }
 
-    const hashedSecret = this.hashSecret(secret);
-    if (hashedSecret !== apiKey.secret) {
+    const [storedSalt, storedHash] = apiKey.secret.split(":");
+    if (!storedSalt || !storedHash) {
+      return null;
+    }
+
+    const hashedSecret = this.hashSecret(secret, Buffer.from(storedSalt, "hex"));
+    const [, computedHash] = hashedSecret.split(":");
+
+    try {
+      if (!crypto.timingSafeEqual(Buffer.from(computedHash), Buffer.from(storedHash))) {
+        return null;
+      }
+    } catch {
       return null;
     }
 


### PR DESCRIPTION
## Summary

Addresses four critical security issues in the authentication and input validation middleware:
- API key secrets hashed with slow KDF instead of fast SHA-256
- Bearer token authentication now properly validates JWTs
- API key verification uses constant-time comparison
- HTML sanitization is now applied to all string inputs

## Changes

### #1062 — API key secrets hashed with unsalted SHA-256
- Replaced SHA-256 with scrypt KDF for key hashing
- Secrets now stored as `salt:hash` format
- Maintains high entropy random secrets properly

### #1061 — Bearer token branch never validates JWT
- Implemented actual JWT verification using jsonwebtoken
- Extracts and validates user claims (id, email)
- Properly rejects invalid/expired tokens

### #1063 — API secret verification uses non-constant-time comparison
- Replaced string inequality with crypto.timingSafeEqual
- Prevents timing side-channel attacks
- Mitigates hash recovery via response time analysis

### #1064 — sanitizeHtml defined but never called
- Integrated sanitizeHtml into validateInput middleware
- HTML escaping now applied to all string inputs from query and body
- Prevents XSS when user input is rendered

Closes #1062, Closes #1061, Closes #1063, Closes #1064