### PR TITLE
Feature/ci and build fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,33 @@ jobs:
               body,
             });
 
+  playwright:
+    name: Playwright E2E Tests
+    runs-on: ubuntu-latest
+    needs: frontend
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 8
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+      - name: Run Playwright tests
+        run: pnpm run test:e2e
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-${{ github.sha }}
+          path: playwright-report/
+          if-no-files-found: ignore
+
   docker-app:
     name: Build Production Docker Image
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-contracts.yml
+++ b/.github/workflows/deploy-contracts.yml
@@ -72,13 +72,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, build]
     environment: testnet
-    outputs:
-      bounty_contract_id: ${{ steps.deploy.outputs.bounty_contract_id }}
-      escrow_contract_id: ${{ steps.deploy.outputs.escrow_contract_id }}
-      freelancer_contract_id: ${{ steps.deploy.outputs.freelancer_contract_id }}
-      governance_contract_id: ${{ steps.deploy.outputs.governance_contract_id }}
-      oracle_contract_id: ${{ steps.deploy.outputs.oracle_contract_id }}
-      identity_contract_id: ${{ steps.deploy.outputs.identity_contract_id }}
     steps:
       - uses: actions/checkout@v6
 
@@ -127,90 +120,24 @@ jobs:
           name: contracts-testnet-${{ github.sha }}
           path: contracts.json
 
-  deploy-mainnet:
-    name: Deploy to Mainnet
-    runs-on: ubuntu-latest
-    needs: deploy-testnet
-    environment: mainnet
-    if: github.ref == 'refs/heads/main'
-    outputs:
-      bounty_contract_id: ${{ steps.deploy.outputs.bounty_contract_id }}
-      escrow_contract_id: ${{ steps.deploy.outputs.escrow_contract_id }}
-      freelancer_contract_id: ${{ steps.deploy.outputs.freelancer_contract_id }}
-      governance_contract_id: ${{ steps.deploy.outputs.governance_contract_id }}
-      oracle_contract_id: ${{ steps.deploy.outputs.oracle_contract_id }}
-      identity_contract_id: ${{ steps.deploy.outputs.identity_contract_id }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: contract-wasm-${{ github.sha }}
-          path: artifacts
-
-      - name: Install Stellar CLI
-        run: |
-          cargo install --locked stellar-cli --features opt 2>/dev/null || \
-          cargo install stellar-cli --features opt
-
-      - name: Deploy contracts to Mainnet
-        id: deploy
-        env:
-          STELLAR_NETWORK: mainnet
-          STELLAR_RPC_URL: ${{ env.MAINNET_RPC_URL }}
-          STELLAR_NETWORK_PASSPHRASE: ${{ env.MAINNET_PASSPHRASE }}
-          STELLAR_ADMIN_SECRET: ${{ secrets.MAINNET_DEPLOYER_SECRET }}
-          WASM_DIR: artifacts
-        run: node scripts/deploy.js
-
-      - name: Write contracts.json
-        run: |
-          cat > contracts.json <<EOF
-          {
-            "network": "mainnet",
-            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "commit": "${{ github.sha }}",
-            "contracts": {
-              "bounty": "${{ steps.deploy.outputs.bounty_contract_id }}",
-              "escrow": "${{ steps.deploy.outputs.escrow_contract_id }}",
-              "freelancer": "${{ steps.deploy.outputs.freelancer_contract_id }}",
-              "governance": "${{ steps.deploy.outputs.governance_contract_id }}",
-              "oracle": "${{ steps.deploy.outputs.oracle_contract_id }}",
-              "identity": "${{ steps.deploy.outputs.identity_contract_id }}"
-            }
-          }
-          EOF
-
-      - name: Upload contracts.json
-        uses: actions/upload-artifact@v4
-        with:
-          name: contracts-mainnet-${{ github.sha }}
-          path: contracts.json
-
   notify:
     name: Deployment Notification
     runs-on: ubuntu-latest
-    needs: [deploy-testnet, deploy-mainnet]
+    needs: deploy-testnet
     if: always()
     steps:
       - name: Determine status
         id: status
         run: |
           TESTNET_RESULT="${{ needs.deploy-testnet.result }}"
-          MAINNET_RESULT="${{ needs.deploy-mainnet.result }}"
-          if [[ "$TESTNET_RESULT" == "failure" || "$MAINNET_RESULT" == "failure" ]]; then
+          if [[ "$TESTNET_RESULT" == "failure" ]]; then
             echo "status=failure" >> "$GITHUB_OUTPUT"
             echo "emoji=❌" >> "$GITHUB_OUTPUT"
             echo "color=danger" >> "$GITHUB_OUTPUT"
-          elif [[ "$TESTNET_RESULT" == "success" && ("$MAINNET_RESULT" == "success" || "$MAINNET_RESULT" == "skipped") ]]; then
+          else
             echo "status=success" >> "$GITHUB_OUTPUT"
             echo "emoji=✅" >> "$GITHUB_OUTPUT"
             echo "color=good" >> "$GITHUB_OUTPUT"
-          else
-            echo "status=warning" >> "$GITHUB_OUTPUT"
-            echo "emoji=⚠️" >> "$GITHUB_OUTPUT"
-            echo "color=warning" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Post to Slack
@@ -225,14 +152,12 @@ jobs:
           curl -fsSL -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
             -d '{
-              "text": "${{ steps.status.outputs.emoji }} *Soroban Contract Deployment* — `${{ github.sha }}`",
+              "text": "${{ steps.status.outputs.emoji }} *Soroban Contract Testnet Deployment* — `${{ github.sha }}`",
               "attachments": [{
                 "color": "${{ steps.status.outputs.color }}",
                 "fields": [
                   {"title": "Status", "value": "${{ steps.status.outputs.status }}", "short": true},
                   {"title": "Branch", "value": "`${{ github.ref_name }}`", "short": true},
-                  {"title": "Testnet", "value": "${{ needs.deploy-testnet.result }}", "short": true},
-                  {"title": "Mainnet", "value": "${{ needs.deploy-mainnet.result }}", "short": true},
                   {"title": "Run", "value": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>", "short": false}
                 ]
               }]
@@ -241,12 +166,13 @@ jobs:
       - name: Create GitHub deployment summary
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
-          ## ${{ steps.status.outputs.emoji }} Contract Deployment — `${{ github.sha }}`
+          ## ${{ steps.status.outputs.emoji }} Testnet Deployment — `${{ github.sha }}`
 
           | Stage | Result |
           |---|---|
           | Testnet | ${{ needs.deploy-testnet.result }} |
-          | Mainnet | ${{ needs.deploy-mainnet.result }} |
 
           [View full run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          ℹ️ Mainnet deployments are managed by the release workflow (deploy-mainnet.yml).
           EOF

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -41,7 +41,13 @@ jobs:
           cargo install stellar-cli --features opt
 
       - name: Build contracts
-        run: cd backend && cargo build --release --target wasm32-unknown-unknown
+        run: cd backend && cargo build --release --target wasm32-unknown-unknown \
+          --package stellar-bounty-contract \
+          --package stellar-escrow-contract \
+          --package stellar-freelancer-contract \
+          --package stellar-governance-contract \
+          --package oracle \
+          --package stellar-identity-contract
 
       - name: Run contract unit tests
         run: cd backend && cargo test --all-features
@@ -62,6 +68,8 @@ jobs:
       escrow_contract_id: ${{ steps.deploy.outputs.escrow_contract_id }}
       freelancer_contract_id: ${{ steps.deploy.outputs.freelancer_contract_id }}
       governance_contract_id: ${{ steps.deploy.outputs.governance_contract_id }}
+      oracle_contract_id: ${{ steps.deploy.outputs.oracle_contract_id }}
+      identity_contract_id: ${{ steps.deploy.outputs.identity_contract_id }}
     steps:
       - uses: actions/checkout@v6
 
@@ -110,6 +118,8 @@ jobs:
           NEXT_PUBLIC_ESCROW_CONTRACT_ID: ${{ needs.deploy-contracts.outputs.escrow_contract_id }}
           NEXT_PUBLIC_FREELANCER_CONTRACT_ID: ${{ needs.deploy-contracts.outputs.freelancer_contract_id }}
           NEXT_PUBLIC_GOVERNANCE_CONTRACT_ID: ${{ needs.deploy-contracts.outputs.governance_contract_id }}
+          NEXT_PUBLIC_ORACLE_CONTRACT_ID: ${{ needs.deploy-contracts.outputs.oracle_contract_id }}
+          NEXT_PUBLIC_IDENTITY_CONTRACT_ID: ${{ needs.deploy-contracts.outputs.identity_contract_id }}
         run: pnpm build
 
       - name: Deploy to Vercel (production)
@@ -151,6 +161,8 @@ jobs:
                   {"title": "Escrow Contract",     "value": "`${{ needs.deploy-contracts.outputs.escrow_contract_id }}`",     "short": true},
                   {"title": "Freelancer Contract", "value": "`${{ needs.deploy-contracts.outputs.freelancer_contract_id }}`", "short": true},
                   {"title": "Governance Contract", "value": "`${{ needs.deploy-contracts.outputs.governance_contract_id }}`", "short": true},
+                  {"title": "Oracle Contract",     "value": "`${{ needs.deploy-contracts.outputs.oracle_contract_id }}`",     "short": true},
+                  {"title": "Identity Contract",   "value": "`${{ needs.deploy-contracts.outputs.identity_contract_id }}`",   "short": true},
                   {"title": "Run",                 "value": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>", "short": false}
                 ]
               }]
@@ -167,6 +179,8 @@ jobs:
           | Escrow | \`${{ needs.deploy-contracts.outputs.escrow_contract_id }}\` |
           | Freelancer | \`${{ needs.deploy-contracts.outputs.freelancer_contract_id }}\` |
           | Governance | \`${{ needs.deploy-contracts.outputs.governance_contract_id }}\` |
+          | Oracle | \`${{ needs.deploy-contracts.outputs.oracle_contract_id }}\` |
+          | Identity | \`${{ needs.deploy-contracts.outputs.identity_contract_id }}\` |
 
           [View full run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           EOF

--- a/.github/workflows/nightly-tier-upgrade.yml
+++ b/.github/workflows/nightly-tier-upgrade.yml
@@ -43,12 +43,23 @@ jobs:
 
       - name: Notify on failure
         if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: 832,
-              body: '⚠️ Nightly tier upgrade failed. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
-            })
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [[ -z "$SLACK_WEBHOOK_URL" ]]; then
+            echo "⚠️ SLACK_WEBHOOK_URL not set, skipping notification"
+            exit 0
+          fi
+          curl -fsSL -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "text": "❌ *Nightly Tier Upgrade Failed*",
+              "attachments": [{
+                "color": "danger",
+                "fields": [
+                  {"title": "Workflow", "value": "Nightly Tier Upgrade", "short": true},
+                  {"title": "Status", "value": "Failed", "short": true},
+                  {"title": "Run", "value": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>", "short": false}
+                ]
+              }]
+            }'

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,15 +26,27 @@ COPY backend/tests     ./tests
 # Build all contracts in release mode.
 RUN cargo build --release --target wasm32-unknown-unknown \
         --package stellar-bounty-contract \
+        --package stellar-core-contract \
         --package stellar-escrow-contract \
         --package stellar-freelancer-contract \
-        --package stellar-governance-contract
+        --package stellar-governance-contract \
+        --package stellar-identity-contract \
+        --package stellar-insurance-contract \
+        --package oracle \
+        --package stellar-referral-contract \
+        --package stellar_insights
 
 # ── Output stage ────────────────────────────────────────────────────────────
 FROM scratch AS artifacts
 COPY --from=builder \
     /build/target/wasm32-unknown-unknown/release/bounty.wasm \
+    /build/target/wasm32-unknown-unknown/release/core.wasm \
     /build/target/wasm32-unknown-unknown/release/escrow.wasm \
     /build/target/wasm32-unknown-unknown/release/freelancer.wasm \
     /build/target/wasm32-unknown-unknown/release/governance.wasm \
+    /build/target/wasm32-unknown-unknown/release/identity.wasm \
+    /build/target/wasm32-unknown-unknown/release/insurance.wasm \
+    /build/target/wasm32-unknown-unknown/release/oracle.wasm \
+    /build/target/wasm32-unknown-unknown/release/referral.wasm \
+    /build/target/wasm32-unknown-unknown/release/stellar_insights.wasm \
     /

--- a/scripts/build-reproducible.sh
+++ b/scripts/build-reproducible.sh
@@ -8,7 +8,7 @@
 #   ./scripts/build-reproducible.sh
 #
 # Output:
-#   artifacts/{bounty,escrow,freelancer,governance}.wasm
+#   artifacts/{bounty,core,escrow,freelancer,governance,identity,insurance,oracle,referral,stellar_insights}.wasm
 #   artifacts/hashes.sha256
 
 set -euo pipefail
@@ -29,7 +29,7 @@ docker build \
 # Extract WASM artifacts from the image without running a container.
 mkdir -p "$ARTIFACTS_DIR"
 
-for CONTRACT in bounty escrow freelancer governance; do
+for CONTRACT in bounty core escrow freelancer governance identity insurance oracle referral stellar_insights; do
   docker run --rm --entrypoint cat "$IMAGE_TAG" \
     "/build/target/wasm32-unknown-unknown/release/${CONTRACT}.wasm" \
     > "$ARTIFACTS_DIR/${CONTRACT}.wasm"
@@ -37,7 +37,7 @@ for CONTRACT in bounty escrow freelancer governance; do
 done
 
 # Write canonical hash file.
-(cd "$ARTIFACTS_DIR" && sha256sum bounty.wasm escrow.wasm freelancer.wasm governance.wasm) \
+(cd "$ARTIFACTS_DIR" && sha256sum bounty.wasm core.wasm escrow.wasm freelancer.wasm governance.wasm identity.wasm insurance.wasm oracle.wasm referral.wasm stellar_insights.wasm) \
   > "$ARTIFACTS_DIR/hashes.sha256"
 
 echo ""


### PR DESCRIPTION
## Summary

   Fixes four critical CI/workflow and reproducible-build issues:
   - Adds Playwright e2e test coverage to the CI pipeline
   - Enables reproducible builds for all 10 contracts (not just 4)
   - Removes stale hardcoded issue references in notification workflows
   - Consolidates divergent mainnet deployment paths for safety

   ## Changes

   ### #1051 — Playwright E2E Tests
   - Added `playwright` job to ci.yml that installs browsers and runs `pnpm run test:e2e`
   - Uploads Playwright report on failure for debugging
   - Ensures e2e test coverage is verified on every push and PR

   ### #1043 — Reproducible Contract Builds
   - Updated Dockerfile to build all 10 contracts (core, identity, insurance, oracle, referral, stellar_insights were missing)
   - Updated scripts/build-reproducible.sh to extract and hash all 10 contracts
   - Ensures full contract suite has reproducibility guarantees

   ### #1040 — Nightly Workflow Notifications
   - Replaced hardcoded GitHub issue #832 comment with Slack webhook notification
   - Matches the notification pattern already used in deploy-contracts.yml and deploy-mainnet.yml
   - Prevents stale issue references from breaking failure alerts

   ### #1041 — Consolidate Mainnet Deployments
   - Removed automatic mainnet deployment from deploy-contracts.yml (on every main push)
   - Made deploy-mainnet.yml the single source of truth (release-triggered, with semver validation + RPC simulation)
   - Updated deploy-mainnet.yml to include oracle/identity contracts with RPC safeguards
   - Eliminates divergent safety gates: oracle/identity no longer deploy without simulation

   ## Test plan

   - [ ] Verify Playwright job runs on next CI workflow (should see test:e2e step)
   - [ ] Build Dockerfile locally: `./scripts/build-reproducible.sh` produces all 10 .wasm files
   - [ ] Verify hashes.sha256 includes all 10 contracts after build
   - [ ] Confirm nightly failure now posts to Slack (set SLACK_WEBHOOK_URL secret)
   - [ ] Verify next release triggers deploy-mainnet.yml with oracle/identity in deployment and frontend env vars

   Closes #1051, Closes #1043, Closes #1040, Closes #1041