### PR TITLE
fix(notifications): bind getServerSession to authOptions so routes stop 401ing

### DIFF
--- a/app/api/notifications/[id]/read/route.ts
+++ b/app/api/notifications/[id]/read/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/lib/auth/auth';
 
 export async function PATCH(
   _request: Request,

--- a/app/api/notifications/read-all/route.ts
+++ b/app/api/notifications/read-all/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/lib/auth/auth';
 
 export async function PATCH() {
   const session = await getServerSession();

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/lib/auth/auth';
 
 export async function GET(request: Request) {
   const session = await getServerSession();


### PR DESCRIPTION
Closes #1122

## Problem

The three notifications routes imported `getServerSession` directly from `next-auth` and called it with **no arguments**. Without `authOptions` that call can't resolve a session, so it returned `null`, the `!session?.user` guard tripped, and every request answered **401 — to real, logged-in users**.

The notification centre was broken end to end: list, mark-one-read, and mark-all-read all failed, despite frontend and backend both being fully implemented. Nothing *looked* wrong; the endpoints simply denied everyone.

## Fix

Switched all three to `@/lib/auth/auth`, the app's `authOptions`-bound wrapper:

```ts
// lib/auth/auth.ts
export function getServerSession() {
  return nextAuthGetServerSession(authOptions);
}
```

This matches the working pattern in `app/api/onboarding/route.ts` and `app/api/profile/completion/route.ts`. The wrapper takes no arguments either, so **the call sites are unchanged** — this is an import swap and nothing else.

Files:
- `app/api/notifications/route.ts`
- `app/api/notifications/[id]/read/route.ts`
- `app/api/notifications/read-all/route.ts`

## Worth flagging: 18 more files have the same bug

While confirming the fix I grepped for the pattern across the app. It isn't limited to notifications and the GDPR/admin-report routes the issue mentions — **18 further files** import `getServerSession` unbound:

```
app/admin/actions.ts
app/api/admin/disputes/route.ts
app/api/admin/disputes/[id]/resolve/route.ts
app/api/admin/feature-flags/route.ts
app/api/admin/feature-flags/[name]/route.ts
app/api/admin/kyc/route.ts
app/api/admin/kyc/[id]/review/route.ts
app/api/admin/reports/bounties/route.ts
app/api/admin/reports/disputes/route.ts
app/api/admin/reports/revenue/route.ts
app/api/admin/reports/users/route.ts
app/api/feature-flags/evaluate/route.ts
app/api/payments/route.ts
app/api/sync/pull/route.ts
app/api/sync/push/route.ts
app/api/user/account/route.ts
app/api/user/data-export/route.ts
lib/feature-flags/middleware.ts
```

If these behave the same way, the entire admin surface, payments, and offline sync are also 401ing. **I've left them alone deliberately** — sweeping 18 unrelated files into a notifications fix would make this diff much harder to review, and some may already have issues open. Happy to do them in a follow-up PR, either as one batch or split by area — just say which you'd prefer.

Given the pattern is this widespread, an ESLint `no-restricted-imports` rule banning `getServerSession` from `next-auth` outside `lib/auth/` would stop it recurring. I can add that too.

## Verification

Three-line import change with no logic touched. I have not run the dev server or the test suite here, so I haven't exercised the endpoints against a live session — worth a click through the notification centre on review to confirm the 401s are gone.