### PR TITLE
fix(bounty): accept any M-of-N multisig quorum, not a fixed prefix

### DIFF
--- a/backend/contracts/bounty/src/lib.rs
+++ b/backend/contracts/bounty/src/lib.rs
@@ -408,7 +408,17 @@ impl BountyContract {
         true
     }
 
-    pub fn complete_bounty(env: Env, bounty_id: u64) -> bool {
+    /// Approve completion and release payment.
+    ///
+    /// `approvers` names the multi-sig signers authorising this call. It is
+    /// ignored for bounties below the multi-sig threshold — pass an empty
+    /// `Vec` for those. Above the threshold it must contain at least
+    /// `required` distinct addresses, all drawn from the configured signer
+    /// set, and each must have authorised the invocation.
+    ///
+    /// Any `required`-sized subset satisfies the policy; the signers no longer
+    /// have to be the first `required` entries in the stored order (#1113).
+    pub fn complete_bounty(env: Env, bounty_id: u64, approvers: Vec<Address>) -> bool {
         let bounty_key = (Symbol::new(&env, "bounty"), bounty_id);
         let mut bounty = env
             .storage()
@@ -441,14 +451,44 @@ impl BountyContract {
                 .get::<DataKey, u32>(&DataKey::MultisigRequired)
                 .unwrap_or(2);
 
-            // Collect auth from each signer; count how many authorised.
+            // #1113: the approving subset is named by the caller rather than
+            // inferred by walking `signers` in stored order.
+            //
+            // `require_auth()` panics when the given address did not authorise
+            // the invocation — it cannot be used as a boolean test. The previous
+            // loop called it unconditionally on the first `required` entries, so
+            // it demanded that specific prefix rather than any M of N: a
+            // legitimate quorum that happened not to be the first M in the list
+            // panicked on an earlier signer who was never involved.
+            //
+            // Naming the approvers up front means every require_auth() below is
+            // expected to succeed, which is the only way to use it correctly.
+            assert!(
+                approvers.len() as u32 >= required,
+                "Insufficient multi-sig authorisations for high-value bounty"
+            );
+
             let mut auth_count: u32 = 0;
-            for signer in signers.iter() {
-                signer.require_auth();
-                auth_count += 1;
-                if auth_count >= required {
-                    break;
+            for (i, approver) in approvers.iter().enumerate() {
+                // Every approver must belong to the configured signer set,
+                // otherwise any address could pad the quorum with its own
+                // signature.
+                assert!(
+                    signers.contains(&approver),
+                    "Approver is not a configured multi-sig signer"
+                );
+
+                // Without this, [signer_a, signer_a, signer_a] would satisfy a
+                // 3-of-5 policy with one key — turning M-of-N into 1-of-N.
+                for j in (i + 1)..(approvers.len() as usize) {
+                    assert!(
+                        approver != approvers.get(j as u32).unwrap(),
+                        "Duplicate approver in multi-sig set"
+                    );
                 }
+
+                approver.require_auth();
+                auth_count += 1;
             }
 
             assert!(
@@ -763,11 +803,195 @@ mod tests {
         contract.submit_completion(&bounty_id, &freelancer);
 
         // With mock_all_auths, all require_auth calls pass — completion succeeds
-        let result = contract.complete_bounty(&bounty_id);
+        let mut approvers = soroban_sdk::Vec::new(&env);
+        approvers.push_back(signer1.clone());
+        approvers.push_back(signer2.clone());
+        let result = contract.complete_bounty(&bounty_id, &approvers);
         assert!(result);
 
         let bounty = contract.get_bounty(&bounty_id);
         assert_eq!(bounty.status, BountyStatus::Completed);
+    }
+
+    /// #1113: the regression the old implementation could not pass.
+    ///
+    /// A 2-of-3 policy approved by signers 2 and 3 — a legitimate quorum that
+    /// is not the first two entries in the stored list. The previous loop
+    /// walked `signers` in order and called `require_auth()` unconditionally,
+    /// so it panicked on signer 1, who was never involved.
+    #[test]
+    fn test_multisig_accepts_non_prefix_subset() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract = BountyContractClient::new(&env, &env.register_contract(None, BountyContract));
+
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let signer1 = Address::generate(&env);
+        let signer2 = Address::generate(&env);
+        let signer3 = Address::generate(&env);
+
+        contract.initialize(&admin);
+        let mut signers = soroban_sdk::Vec::new(&env);
+        signers.push_back(signer1.clone());
+        signers.push_back(signer2.clone());
+        signers.push_back(signer3.clone());
+        contract.set_multisig_signers(&admin, &signers, &2u32);
+
+        let bounty_id = contract.create_bounty(
+            &creator,
+            &String::from_str(&env, "High-Value Bounty"),
+            &String::from_str(&env, "Approved by a non-prefix quorum"),
+            &MULTISIG_THRESHOLD,
+            &100u64,
+        );
+        let app_id = contract.apply_for_bounty(
+            &bounty_id,
+            &freelancer,
+            &String::from_str(&env, "I can do this"),
+            &MULTISIG_THRESHOLD,
+            &30u64,
+        );
+        contract.select_freelancer(&bounty_id, &app_id);
+        contract.submit_completion(&bounty_id, &freelancer);
+
+        // Signers 2 and 3 — deliberately skipping the first entry.
+        let mut approvers = soroban_sdk::Vec::new(&env);
+        approvers.push_back(signer2.clone());
+        approvers.push_back(signer3.clone());
+
+        assert!(contract.complete_bounty(&bounty_id, &approvers));
+        assert_eq!(contract.get_bounty(&bounty_id).status, BountyStatus::Completed);
+    }
+
+    #[test]
+    #[should_panic(expected = "Duplicate approver")]
+    fn test_multisig_rejects_duplicate_approver() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract = BountyContractClient::new(&env, &env.register_contract(None, BountyContract));
+
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let signer1 = Address::generate(&env);
+        let signer2 = Address::generate(&env);
+
+        contract.initialize(&admin);
+        let mut signers = soroban_sdk::Vec::new(&env);
+        signers.push_back(signer1.clone());
+        signers.push_back(signer2.clone());
+        contract.set_multisig_signers(&admin, &signers, &2u32);
+
+        let bounty_id = contract.create_bounty(
+            &creator,
+            &String::from_str(&env, "High-Value Bounty"),
+            &String::from_str(&env, "Duplicate approver"),
+            &MULTISIG_THRESHOLD,
+            &100u64,
+        );
+        let app_id = contract.apply_for_bounty(
+            &bounty_id,
+            &freelancer,
+            &String::from_str(&env, "I can do this"),
+            &MULTISIG_THRESHOLD,
+            &30u64,
+        );
+        contract.select_freelancer(&bounty_id, &app_id);
+        contract.submit_completion(&bounty_id, &freelancer);
+
+        // Without the duplicate check this satisfies 2-of-2 with a single key,
+        // collapsing M-of-N to 1-of-N.
+        let mut approvers = soroban_sdk::Vec::new(&env);
+        approvers.push_back(signer1.clone());
+        approvers.push_back(signer1.clone());
+        contract.complete_bounty(&bounty_id, &approvers);
+    }
+
+    #[test]
+    #[should_panic(expected = "not a configured multi-sig signer")]
+    fn test_multisig_rejects_outsider_approver() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract = BountyContractClient::new(&env, &env.register_contract(None, BountyContract));
+
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let signer1 = Address::generate(&env);
+        let signer2 = Address::generate(&env);
+
+        contract.initialize(&admin);
+        let mut signers = soroban_sdk::Vec::new(&env);
+        signers.push_back(signer1.clone());
+        signers.push_back(signer2.clone());
+        contract.set_multisig_signers(&admin, &signers, &2u32);
+
+        let bounty_id = contract.create_bounty(
+            &creator,
+            &String::from_str(&env, "High-Value Bounty"),
+            &String::from_str(&env, "Outsider approver"),
+            &MULTISIG_THRESHOLD,
+            &100u64,
+        );
+        let app_id = contract.apply_for_bounty(
+            &bounty_id,
+            &freelancer,
+            &String::from_str(&env, "I can do this"),
+            &MULTISIG_THRESHOLD,
+            &30u64,
+        );
+        contract.select_freelancer(&bounty_id, &app_id);
+        contract.submit_completion(&bounty_id, &freelancer);
+
+        // An arbitrary address must not be able to pad the quorum with its own
+        // signature.
+        let mut approvers = soroban_sdk::Vec::new(&env);
+        approvers.push_back(signer1.clone());
+        approvers.push_back(Address::generate(&env));
+        contract.complete_bounty(&bounty_id, &approvers);
+    }
+
+    #[test]
+    #[should_panic(expected = "Insufficient multi-sig authorisations")]
+    fn test_multisig_rejects_too_few_approvers() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract = BountyContractClient::new(&env, &env.register_contract(None, BountyContract));
+
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let signer1 = Address::generate(&env);
+        let signer2 = Address::generate(&env);
+
+        contract.initialize(&admin);
+        let mut signers = soroban_sdk::Vec::new(&env);
+        signers.push_back(signer1.clone());
+        signers.push_back(signer2.clone());
+        contract.set_multisig_signers(&admin, &signers, &2u32);
+
+        let bounty_id = contract.create_bounty(
+            &creator,
+            &String::from_str(&env, "High-Value Bounty"),
+            &String::from_str(&env, "Too few approvers"),
+            &MULTISIG_THRESHOLD,
+            &100u64,
+        );
+        let app_id = contract.apply_for_bounty(
+            &bounty_id,
+            &freelancer,
+            &String::from_str(&env, "I can do this"),
+            &MULTISIG_THRESHOLD,
+            &30u64,
+        );
+        contract.select_freelancer(&bounty_id, &app_id);
+        contract.submit_completion(&bounty_id, &freelancer);
+
+        let mut approvers = soroban_sdk::Vec::new(&env);
+        approvers.push_back(signer1.clone());
+        contract.complete_bounty(&bounty_id, &approvers);
     }
 
     #[test]
@@ -798,7 +1022,8 @@ mod tests {
 
         contract.select_freelancer(&bounty_id, &app_id);
         contract.submit_completion(&bounty_id, &freelancer);
-        let result = contract.complete_bounty(&bounty_id);
+        // Below the threshold, so `approvers` is ignored — pass an empty Vec.
+        let result = contract.complete_bounty(&bounty_id, &soroban_sdk::Vec::new(&env));
         assert!(result);
     }
 


### PR DESCRIPTION
Closes #1113
Closes #1078

## Problem

`complete_bounty` walked the configured `signers` in **stored order** and called `require_auth()` unconditionally on each until `required` was reached:

```rust
for signer in signers.iter() {
    signer.require_auth();
    auth_count += 1;
    if auth_count >= required { break; }
}
```

`require_auth()` **panics** when the given address did not authorise the current invocation — it cannot be used as a soft or boolean check.

So this did not accept *"any M of the N configured signers"*. It hard-required the **first M by stored order**, and panicked on the first list entry that hadn't signed, even when later entries had.

A legitimate quorum that happened not to be the first M in the list could not approve a high-value bounty at all — the call died on an earlier signer who was never involved. The doc comment on `set_multisig_signers` promises genuine M-of-N flexibility, so this was a real gap between the documented policy and the implemented one.

## Fix

The approving subset is now named explicitly by the caller:

```rust
complete_bounty(env, bounty_id, approvers: Vec<Address>)
```

Naming the approvers up front is what makes `require_auth()` **usable** here — every call is expected to succeed, which is the only correct way to use it.

Each approver is then verified to be in the configured signer set, so an arbitrary address can't pad the quorum with its own signature.

### The duplicate check matters as much as the fix

Approvers are also checked for duplicates. Without that, `[signer_a, signer_a, signer_a]` would satisfy a 3-of-5 policy with a **single key** — collapsing M-of-N to 1-of-N, a worse bug than the one being fixed.

`approvers` is ignored below the multi-sig threshold; those callers pass an empty `Vec`.

## ⚠️ ABI change

`complete_bounty` gains a parameter. **Callers must be updated.**

This is the approach the issue suggests, and I don't think it's avoidable: Soroban offers no way to test whether an address authorised without panicking, so the authorising subset genuinely cannot be determined from inside the contract. If you'd rather preserve the existing signature, the only alternative I can see is a second entry point (`complete_bounty_multisig`) with the old one restricted to below-threshold bounties — happy to do that instead if ABI stability matters more here.

## Tests

Updated both existing multi-sig tests, and added four. The one that matters:

**`test_multisig_accepts_non_prefix_subset`** — a 2-of-3 policy approved by signers **2 and 3**, deliberately skipping the first entry. This is precisely what the old implementation could not do, and it's the regression guard for this issue.

The other three cover duplicate approvers, an outsider approver, and too few approvers.

## Verification

I have not run `cargo test` here. The tests follow the file's existing harness (`mock_all_auths`, `BountyContractClient`, `should_panic(expected = ...)` matching the assert messages), but they haven't been executed — worth running on review, particularly the non-prefix test, since that's the one asserting the bug is actually gone.