### PR TITLE
feat(mobile): route HomeScreen through the i18n engine

### DIFF
--- a/mobile/src/i18n/locales/ar.ts
+++ b/mobile/src/i18n/locales/ar.ts
@@ -175,6 +175,20 @@ const ar = {
     languageChanged: 'تم تحديث اللغة إلى {{language}}',
     rtlNote: 'تم تفعيل تخطيط اليمين إلى اليسار',
   },
+  home: {
+    greeting: 'مرحبًا، صانع Stellar',
+    subtitle: 'تابع المحافظ الرائجة والطلب على المشاريع وأمّن جلستك عبر الدخول البيومتري.',
+    useBiometrics: 'استخدام البصمة',
+    refresh: 'تحديث',
+    audio: 'الصوت',
+    multiSig: 'التوقيع المتعدد',
+    peerTransfer: 'تحويل بين الأقران',
+    trendingTitle: 'المحافظ الرائجة',
+    trendingCaption: 'مختارة بناءً على أبرز نشاط للمستخدمين.',
+    cachedData: 'بيانات مخزّنة مؤقتًا من {{time}}',
+    loadingAnalytics: 'جارٍ تحميل تحليلات المحفظة…',
+    projectBountyFeed: 'موجز المشاريع والمكافآت',
+  },
 };
 
 export default ar;

--- a/mobile/src/i18n/locales/de.ts
+++ b/mobile/src/i18n/locales/de.ts
@@ -175,6 +175,20 @@ const de = {
     languageChanged: 'Sprache aktualisiert: {{language}}',
     rtlNote: 'Rechts-nach-links-Layout aktiviert',
   },
+  home: {
+    greeting: 'Hallo, Stellar-Creator',
+    subtitle: 'Verfolge angesagte Portfolios und Projektnachfrage und sichere deine Sitzung per biometrischem Zugang.',
+    useBiometrics: 'Biometrie verwenden',
+    refresh: 'Aktualisieren',
+    audio: 'Audio',
+    multiSig: 'Multi-Signatur',
+    peerTransfer: 'Peer-Übertragung',
+    trendingTitle: 'Angesagte Portfolios',
+    trendingCaption: 'Ausgewählt nach der wichtigsten Nutzeraktivität.',
+    cachedData: 'Zwischengespeicherte Daten von {{time}}',
+    loadingAnalytics: 'Portfolio-Analysen werden geladen…',
+    projectBountyFeed: 'Projekt- und Bounty-Feed',
+  },
 };
 
 export default de;

--- a/mobile/src/i18n/locales/en.ts
+++ b/mobile/src/i18n/locales/en.ts
@@ -176,6 +176,20 @@ const en = {
     languageChanged: 'Language updated to {{language}}',
     rtlNote: 'Right-to-left layout enabled',
   },
+  home: {
+    greeting: 'Hello, Stellar Creator',
+    subtitle: 'Track trending portfolios, project demand, and secure your session with biometric access.',
+    useBiometrics: 'Use Biometrics',
+    refresh: 'Refresh',
+    audio: 'Audio',
+    multiSig: 'Multi-Sig',
+    peerTransfer: 'Peer Transfer',
+    trendingTitle: 'Trending portfolios',
+    trendingCaption: 'Selected from top user activity.',
+    cachedData: 'Cached data from {{time}}',
+    loadingAnalytics: 'Loading portfolio analytics…',
+    projectBountyFeed: 'Project & Bounty feed',
+  },
 };
 
 export default en;

--- a/mobile/src/i18n/locales/es.ts
+++ b/mobile/src/i18n/locales/es.ts
@@ -175,6 +175,20 @@ const es = {
     languageChanged: 'Idioma actualizado a {{language}}',
     rtlNote: 'Diseño de derecha a izquierda activado',
   },
+  home: {
+    greeting: 'Hola, creador de Stellar',
+    subtitle: 'Sigue los portafolios en tendencia, la demanda de proyectos y protege tu sesión con acceso biométrico.',
+    useBiometrics: 'Usar biometría',
+    refresh: 'Actualizar',
+    audio: 'Audio',
+    multiSig: 'Multifirma',
+    peerTransfer: 'Transferencia entre pares',
+    trendingTitle: 'Portafolios en tendencia',
+    trendingCaption: 'Seleccionados según la actividad principal de los usuarios.',
+    cachedData: 'Datos en caché de {{time}}',
+    loadingAnalytics: 'Cargando análisis del portafolio…',
+    projectBountyFeed: 'Proyectos y recompensas',
+  },
 };
 
 export default es;

--- a/mobile/src/i18n/locales/fr.ts
+++ b/mobile/src/i18n/locales/fr.ts
@@ -175,6 +175,20 @@ const fr = {
     languageChanged: 'Langue mise à jour : {{language}}',
     rtlNote: 'Mise en page droite-à-gauche activée',
   },
+  home: {
+    greeting: 'Bonjour, créateur Stellar',
+    subtitle: 'Suivez les portfolios tendance, la demande de projets et sécurisez votre session par accès biométrique.',
+    useBiometrics: 'Utiliser la biométrie',
+    refresh: 'Actualiser',
+    audio: 'Audio',
+    multiSig: 'Multisignature',
+    peerTransfer: 'Transfert pair à pair',
+    trendingTitle: 'Portfolios tendance',
+    trendingCaption: "Sélectionnés d'après l'activité principale des utilisateurs.",
+    cachedData: 'Données en cache du {{time}}',
+    loadingAnalytics: 'Chargement des analyses du portfolio…',
+    projectBountyFeed: 'Fil des projets et primes',
+  },
 };
 
 export default fr;

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -14,6 +14,7 @@ import * as Haptics from "expo-haptics";
 import { useNavigation } from "@react-navigation/native";
 import { useRouter } from "expo-router";
 import { useTheme } from "../theme/ThemeProvider";
+import { useI18n } from "../i18n/I18nProvider";
 import { useOfflineData } from "../hooks/useOfflineData";
 import { useInfiniteScroll } from "../hooks/useInfiniteScroll";
 import {
@@ -152,6 +153,7 @@ async function fetchHomeData(): Promise<HomeData> {
 
 export function HomeScreen() {
   const { colors, isDark } = useTheme();
+  const { t } = useI18n();
   const router = useRouter();
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -219,12 +221,12 @@ export function HomeScreen() {
       <View style={styles.section}>
         <View style={styles.sectionHeader}>
           <Text style={[styles.sectionTitle, { color: colors.text }]}>
-            Trending portfolios
+            {t("home.trendingTitle")}
           </Text>
           <Text
             style={[styles.sectionCaption, { color: colors.textSecondary }]}
           >
-            Selected from top user activity.
+            {t("home.trendingCaption")}
           </Text>
         </View>
         <FlatList
@@ -284,22 +286,21 @@ export function HomeScreen() {
         >
           <View>
             <Text style={[styles.title, { color: colors.text }]}>
-              Hello, Stellar Creator
+              {t("home.greeting")}
             </Text>
             <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-              Track trending portfolios, project demand, and secure your session
-              with biometric access.
+              {t("home.subtitle")}
             </Text>
           </View>
           <View style={styles.heroActions}>
             <ActionButton
-              title="Use Biometrics"
+              title={t("home.useBiometrics")}
               onPress={() => navigation.navigate("BiometricAuth")}
               variant="primary"
               accessibilityLabel="Open biometric authentication screen"
             />
             <ActionButton
-              title="Refresh"
+              title={t("home.refresh")}
               onPress={handleRefresh}
               variant="secondary"
               accessibilityLabel="Refresh home content"
@@ -307,21 +308,21 @@ export function HomeScreen() {
           </View>
           <View style={styles.featureActions}>
             <ActionButton
-              title="Audio"
+              title={t("home.audio")}
               onPress={handleNavigateToAudio}
               variant="secondary"
               style={styles.featureButton}
               accessibilityLabel="Open audio playback screen"
             />
             <ActionButton
-              title="Multi-Sig"
+              title={t("home.multiSig")}
               onPress={handleNavigateToMultiSig}
               variant="secondary"
               style={styles.featureButton}
               accessibilityLabel="Open multi-signature approval screen"
             />
             <ActionButton
-              title="Peer Transfer"
+              title={t("home.peerTransfer")}
               onPress={handleNavigateToP2P}
               variant="secondary"
               style={styles.featureButton}
@@ -341,7 +342,7 @@ export function HomeScreen() {
             ]}
           >
             <Text style={[styles.staleText, { color: colors.warning }]}>
-              Cached data from {cachedAt.toLocaleTimeString()}
+              {t("home.cachedData", { time: cachedAt.toLocaleTimeString() })}
             </Text>
           </View>
         )}
@@ -350,7 +351,7 @@ export function HomeScreen() {
           <View style={styles.loadingWrapper}>
             <ActivityIndicator color={colors.primary} size="large" />
             <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
-              Loading portfolio analytics…
+              {t("home.loadingAnalytics")}
             </Text>
           </View>
         ) : (
@@ -359,7 +360,7 @@ export function HomeScreen() {
             {trendingSection}
             <ProjectBountyList
               items={data?.projectBountyItems ?? []}
-              title="Project & Bounty feed"
+              title={t("home.projectBountyFeed")}
               onSelect={onItemSelect}
             />
           </>


### PR DESCRIPTION
Closes #1078 — **first tranche, not the whole audit.** See scope note at the bottom.

## Problem

`src/i18n/` ships a complete translation engine — 5 locales, RTL flag, safe interpolation, AsyncStorage persistence — that only `LanguageSettingsScreen` and `MessagingScreen` actually consumed. Changing the language setting had almost no visible effect, which reads to a user as a **broken** feature rather than a missing one.

## This PR

Converts **HomeScreen**, the first of the four priority screens the issue names. It's the app's landing surface — where a Spanish- or Arabic-selecting user first sees whether their choice took effect at all.

Twelve hardcoded strings now resolve through `t()`:

- hero greeting and subtitle
- five action button titles (biometrics, refresh, audio, multi-sig, peer transfer)
- trending section title and caption
- the cached-data notice — via **interpolation** rather than string concatenation, so locales can place the timestamp where their grammar requires
- the loading message and the project/bounty feed title

## Translations, not placeholders

Added a `home` block to all five locale files with **real translations**. An untranslated key falls back to English anyway, so English placeholders would have made the screen look converted while changing nothing for the user — the exact failure this issue is about.

Verified programmatically that `es`/`fr`/`de`/`ar` mirror `en`'s `home` keys exactly, since the engine expects every locale to share the base structure:

```
es OK
fr OK
de OK
ar OK
```

## Scope — why one screen

This is **1 of ~34**. I kept it deliberately narrow so the key-naming convention (`home.*`) and the translation quality can be reviewed on a diff that's actually readable, before the same pattern gets applied across the remaining 33. If the approach looks right, the rest is mechanical and I'll continue in follow-ups.

Next up, from the issue's priority list:

| Screen | Lines | Note |
|---|---|---|
| `BountyListScreen` | 506 | |
| `CreatorProfileScreen` | 623 | |
| `OnboardingScreen` | 15 | **Not a screen conversion** — it's a thin wrapper; the strings live in `components/onboarding/OnboardingWalkthrough` |

That last one is worth flagging: the issue lists `OnboardingScreen.tsx` among the offenders, but converting it means converting the walkthrough component instead. Happy to fold that in.

## Verification

I have not run the app or the test suite. The change is a hook import, one destructure, and twelve string substitutions — but `useI18n()` throws when used outside `<I18nProvider>`, so it's worth confirming HomeScreen renders inside the provider in your navigation tree. If it doesn't, that's a one-line fix at the provider mount rather than anything here.