### PR TITLE
security(signaling): require auth session, enforce peer/room ownership

### DIFF
--- a/__tests__/signaling.test.ts
+++ b/__tests__/signaling.test.ts
@@ -164,6 +164,13 @@ describe('buildIceServers()', () => {
 
 // ── API route tests ──────────────────────────────────────────────────────────
 
+// The route now requires an authenticated session (#1124) -- mock a signed-in
+// user so these tests exercise the actual relay/credential logic rather than
+// hitting the 401 path.
+vi.mock('@/lib/auth/auth', () => ({
+  getServerSession: async () => ({ user: { id: 'test-user-1' } }),
+}));
+
 // Mock Next.js modules for route testing
 vi.mock('next/server', () => ({
   NextRequest: class {

--- a/app/api/signaling/route.ts
+++ b/app/api/signaling/route.ts
@@ -15,6 +15,44 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createHmac } from 'crypto';
+import { getServerSession } from '@/lib/auth/auth';
+
+const MAX_PEERS_PER_ROOM = parseInt(process.env.MAX_PEERS_PER_ROOM ?? '2', 10);
+
+// Tracks which authenticated user owns a given peerId, and which
+// authenticated users are members of a given room. Both are populated
+// on first use (first-come, first-served up to MAX_PEERS_PER_ROOM) since
+// there is no separate call/stream-invite record in this codebase to check
+// membership against — this is a real, self-contained substitute: it stops
+// an unauthenticated caller from reading/writing at all, stops one
+// authenticated user from impersonating another peerId, and caps how many
+// distinct users can ever inject into a guessed/observed roomId.
+const peerOwners = new Map<string, { userId: string; lastSeen: number }>(); // peerId -> owner
+const roomMembers = new Map<string, Map<string, number>>(); // roomId -> userId -> lastSeen
+
+/** Registers (or verifies) that `userId` owns `peerId`. Returns false on conflict. */
+function claimPeerId(peerId: string, userId: string): boolean {
+  const owner = peerOwners.get(peerId);
+  if (owner === undefined) {
+    peerOwners.set(peerId, { userId, lastSeen: Date.now() });
+    return true;
+  }
+  if (owner.userId !== userId) return false;
+  owner.lastSeen = Date.now();
+  return true;
+}
+
+/** Registers (or verifies) `userId` as a member of `roomId`. Returns false if the room is full. */
+function claimRoomMembership(roomId: string, userId: string): boolean {
+  let members = roomMembers.get(roomId);
+  if (!members) {
+    members = new Map();
+    roomMembers.set(roomId, members);
+  }
+  if (!members.has(userId) && members.size >= MAX_PEERS_PER_ROOM) return false;
+  members.set(userId, Date.now());
+  return true;
+}
 
 const TURN_SECRET = process.env.TURN_SECRET ?? 'insecure-dev-secret';
 const TURN_HOST = process.env.TURN_HOST ?? 'turn.example.com';
@@ -45,6 +83,15 @@ setInterval(() => {
     const fresh = entries.filter((e) => e.ts > cutoff);
     if (fresh.length === 0) signalingStore.delete(key);
     else signalingStore.set(key, fresh);
+  }
+  for (const [peerId, owner] of peerOwners) {
+    if (owner.lastSeen <= cutoff) peerOwners.delete(peerId);
+  }
+  for (const [roomId, members] of roomMembers) {
+    for (const [userId, lastSeen] of members) {
+      if (lastSeen <= cutoff) members.delete(userId);
+    }
+    if (members.size === 0) roomMembers.delete(roomId);
   }
 }, 60_000).unref?.();
 
@@ -77,11 +124,30 @@ function generateIceServers(peerId: string) {
  * Polls for inbound signaling messages (HTTP fallback for mobile clients).
  */
 export async function GET(req: NextRequest) {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = session.user.id;
+
   const roomId = req.nextUrl.searchParams.get('roomId');
   const sinceParam = req.nextUrl.searchParams.get('since');
   const peerIdParam = req.nextUrl.searchParams.get('peerId');
 
   if (roomId && peerIdParam) {
+    if (!claimPeerId(peerIdParam, userId)) {
+      return NextResponse.json(
+        { error: 'peerId is already registered to another user' },
+        { status: 403 },
+      );
+    }
+    if (!claimRoomMembership(roomId, userId)) {
+      return NextResponse.json(
+        { error: 'Room is full' },
+        { status: 403 },
+      );
+    }
+
     const since = sinceParam ? Number(sinceParam) : 0;
     const key = `${roomId}:${peerIdParam}`;
     const entries = signalingStore.get(key) ?? [];
@@ -90,8 +156,13 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ messages });
   }
 
-  const peerId =
-    peerIdParam ?? `web-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const peerId = peerIdParam ?? `${userId}-${Date.now().toString(36)}`;
+  if (!claimPeerId(peerId, userId)) {
+    return NextResponse.json(
+      { error: 'peerId is already registered to another user' },
+      { status: 403 },
+    );
+  }
 
   return NextResponse.json({
     iceServers: generateIceServers(peerId),
@@ -115,6 +186,12 @@ export async function GET(req: NextRequest) {
  *   to       string?  Target peer ID (optional, broadcasts if omitted)
  */
 export async function POST(req: NextRequest) {
+  const session = await getServerSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = session.user.id;
+
   try {
     const body = await req.json();
     const { roomId, peerId, type, sdp, candidate, to, amount, asset } = body;
@@ -123,6 +200,19 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         { error: 'Missing required fields: roomId, peerId, type' },
         { status: 400 },
+      );
+    }
+
+    if (!claimPeerId(peerId, userId)) {
+      return NextResponse.json(
+        { error: 'peerId is already registered to another user' },
+        { status: 403 },
+      );
+    }
+    if (!claimRoomMembership(roomId, userId)) {
+      return NextResponse.json(
+        { error: 'Room is full' },
+        { status: 403 },
       );
     }
 


### PR DESCRIPTION
## Summary

Closes #1124.

`app/api/signaling/route.ts`'s `GET` and `POST` handlers took `roomId`/`peerId` straight from query params or JSON body with no session check and no verification that the caller was a participant in that room. Since `SignalingEntry` carries `amount`/`asset` (in-band payment-intent signaling) alongside SDP/ICE data, anyone who learned or guessed a `roomId` could poll `GET` to read another peer's offers, or `POST` forged SDP/ICE/payment-amount messages into that room — fully unauthenticated.

**What this PR adds:**

- Both `GET` and `POST` now require a real NextAuth session (`getServerSession()` / `session.user.id`), the same pattern used by every other authenticated route in this repo (e.g. `app/api/kyc/submit/route.ts`), and return `401` if absent.
- This codebase has **no separate call/stream-invite record** to check "is this user a registered participant of `roomId`" against — I grepped the whole repo including `prisma/schema.prisma` and there's no `Stream`/`Call` model anywhere. Rather than fabricate a check against infrastructure that doesn't exist, I added a real, self-contained substitute directly in the route:
  - `peerOwners`: binds each `peerId` to the first authenticated user who uses it — a different user can never send/read as a `peerId` they don't own (closes the identity-spoofing angle).
  - `roomMembers`: caps each `roomId` at `MAX_PEERS_PER_ROOM` (2, matching the P2P design already used by the standalone WS signaling server in `server/signaling.ts`) distinct authenticated users, first-come-first-served — a third party who merely learns/guesses a `roomId` that already has its two real participants can no longer inject into it.
  - Both maps are pruned on the same 60s interval / 5-minute TTL the existing `signalingStore` already uses, so they can't grow unbounded.

**What this doesn't fully solve**: this isn't the same as "verify the caller was actually invited to this specific call" — that needs a real call/session record this codebase doesn't have yet (a reasonable follow-up: add a `StreamSession`/`CallInvite` model and check against it instead of first-come-first-served). What it does close are the two concrete exploits in the issue: fully unauthenticated access, and unlimited third-party injection into an observed `roomId`.

- Updated `__tests__/signaling.test.ts` to mock an authenticated session (`vi.mock('@/lib/auth/auth', ...)`) so the existing `GET`/`POST` route tests continue to exercise the real relay logic instead of hitting the new 401 path.

## Test plan

- No install/build was run for this change (current task scope) — reviewed the logic and existing test mocking pattern (`vi.mock('next/server', ...)`) by hand and added an equivalent mock for the new auth dependency.
- [ ] Maintainer: `npm test __tests__/signaling.test.ts` to confirm.