### PR TITLE
fix: vector search fallback signal, timing-safe cron auth, Redis-back…

### DIFF
--- a/app/api/admin/cron/corridor-aggregation/route.ts
+++ b/app/api/admin/cron/corridor-aggregation/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
 import { aggregateCorridorPayments } from '@/backend/services/corridor-analytics';
 
 /**
@@ -10,11 +11,28 @@ import { aggregateCorridorPayments } from '@/backend/services/corridor-analytics
  * Authorization: Requires valid cron secret in X-Cron-Secret header
  */
 export async function POST(req: NextRequest) {
-  // Verify cron secret
+  // Verify cron secret using a constant-time comparison to prevent timing
+  // side-channel attacks. A plain !== comparison leaks information about how
+  // many leading characters of a guess match, allowing incremental recovery
+  // of the secret by a network-positioned attacker.
   const cronSecret = req.headers.get('x-cron-secret');
   const validSecret = process.env.CRON_SECRET;
 
-  if (!validSecret || cronSecret !== validSecret) {
+  const authorized = (() => {
+    if (!validSecret || !cronSecret) return false;
+    try {
+      const a = Buffer.from(cronSecret);
+      const b = Buffer.from(validSecret);
+      // timingSafeEqual requires equal-length buffers; length mismatch itself
+      // is not secret, so the early-return here is safe.
+      if (a.length !== b.length) return false;
+      return crypto.timingSafeEqual(a, b);
+    } catch {
+      return false;
+    }
+  })();
+
+  if (!authorized) {
     return NextResponse.json(
       { error: 'Unauthorized: Invalid or missing cron secret' },
       { status: 401 }

--- a/app/api/search/vector/route.ts
+++ b/app/api/search/vector/route.ts
@@ -67,6 +67,10 @@ export async function POST(req: NextRequest) {
 
     if (error) {
       // Graceful degradation: fall back to text search if vector search fails.
+      // Signal the degraded mode to callers and monitoring via a response flag
+      // and a non-200 status, mirroring the pattern used in /api/search/hybrid.
+      console.warn('[vector-search] match_creators RPC failed, falling back to text search:', error.message);
+
       const { data: fallback } = await supabaseServer
         .from('creators')
         .select('id, name, title, discipline, skills')
@@ -78,7 +82,18 @@ export async function POST(req: NextRequest) {
         score: 0.5,
         matchedTags: [],
       }));
-      return NextResponse.json(results);
+
+      return NextResponse.json(
+        {
+          results,
+          meta: {
+            engine: 'text-fallback',
+            fallback: true,
+            fallbackReason: 'vector-search-unavailable',
+          },
+        },
+        { status: 503 },
+      );
     }
 
     // Apply tag filtering on the server side.

--- a/hooks/useAnalyticsWorker.ts
+++ b/hooks/useAnalyticsWorker.ts
@@ -88,6 +88,16 @@ export function useAnalyticsWorker() {
     }
 
     return () => {
+      // Reject all in-flight promises before terminating so callers never hang.
+      // Without this, any await run(...) that is still pending when the component
+      // unmounts would dangle forever — no error, no resolution, just a stale
+      // loading state stuck on screen.
+      const terminationError = new Error('Analytics worker terminated')
+      for (const { reject } of pendingRef.current.values()) {
+        reject(terminationError)
+      }
+      pendingRef.current.clear()
+
       worker.terminate()
       workerRef.current = null
     }

--- a/lib/payments/idempotency.ts
+++ b/lib/payments/idempotency.ts
@@ -1,4 +1,22 @@
-const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+/**
+ * Idempotency cache for the payments API.
+ *
+ * Uses Redis as the primary store so the dedup guarantee holds across multiple
+ * instances and serverless cold-starts. Falls back to an in-process Map when
+ * Redis is not configured (local dev / test), preserving the original
+ * behaviour in those environments.
+ *
+ * The fallback is intentionally best-effort: it protects against duplicate
+ * requests within the same process but not across horizontally-scaled replicas.
+ * Set REDIS_URL in production to get the full cross-instance guarantee.
+ */
+
+import { redisGet, redisSet } from '@/lib/storage/redis';
+
+const TTL_MS = 24 * 60 * 60 * 1000;     // 24 hours (in-memory fallback)
+const TTL_REDIS_S = 24 * 60 * 60;       // 24 hours (Redis TTL, in seconds)
+
+const REDIS_PREFIX = 'idempotency:payments:';
 
 interface CachedResponse {
   status: number;
@@ -6,9 +24,11 @@ interface CachedResponse {
   createdAt: number;
 }
 
+// ── In-process fallback store ─────────────────────────────────────────────────
+
 type Store = Map<string, CachedResponse>;
 
-function getStore(): Store {
+function getLocalStore(): Store {
   const g = globalThis as unknown as { __idempotencyStore?: Store };
   if (!g.__idempotencyStore) {
     g.__idempotencyStore = new Map();
@@ -18,7 +38,7 @@ function getStore(): Store {
 
 function pruneExpired(): void {
   const now = Date.now();
-  const store = getStore();
+  const store = getLocalStore();
   for (const [key, entry] of store) {
     if (now - entry.createdAt > TTL_MS) {
       store.delete(key);
@@ -26,20 +46,53 @@ function pruneExpired(): void {
   }
 }
 
-export function getCachedResponse(key: string): { status: number; body: unknown } | null {
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Look up a previously cached response for this idempotency key.
+ * Checks Redis first; falls back to the in-process map if Redis is
+ * unavailable (REDIS_URL not set or connection error).
+ */
+export async function getCachedResponse(
+  key: string,
+): Promise<{ status: number; body: unknown } | null> {
+  // Try Redis first.
+  const redisEntry = await redisGet<CachedResponse>(`${REDIS_PREFIX}${key}`);
+  if (redisEntry) {
+    return { status: redisEntry.status, body: redisEntry.body };
+  }
+
+  // Fallback: in-process map (single-instance / dev only).
   pruneExpired();
-  const entry = getStore().get(key);
+  const entry = getLocalStore().get(key);
   if (!entry) return null;
   if (Date.now() - entry.createdAt > TTL_MS) {
-    getStore().delete(key);
+    getLocalStore().delete(key);
     return null;
   }
   return { status: entry.status, body: entry.body };
 }
 
-export function cacheResponse(key: string, status: number, body: unknown): void {
-  getStore().set(key, { status, body, createdAt: Date.now() });
+/**
+ * Persist a response so that subsequent requests with the same key return it
+ * without re-running the Stripe call. Writes to Redis when available; also
+ * writes the in-process fallback for immediate consistency within this replica.
+ */
+export async function cacheResponse(
+  key: string,
+  status: number,
+  body: unknown,
+): Promise<void> {
+  const entry: CachedResponse = { status, body, createdAt: Date.now() };
+
+  // Persist to Redis (no-op if REDIS_URL is not set).
+  await redisSet(`${REDIS_PREFIX}${key}`, entry, TTL_REDIS_S);
+
+  // Also write the local fallback so same-instance retries are instant.
+  getLocalStore().set(key, entry);
 }
+
+// ── Test helper ───────────────────────────────────────────────────────────────
 
 export function __resetIdempotencyStoreForTests(): void {
   const g = globalThis as unknown as { __idempotencyStore?: Store };


### PR DESCRIPTION
…ed idempotency, worker cleanup

Closes #1125 
closes #1127 
closes #1129 
closes #1135

## #1125 — vector search silently falls back with no degraded-mode signal

app/api/search/vector/route.ts: when the match_creators RPC fails, the handler now returns a 503 instead of a plain 200, wraps the fallback results under a 'results' key, and includes a meta object with { engine: 'text-fallback', fallback: true, fallbackReason: 'vector-search-unavailable' }. This mirrors the pattern already used in app/api/search/hybrid/route.ts so callers and monitoring can reliably distinguish real semantic ranking from degraded text-substring fallback.

## #1127 — cron corridor-aggregation secret compared with non-constant-time !==

app/api/admin/cron/corridor-aggregation/route.ts: replaced the plain cronSecret !== validSecret check with crypto.timingSafeEqual on fixed-length Buffers, guarded by an explicit length check (timingSafeEqual throws on unequal lengths). This closes the timing side-channel that could allow a network-positioned attacker to incrementally recover CRON_SECRET and trigger the aggregation job at will. Pattern matches the correct usage already in app/api/webhooks/email/bounce/route.ts.

## #1129 — payments idempotency cache lives in a globalThis Map, risking duplicate Stripe charges

lib/payments/idempotency.ts: replaced the single-process globalThis Map with a Redis-backed store (using the existing lib/storage/redis.ts client). getCachedResponse checks Redis first; cacheResponse writes to Redis and also to the local map for same-replica performance. When REDIS_URL is not set the module falls back to the original in-process behaviour so local dev and tests are unaffected. In production, dedup now holds across all horizontally-scaled instances and serverless cold-starts, preventing duplicate PaymentIntent creation and double capture/refund on retried requests.

## #1135 — useAnalyticsWorker never settles pending promises on termination

hooks/useAnalyticsWorker.ts: the useEffect cleanup now iterates pendingRef.current, rejects every in-flight promise with an explicit 'Analytics worker terminated' error, and clears the map before calling worker.terminate(). Previously, unmounting a component (e.g. navigating away from the analytics dashboard) while a computation was in-flight would leave the caller's await run(...) permanently unresolved, causing spinners and disabled UI to hang forever with no error surface.