### PR TITLE
fix: auth binding on sync/admin-report routes, contract input validation

### DIFF
--- a/app/api/admin/reports/bounties/route.ts
+++ b/app/api/admin/reports/bounties/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/lib/auth/auth';
 import { prisma } from '@/lib/prisma';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { toCSV } from '@/lib/export-utils';

--- a/app/api/admin/reports/disputes/route.ts
+++ b/app/api/admin/reports/disputes/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/lib/auth/auth';
 import { prisma } from '@/lib/prisma';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { toCSV } from '@/lib/export-utils';

--- a/app/api/admin/reports/revenue/route.ts
+++ b/app/api/admin/reports/revenue/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/lib/auth/auth';
 import { prisma } from '@/lib/prisma';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { toCSV } from '@/lib/export-utils';

--- a/app/api/admin/reports/users/route.ts
+++ b/app/api/admin/reports/users/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/lib/auth/auth';
 import { prisma } from '@/lib/prisma';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { toCSV } from '@/lib/export-utils';

--- a/app/api/sync/pull/route.ts
+++ b/app/api/sync/pull/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/lib/auth/auth';
 import { prisma } from '@/lib/prisma';
 
 /**

--- a/app/api/sync/push/route.ts
+++ b/app/api/sync/push/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from '@/lib/auth/auth';
 import { prisma } from '@/lib/prisma';
 
 interface PushPayload {

--- a/backend/contracts/escrow/src/lib.rs
+++ b/backend/contracts/escrow/src/lib.rs
@@ -40,6 +40,12 @@ pub const DEFAULT_PLATFORM_FEE_CAP: i128 = 500;
 /// After this window anyone can call `resolve_expired_dispute` for a 50/50 split.
 pub const DISPUTE_TIMEOUT_SECS: u64 = 30 * 24 * 3600;
 
+/// Bounds for the governance-configurable oracle freshness threshold (#1110).
+/// A value of 0 would mark every recorded price stale immediately, while an
+/// unbounded value would defeat the freshness guard entirely.
+pub const MIN_ORACLE_STALENESS_SECS: u64 = 60;
+pub const MAX_ORACLE_STALENESS_SECS: u64 = 86_400;
+
 /// Governance-configurable fee configuration stored on-chain (#722).
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -1110,6 +1116,8 @@ impl EscrowContract {
             .get::<Symbol, Address>(&Symbol::new(&env, "platform_admin"))
             .expect("Platform admin not set");
         assert_eq!(admin, stored_admin, "Only governance multisig can set staleness");
+        assert!(staleness_secs >= MIN_ORACLE_STALENESS_SECS, "Staleness must be at least 60 seconds");
+        assert!(staleness_secs <= MAX_ORACLE_STALENESS_SECS, "Staleness must not exceed 86_400 seconds");
         env.storage().persistent().set(&DataKey::OracleStalenessSecs, &staleness_secs);
     }
 

--- a/backend/contracts/identity/src/lib.rs
+++ b/backend/contracts/identity/src/lib.rs
@@ -70,6 +70,7 @@ const ONE_YEAR_SECS: u64 = 365 * 24 * 60 * 60;
 #[contractimpl]
 impl IdentityContract {
     pub fn initialize(env: Env, admin: Address) {
+        admin.require_auth();
         assert!(!env.storage().persistent().has(&DataKey::Admin), "Already initialized");
         env.storage().persistent().set(&DataKey::Admin, &admin);
     }


### PR DESCRIPTION
Fixes #1108, #1110, #1121, #1123.

- identity: add `admin.require_auth()` to `IdentityContract::initialize` so the address being set as admin must actually authorize the call, matching the pattern in `insurance` and `stellar_insights`. Without it anyone could front-run deployment and claim the admin slot. (#1108)

- escrow: bound `set_oracle_staleness_secs` to [60, 86_400], mirroring the bounds-checking style of `update_fee` in the same file. A value of 0 made every price stale on arrival; an unbounded value defeated the freshness guard entirely. (#1110)

- admin reports (bounties/disputes/revenue/users) and mobile offline-sync (pull/push): these six routes called `getServerSession()` with no `authOptions`, so the session never resolved and every request 401'd. Import the configured `@/lib/auth/auth` wrapper instead. (#1121, #1123)
closes #1108, 
closes #1110,
closes #1121, 
closes #1123.