### PR TITLE
fix: workspace member, epoch auth, bounty cap, analytics TTL (#1106 #…

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "contracts/identity",
     "contracts/referral",
     "contracts/stellar_insights",
+    "contracts/insurance",
     "contracts/test-utils",
     "services/api",
     "services/auth",

--- a/backend/contracts/stellar_insights/src/lib.rs
+++ b/backend/contracts/stellar_insights/src/lib.rs
@@ -8,6 +8,9 @@ use soroban_sdk::{
 /// Challenge deposit in stroops (10 XLM).
 pub const CHALLENGE_DEPOSIT: i128 = 100_000_000;
 
+/// Maximum reputation bonus that can be awarded per bounty completion.
+pub const MAX_BONUS_PER_COMPLETION: i64 = 100;
+
 const SECONDS_PER_MONTH: u64 = 30 * 86400;
 const GRACE_PERIOD_MONTHS: u64 = 3;
 const DECAY_SCALE: i64 = 10_000;
@@ -88,6 +91,7 @@ pub enum InsightsError {
     ChallengeNotFound = 6,
     ChallengeNotPending = 7,
     InvalidRating = 8,
+    BonusExceedsLimit = 9,
 }
 
 #[contract]
@@ -260,7 +264,10 @@ impl StellarInsights {
         Self::load_challenge(&env, challenge_id)
     }
 
-    pub fn validate_epoch(env: Env, epoch: u64, data_hash: String) -> bool {
+    pub fn validate_epoch(env: Env, admin: Address, epoch: u64, data_hash: String) -> bool {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+
         let current_timestamp = env.ledger().timestamp();
 
         match validate_epoch_range(epoch, current_timestamp) {
@@ -358,9 +365,11 @@ impl StellarInsights {
         true
     }
 
-    pub fn record_bounty_completion(env: Env, creator: Address, bonus: i64) -> bool {
-        creator.require_auth();
+    pub fn record_bounty_completion(env: Env, admin: Address, creator: Address, bonus: i64) -> bool {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
         assert!(bonus >= 0, "Bonus must be non-negative");
+        assert!(bonus <= MAX_BONUS_PER_COMPLETION, "Bonus exceeds maximum allowed per completion");
 
         let mut rep: CreatorReputation = env
             .storage()

--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -2,6 +2,9 @@
 
 use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Env, String, Symbol};
 
+const TTL_THRESHOLD: u32 = 100;
+const TTL_TARGET: u32 = 518_400;
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -29,13 +32,22 @@ impl AnalyticsContract {
             event_type,
         };
         env.storage().persistent().set(&key, &event);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
         true
     }
 
     pub fn get_event(env: Env, event_id: u64) -> Option<AnalyticsEvent> {
         let key = (Symbol::new(&env, "event"), event_id);
-        env.storage()
+        let result = env.storage()
             .persistent()
-            .get::<(Symbol, u64), AnalyticsEvent>(&key)
+            .get::<(Symbol, u64), AnalyticsEvent>(&key);
+        if result.is_some() {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        }
+        result
     }
 }


### PR DESCRIPTION
## Summary

Fixes four distinct issues across the Soroban smart contracts — two security vulnerabilities, one missing workspace member preventing CI coverage, and one silent data-expiry bug.

---

## Changes

### #1115 — Add `contracts/insurance` to the Cargo workspace

`backend/Cargo.toml` was missing `contracts/insurance` from the `[workspace] members` list despite the contract being fully implemented. This meant `cargo test --all-features` never built or tested it.

**Fix:** Added `"contracts/insurance"` to the members list.

Closes #1115

---

### #1114 — Add admin auth check to `validate_epoch`

`StellarInsights::validate_epoch` accepted an `epoch` and `data_hash` from any caller with no `require_auth()` call. Any account could silently overwrite an existing epoch's `data_hash`.

**Fix:** Added an `admin: Address` parameter, `admin.require_auth()`, and `require_admin()` — matching the exact pattern used by `uphold_challenge`, `reject_challenge`, and `set_reputation`.

Closes #1114

---

### #1112 — Gate `record_bounty_completion` on admin auth and cap `bonus`

`record_bounty_completion` only called `creator.require_auth()`, meaning any creator could self-award arbitrary reputation with any `bonus` value (only checked `>= 0`).

**Fix:**
- Replaced `creator.require_auth()` with `admin.require_auth()` + `require_admin()` so only the contract admin can record completions.
- Added `MAX_BONUS_PER_COMPLETION = 100` constant and an upper-bound assertion.
- Added `InsightsError::BonusExceedsLimit = 9` error variant.

Closes #1112

---

### #1106 — Extend TTL on `AnalyticsContract` persistent storage writes and reads

`AnalyticsContract::record_event` stored events via `env.storage().persistent().set()` but never called `extend_ttl`, so all recorded events would silently expire off the ledger.

**Fix:** Added `extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET)` after `set` in `record_event` and after `get` in `get_event`. Uses the same `TTL_THRESHOLD = 100` / `TTL_TARGET = 518_400` (~30 days) constants used across `contracts/core`, `contracts/escrow`, and `contracts/vault`.

Closes #1106
