### PR TITLE
fix: read webhook body once and clarify contracts/ note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Network passphrase: `Test SDF Network ; September 2015`
 > tree is not referenced by any workspace member list or CI job; treat it as
 > legacy/scaffold code pending removal or migration, not as a second deployment
 > target.
+>
+> Additionally, three top-level contracts have **no equivalent in `backend/contracts/` at all**:
+> `contracts/amm` (constant-product AMM), `contracts/vault` (multi-vault batch withdrawal),
+> and `contracts/analytics` (on-chain event analytics). These exist only at the top level
+> and are likewise not built or tested by CI.
 
 ## Getting Started
 

--- a/app/api/webhooks/email/bounce/route.ts
+++ b/app/api/webhooks/email/bounce/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import crypto from 'crypto';
 
-async function verifyWebhookSignature(request: NextRequest): Promise<boolean> {
+async function verifyWebhookSignature(rawBody: string, request: NextRequest): Promise<boolean> {
   const signature = request.headers.get('x-webhook-signature');
   const timestamp = request.headers.get('x-webhook-timestamp');
   const secret = process.env.EMAIL_WEBHOOK_SECRET;
@@ -11,9 +11,8 @@ async function verifyWebhookSignature(request: NextRequest): Promise<boolean> {
     return false;
   }
 
-  const body = await request.text();
   const hmac = crypto.createHmac('sha256', secret);
-  hmac.update(`${timestamp}.${body}`);
+  hmac.update(`${timestamp}.${rawBody}`);
   const expectedSignature = hmac.digest('hex');
 
   return crypto.timingSafeEqual(
@@ -24,7 +23,9 @@ async function verifyWebhookSignature(request: NextRequest): Promise<boolean> {
 
 export async function POST(request: NextRequest) {
   try {
-    const isValid = await verifyWebhookSignature(request);
+    // Read the body once and reuse the string for both signature verification and JSON parsing
+    const rawBody = await request.text();
+    const isValid = await verifyWebhookSignature(rawBody, request);
     if (!isValid) {
       return NextResponse.json(
         { error: 'Unauthorized' },
@@ -32,7 +33,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
+    const body = JSON.parse(rawBody);
     const events = Array.isArray(body) ? body : [body];
 
     for (const event of events) {


### PR DESCRIPTION

Fixes two issues in one pass — a runtime crash in the email bounce webhook and a documentation gap in the README.

---

### fix: email bounce webhook reads body twice and throws (#1118)

`verifyWebhookSignature` was calling `await request.text()` to build the HMAC, then the POST handler called `await request.json()` on the same \`NextRequest\`. A Fetch API body stream can only be consumed once, so the second read always threw \`TypeError: body used already\`, meaning every valid webhook call returned a 500.

**Fix:** read the body once with \`await request.text()\` at the top of \`POST\`, pass the raw string into \`verifyWebhookSignature\`, then call \`JSON.parse(rawBody)\` instead of \`request.json()\`.

Closes #1118

---

### docs: README contracts/ note missing amm, vault, analytics (#1116)

The existing note explained that \`backend/contracts/\` is canonical and that \`core\`/\`escrow\` overlap, but never mentioned that \`contracts/amm\`, \`contracts/vault\`, and \`contracts/analytics\` have **no equivalent in \`backend/contracts/\` at all** and are not built or tested by CI.

**Fix:** added a follow-up sentence to the note explicitly calling out those three contracts.

Closes #1116"