### PR TITLE
fix: screen restoration denylist, offline data deps, fee estimation client, ffmpeg validation (#1094 #1093 #1092 #1091)

### DIFF
--- a/mobile/src/hooks/useFeeEstimation.ts
+++ b/mobile/src/hooks/useFeeEstimation.ts
@@ -44,15 +44,11 @@ export function useFeeEstimation(
     setError(null);
 
     try {
-      const url = `/api/estimate?contract=${encodeURIComponent(contract)}&method=${encodeURIComponent(method)}&budget=${budget}`;
-      const response = await fetch(url);
+      const response = await apiClient.get('/api/estimate', {
+        params: { contract, method, budget },
+      });
 
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-
-      const data = await response.json();
-      setEstimate(data.estimates);
+      setEstimate(response.estimates);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch fee estimate");
       setEstimate(null);

--- a/mobile/src/hooks/useOfflineData.ts
+++ b/mobile/src/hooks/useOfflineData.ts
@@ -98,8 +98,7 @@ export function useOfflineData<T>(
     mounted.current = true;
     load();
     return () => { mounted.current = false; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cacheKey, isOnline]);
+  }, [cacheKey, isOnline, load]);  // Include fetcher (via load) so new fetcher closures re-trigger
 
   // Refresh queue counts whenever connectivity changes
   useEffect(() => {

--- a/mobile/src/media/FFmpegBridge.ts
+++ b/mobile/src/media/FFmpegBridge.ts
@@ -34,6 +34,11 @@ export async function trimVideo(
     throw new Error('StellarFFmpeg native bridge module is not linked or available');
   }
 
+  // Validate trim range: end must be after start (Issue #1091)
+  if (endMs <= startMs) {
+    throw new Error('End time must be after start time');
+  }
+
   // Force maximum clip duration of 60 seconds on trim invocation
   const trimDuration = endMs - startMs;
   if (trimDuration > 60000) {

--- a/mobile/src/services/AppStateRestorationService.ts
+++ b/mobile/src/services/AppStateRestorationService.ts
@@ -43,6 +43,8 @@ export const NON_RESTORABLE_SCREENS = [
   'RegisterScreen',
   'CameraScreen',
   'OnboardingScreen',
+  'MultiSigApprovalScreen',
+  'P2PTransferScreen',
 ] as const;
 
 export interface NavigationState {


### PR DESCRIPTION
## Summary

Fixes four issues assigned to @faith3310:

### #1094: Sensitive-screen denylist not updated for newer financial screens
- Added `MultiSigApprovalScreen` and `P2PTransferScreen` to `NON_RESTORABLE_SCREENS`
- Both involve in-flight fund transfers / multi-party approvals — restoration after a background-kill is a material risk

### #1093: useOfflineData excludes fetcher from dependency array
- Removed the `eslint-disable` for `react-hooks/exhaustive-deps`
- Added `load` (wraps `fetcher` via `useCallback`) to the `useEffect` dependency array
- New fetcher closures now re-trigger the effect instead of silently using the stale fetcher

### #1092: useFeeEstimation imports ApiClient but never uses it
- Replaced raw `fetch('/api/estimate?...')` with `apiClient.get('/api/estimate', { params })`
- RN `fetch` has no document origin for path-only URLs — this failed on-device
- Now goes through the shared `ApiClient` for base-URL/timeout handling

### #1091: FFmpegBridge.trimVideo doesn't validate endMs > startMs
- Added explicit `if (endMs <= startMs) throw new Error('End time must be after start time')`
- Prevents inverted trim ranges from reaching the native FFmpeg bridge

Closes #1094, closes #1093, closes #1092, closes #1091