### PR TITLE
fix: distribution config reconfiguration, LRU translation cache, secure token storage (#1096 #1095 #1090)

### DIFF
--- a/mobile/src/config/DistributionConfigManager.ts
+++ b/mobile/src/config/DistributionConfigManager.ts
@@ -25,7 +25,10 @@ export class DistributionConfigManager {
   }
 
   /**
-   * Initialize singleton instance
+   * Initialize singleton instance.
+   * If called again with different platform/channel, reconfigures the existing
+   * instance and warns. This prevents silently operating on stale config when
+   * initialize() is called with changed arguments (Issue #1096).
    */
   public static initialize(platform: Platform, channel?: ReleaseChannel): DistributionConfigManager {
     const releaseChannel = channel || getCurrentReleaseChannel();
@@ -34,6 +37,21 @@ export class DistributionConfigManager {
         platform,
         releaseChannel,
       );
+      return DistributionConfigManager.instance;
+    }
+
+    // Already initialized — check if the args changed
+    const existing = DistributionConfigManager.instance;
+    if (existing.platform !== platform || existing.channel !== releaseChannel) {
+      console.warn(
+        'DistributionConfigManager.initialize() called with different arguments ' +
+        `(platform: ${existing.platform} -> ${platform}, ` +
+        `channel: ${existing.channel} -> ${releaseChannel}). ` +
+        'Reconfiguring the existing instance.',
+      );
+      existing.platform = platform;
+      existing.channel = releaseChannel;
+      existing.initializeConfig();
     }
     return DistributionConfigManager.instance;
   }

--- a/mobile/src/hooks/useChatTranslation.ts
+++ b/mobile/src/hooks/useChatTranslation.ts
@@ -1,11 +1,18 @@
 /**
  * useChatTranslation — Issue #617
  * Hook for real-time per-message translation with locale switching.
+ *
+ * Issue #1095: Added LRU eviction to prevent unbounded cache growth.
+ * The cache is capped at MAX_TRANSLATION_CACHE entries; when the cap is
+ * reached, the oldest entries are evicted to maintain a bounded footprint.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { AppLocale } from '../i18n';
 import { ChatTranslationService } from '../services/ChatTranslationService';
+
+/** Maximum number of cached message translations before LRU eviction. */
+const MAX_TRANSLATION_CACHE = 200;
 
 export interface MessageTranslation {
   translatedText: string;
@@ -16,6 +23,38 @@ export interface MessageTranslation {
 
 export function useChatTranslation(targetLocale: AppLocale) {
   const [translations, setTranslations] = useState<Record<string, MessageTranslation>>({});
+  const accessOrder = useRef<string[]>([]);
+
+  /**
+   * Evict oldest entries when the cache exceeds MAX_TRANSLATION_CACHE.
+   * Uses a simple FIFO strategy based on insertion order (accessOrder ref).
+   */
+  const evictIfNeeded = useCallback((current: Record<string, MessageTranslation>) => {
+    const keys = Object.keys(current);
+    if (keys.length <= MAX_TRANSLATION_CACHE) return current;
+
+    // Evict oldest entries that are not currently visible
+    const toRemove: string[] = [];
+    const visibleKeys = new Set(
+      accessOrder.current.filter((k) => current[k]?.isVisible),
+    );
+
+    for (const key of accessOrder.current) {
+      if (keys.length - toRemove.length <= MAX_TRANSLATION_CACHE) break;
+      if (!visibleKeys.has(key)) {
+        toRemove.push(key);
+      }
+    }
+
+    // Update access order
+    accessOrder.current = accessOrder.current.filter((k) => !toRemove.includes(k));
+
+    const next = { ...current };
+    for (const key of toRemove) {
+      delete next[key];
+    }
+    return next;
+  }, []);
 
   const toggleTranslation = useCallback(
     async (messageId: string, originalText: string, sourceLocale: AppLocale = 'en') => {
@@ -32,6 +71,9 @@ export function useChatTranslation(targetLocale: AppLocale) {
 
       // If already translated (cached), just show it
       if (current?.translatedText && !current.error) {
+        // Move to end of access order (LRU update)
+        accessOrder.current = accessOrder.current.filter((id) => id !== messageId);
+        accessOrder.current.push(messageId);
         setTranslations((prev) => ({
           ...prev,
           [messageId]: { ...prev[messageId], isVisible: true },
@@ -39,11 +81,19 @@ export function useChatTranslation(targetLocale: AppLocale) {
         return;
       }
 
+      // Track access order for LRU
+      if (!accessOrder.current.includes(messageId)) {
+        accessOrder.current.push(messageId);
+      }
+
       // Start loading
-      setTranslations((prev) => ({
-        ...prev,
-        [messageId]: { translatedText: '', isLoading: true, error: null, isVisible: true },
-      }));
+      setTranslations((prev) => {
+        const updated = {
+          ...prev,
+          [messageId]: { translatedText: '', isLoading: true, error: null, isVisible: true },
+        };
+        return evictIfNeeded(updated);
+      });
 
       try {
         const result = await ChatTranslationService.translate(
@@ -51,7 +101,7 @@ export function useChatTranslation(targetLocale: AppLocale) {
           targetLocale,
           sourceLocale,
         );
-        setTranslations((prev) => ({
+        setTranslations((prev) => evictIfNeeded({
           ...prev,
           [messageId]: {
             translatedText: result.translatedText,
@@ -61,7 +111,7 @@ export function useChatTranslation(targetLocale: AppLocale) {
           },
         }));
       } catch {
-        setTranslations((prev) => ({
+        setTranslations((prev) => evictIfNeeded({
           ...prev,
           [messageId]: {
             translatedText: '',
@@ -72,10 +122,11 @@ export function useChatTranslation(targetLocale: AppLocale) {
         }));
       }
     },
-    [targetLocale, translations],
+    [targetLocale, translations, evictIfNeeded],
   );
 
   const clearTranslations = useCallback(() => {
+    accessOrder.current = [];
     setTranslations({});
   }, []);
 

--- a/mobile/src/store/authStore.ts
+++ b/mobile/src/store/authStore.ts
@@ -1,25 +1,69 @@
 /**
  * Authentication store.
  *
- * Persisted with `zustand/middleware`'s `persist` using AsyncStorage as the
- * storage adapter. `isHydrated` starts `false` and flips to `true` once the
- * persisted state has been rehydrated, so the app can gate rendering until the
- * auth state is known. Only the durable fields (user/token/isAuthenticated) are
- * persisted — `isHydrated` is always derived at runtime.
+ * Issue #1090: The session token is now persisted via expo-secure-store
+ * (Keychain/Keystore-backed) instead of plain AsyncStorage. AsyncStorage
+ * is not encrypted at rest; expo-secure-store uses platform-native secure
+ * storage. Non-sensitive fields (user) remain in AsyncStorage for fast access.
+ *
+ * `isHydrated` starts `false` and flips to `true` once the persisted state
+ * has been rehydrated, so the app can gate rendering until the auth state
+ * is known.
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import type { AuthState } from './types';
 
-/** AsyncStorage key under which the auth store is persisted. */
+/** AsyncStorage key under which non-sensitive auth fields are persisted. */
 export const AUTH_STORAGE_KEY = '@stellar/auth';
+/** SecureStore key for the sensitive session token. */
+export const AUTH_TOKEN_KEY = 'stellar_auth_token';
+
+/**
+ * Custom storage adapter: splits sensitive token into SecureStore,
+ * keeps non-sensitive fields in AsyncStorage.
+ */
+const secureHybridStorage = {
+  getItem: async (name: string): Promise<string | null> => {
+    const asyncData = await AsyncStorage.getItem(name);
+    if (!asyncData) return null;
+    try {
+      const parsed = JSON.parse(asyncData);
+      // Restore token from SecureStore if present
+      if (parsed && parsed.isAuthenticated) {
+        const token = await SecureStore.getItemAsync(AUTH_TOKEN_KEY);
+        if (token) {
+          parsed.token = token;
+        }
+      }
+      return JSON.stringify(parsed);
+    } catch {
+      return asyncData;
+    }
+  },
+  setItem: async (name: string, value: string): Promise<void> => {
+    try {
+      const parsed = JSON.parse(value);
+      // Store token in SecureStore, strip it from AsyncStorage payload
+      if (parsed && parsed.token) {
+        await SecureStore.setItemAsync(AUTH_TOKEN_KEY, parsed.token);
+        parsed.token = null;
+      }
+      await AsyncStorage.setItem(name, JSON.stringify(parsed));
+    } catch {
+      await AsyncStorage.setItem(name, value);
+    }
+  },
+  removeItem: async (name: string): Promise<void> => {
+    await SecureStore.deleteItemAsync(AUTH_TOKEN_KEY);
+    await AsyncStorage.removeItem(name);
+  },
+};
 
 /**
  * Hook to access the authentication store.
- *
- * @example
- * const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
  */
 export const useAuthStore = create<AuthState>()(
   persist(
@@ -34,8 +78,8 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: AUTH_STORAGE_KEY,
-      storage: createJSONStorage(() => AsyncStorage),
-      // Never persist the transient hydration flag.
+      storage: createJSONStorage(() => secureHybridStorage),
+      // Persist user, token, and isAuthenticated (token goes to SecureStore)
       partialize: (state) => ({
         user: state.user,
         token: state.token,


### PR DESCRIPTION
## Summary

Fixes three issues assigned to @nissinanlung:

### #1096: DistributionConfigManager silently ignores platform/channel on second initialize()
- `initialize()` now warns and reconfigures the existing singleton when called with different platform/channel arguments
- Logs a `console.warn` with old and new values for debuggability

### #1095: useChatTranslation cache has no eviction, grows unbounded
- Added LRU eviction with `MAX_TRANSLATION_CACHE=200` cap
- Non-visible translations evicted first (visible ones preserved)
- Access order tracked via `useRef` for accurate LRU behavior

### #1090: Session auth token persisted in plain AsyncStorage
- Token now stored via `expo-secure-store` (Keychain on iOS, Keystore on Android)
- Non-sensitive fields remain in AsyncStorage
- Custom hybrid storage adapter splits token into SecureStore on write, restores on read
- `clearAuth()` deletes token from SecureStore

Closes #1096, closes #1095, closes #1090